### PR TITLE
Refactor SoR purge to use job framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Build outputs
 target/
+.*dependency-reduced-pom.xml
 
 # OS hidden files
 .DS_Store

--- a/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
@@ -23,6 +23,8 @@ import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
 import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.DataCenterModule;
+import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
+import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
 import com.bazaarvoice.emodb.sor.DataStoreModule;
 import com.bazaarvoice.emodb.sor.DataStoreZooKeeper;
@@ -122,6 +124,8 @@ public class CasBlobStoreTest {
                                 "app_global", new TestCassandraConfiguration("app_global", "sys_delta")))
                         .setHistoryTtl(Period.days(2)));
                 bind(DataStore.class).annotatedWith(SystemDataStore.class).toInstance(mock(DataStore.class));
+                bind(JobService.class).toInstance(mock(JobService.class));
+                bind(JobHandlerRegistry.class).toInstance(mock(JobHandlerRegistry.class));
 
                 bind(DataCenterConfiguration.class).toInstance(new DataCenterConfiguration()
                         .setCurrentDataCenter("datacenter1")

--- a/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
@@ -19,6 +19,8 @@ import com.bazaarvoice.emodb.databus.ReplicationKey;
 import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.DataCenterModule;
 import com.bazaarvoice.emodb.datacenter.api.KeyspaceDiscovery;
+import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
+import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
 import com.bazaarvoice.emodb.sor.DataStoreModule;
 import com.bazaarvoice.emodb.sor.DataStoreZooKeeper;
@@ -121,6 +123,8 @@ public class CasDataStoreTest {
                                 "app_global", new TestCassandraConfiguration("app_global", "sys_delta")))
                         .setHistoryTtl(Period.days(2)));
                 bind(DataStore.class).annotatedWith(SystemDataStore.class).toInstance(mock(DataStore.class));
+                bind(JobService.class).toInstance(mock(JobService.class));
+                bind(JobHandlerRegistry.class).toInstance(mock(JobHandlerRegistry.class));
 
                 bind(DataCenterConfiguration.class).toInstance(new DataCenterConfiguration()
                         .setCurrentDataCenter("datacenter1")

--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -38,6 +38,7 @@ import com.bazaarvoice.emodb.sor.api.WriteConsistency;
 import com.bazaarvoice.emodb.sor.client.DataStoreAuthenticator;
 import com.bazaarvoice.emodb.sor.client.DataStoreClient;
 import com.bazaarvoice.emodb.sor.client.DataStoreStreaming;
+import com.bazaarvoice.emodb.sor.core.DataStoreAsync;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
 import com.bazaarvoice.emodb.test.ResourceTest;
 import com.bazaarvoice.emodb.web.auth.DefaultRoles;
@@ -139,7 +140,7 @@ public class DataStoreJerseyTest extends ResourceTest {
         permissionManager.updateForRole(
                 "update-with-events", new PermissionUpdateRequest().permit("sor|update|*"));
 
-        return setupResourceTestRule(Collections.<Object>singletonList(new DataStoreResource1(_server)), authIdentityManager, permissionManager);
+        return setupResourceTestRule(Collections.<Object>singletonList(new DataStoreResource1(_server, mock(DataStoreAsync.class))), authIdentityManager, permissionManager);
     }
 
     @After

--- a/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
@@ -8,9 +8,12 @@ import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.client.EmoClientException;
 import com.bazaarvoice.emodb.common.jersey.dropwizard.JerseyEmoClient;
 import com.bazaarvoice.emodb.common.zookeeper.store.ZkMapStore;
+import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
+import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.client.DataStoreAuthenticator;
 import com.bazaarvoice.emodb.sor.client.DataStoreClient;
+import com.bazaarvoice.emodb.sor.core.DefaultDataStoreAsync;
 import com.bazaarvoice.emodb.test.ResourceTest;
 import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
 import com.bazaarvoice.emodb.web.resources.sor.DataStoreResource1;
@@ -104,7 +107,7 @@ public class AdHocThrottleTest extends ResourceTest {
                 "all-sor-role", new PermissionUpdateRequest().permit("sor|*|*"));
 
         return setupResourceTestRule(
-                Collections.<Object>singletonList(new DataStoreResource1(_dataStore)),
+                Collections.<Object>singletonList(new DataStoreResource1(_dataStore, new DefaultDataStoreAsync(_dataStore, mock(JobService.class), mock(JobHandlerRegistry.class)))),
                 Collections.<Object>singletonList(new ConcurrentRequestsThrottlingFilter(_deferringRegulatorSupplier)),
                 authIdentityManager, permissionManager);
     }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/PurgeStatus.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/PurgeStatus.java
@@ -1,0 +1,30 @@
+package com.bazaarvoice.emodb.sor.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class PurgeStatus {
+    private final String _table;
+    private final Status _status;
+
+    public enum Status {
+        IN_PROGRESS,
+        COMPLETE,
+        ERROR
+    }
+
+    @JsonCreator
+    public PurgeStatus(@JsonProperty ("table") String table,
+                       @JsonProperty ("status") Status status) {
+        _table = table;
+        _status = status;
+    }
+
+    public String getTable() {
+        return _table;
+    }
+
+    public Status getStatus() {
+        return _status;
+    }
+}

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/UnknownPurgeException.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/UnknownPurgeException.java
@@ -1,0 +1,23 @@
+package com.bazaarvoice.emodb.sor.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Raised when a query is made on a purge that does not exist.
+ */
+@JsonIgnoreProperties({"cause", "localizedMessage", "stackTrace"})
+public class UnknownPurgeException extends RuntimeException {
+    private final String _id;
+
+    @JsonCreator
+    public UnknownPurgeException(@JsonProperty("id") String id) {
+        super("Unknown purge: " + id);
+        _id = id;
+    }
+
+    public String getId() {
+        return _id;
+    }
+}

--- a/sor/pom.xml
+++ b/sor/pom.xml
@@ -43,6 +43,11 @@
         </dependency>
         <dependency>
             <groupId>com.bazaarvoice.emodb</groupId>
+            <artifactId>emodb-job-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.bazaarvoice.emodb</groupId>
             <artifactId>emodb-sor-api</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreAsync.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreAsync.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.emodb.sor.api.Audit;
+import com.bazaarvoice.emodb.sor.api.PurgeStatus;
+
+/**
+ * Interface responsible for Async purge jobs for DataStore
+ */
+public interface DataStoreAsync {
+    /**
+     * starts a purge job on table
+     */
+    String purgeTableAsync(String table, Audit audit);
+
+    /**
+     * gets the status of the job with jobID
+     */
+    PurgeStatus getPurgeStatus(String table, String jobID);
+
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreAsyncModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreAsyncModule.java
@@ -1,0 +1,12 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.google.inject.PrivateModule;
+
+
+public class DataStoreAsyncModule extends PrivateModule{
+    @Override
+    protected void configure() {
+        bind(DataStoreAsync.class).to(DefaultDataStoreAsync.class).asEagerSingleton();
+        expose(DataStoreAsync.class);
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStoreAsync.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStoreAsync.java
@@ -1,0 +1,102 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.emodb.job.api.JobHandler;
+import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
+import com.bazaarvoice.emodb.job.api.JobIdentifier;
+import com.bazaarvoice.emodb.job.api.JobRequest;
+import com.bazaarvoice.emodb.job.api.JobService;
+import com.bazaarvoice.emodb.job.api.JobStatus;
+import com.bazaarvoice.emodb.sor.api.Audit;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.PurgeStatus;
+import com.bazaarvoice.emodb.sor.api.UnknownPurgeException;
+import com.google.common.base.Supplier;
+import com.google.inject.Inject;
+
+import java.util.Date;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Created by andee.liao on 6/7/16.
+ */
+public class DefaultDataStoreAsync implements DataStoreAsync {
+    private final DataStore _dataStore;
+    private final JobService _jobService;
+
+    @Inject
+    public DefaultDataStoreAsync(DataStore dataStore, JobService jobService, JobHandlerRegistry jobHandlerRegistry) {
+        _dataStore = dataStore;
+        _jobService = jobService;
+
+        checkNotNull(jobHandlerRegistry, "jobHandlerRegistry");
+        registerPurgeJobHandler(jobHandlerRegistry);
+    }
+
+    private void registerPurgeJobHandler(JobHandlerRegistry jobHandlerRegistry) {
+        jobHandlerRegistry.addHandler(
+                PurgeJob.INSTANCE,
+                new Supplier<JobHandler<PurgeRequest, PurgeResult>>() {
+                    @Override
+                    public JobHandler<PurgeRequest, PurgeResult> get() {
+                        return getPurgeRequestPurgeResultJobHandler();
+                    }
+                });
+    }
+
+    protected JobHandler<PurgeRequest, PurgeResult> getPurgeRequestPurgeResultJobHandler() {
+        return new JobHandler<PurgeRequest, PurgeResult>() {
+            @Override
+            public PurgeResult run(PurgeRequest request){
+                _dataStore.purgeTableUnsafe(request.getTable(), request.getAudit());
+                return new PurgeResult(new Date());
+            }
+        };
+    }
+
+    @Override
+    public String purgeTableAsync(String table, Audit audit) {
+        checkNotNull(audit, "audit");
+
+        JobIdentifier<PurgeRequest, PurgeResult> jobId =
+                _jobService.submitJob(
+                        new JobRequest<>(PurgeJob.INSTANCE, new PurgeRequest(table, audit)));
+        return jobId.toString();
+    }
+
+    @Override
+    public PurgeStatus getPurgeStatus( String table, String jobID) {
+        checkNotNull(table, "table");
+
+        JobIdentifier<PurgeRequest, PurgeResult> jobId;
+        try {
+            jobId = JobIdentifier.fromString(jobID, PurgeJob.INSTANCE);
+        } catch (IllegalArgumentException e) {
+            // The tableName is illegal and therefore cannot match any purge jobs.
+            throw new UnknownPurgeException(jobID);
+        }
+
+        JobStatus<PurgeRequest, PurgeResult> status = _jobService.getJobStatus(jobId);
+
+        if (status == null) {
+            throw new UnknownPurgeException(jobID);
+        }
+
+        PurgeRequest request = status.getRequest();
+        if (request == null) {
+            throw new IllegalStateException("Purge request details not found: " + jobId);
+        }
+
+        switch (status.getStatus()) {
+            case FINISHED:
+                return new PurgeStatus(request.getTable(), PurgeStatus.Status.COMPLETE);
+
+            case FAILED:
+                return new PurgeStatus(request.getTable(), PurgeStatus.Status.ERROR);
+
+            default:
+                return new PurgeStatus(request.getTable(), PurgeStatus.Status.IN_PROGRESS);
+        }
+    }
+
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/PurgeJob.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/PurgeJob.java
@@ -1,0 +1,12 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.emodb.job.api.JobType;
+
+public class PurgeJob extends JobType<PurgeRequest, PurgeResult> {
+
+    final public static PurgeJob INSTANCE = new PurgeJob();
+
+    private PurgeJob() {
+        super("purge", PurgeRequest.class, PurgeResult.class);
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/PurgeRequest.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/PurgeRequest.java
@@ -1,0 +1,29 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.emodb.sor.api.Audit;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+
+public class PurgeRequest  {
+
+    private final Audit _audit;
+    private final String _table;
+
+    @JsonCreator
+    public PurgeRequest(@JsonProperty("table") String table, @JsonProperty("audit") Audit audit) {
+        _audit = checkNotNull(audit, "audit");
+        _table = checkNotNull(table, "table");
+    }
+
+    public Audit getAudit() {
+        return _audit;
+    }
+
+    public String getTable() {
+        return _table;
+    }
+}
+

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/PurgeResult.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/PurgeResult.java
@@ -1,0 +1,21 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Date;
+
+public class PurgeResult {
+
+    private final Date _purgeCompleteTime;
+
+    @JsonCreator
+    public PurgeResult(@JsonProperty("purgeCompleteTime") Date purgeCompleteTime) {
+        _purgeCompleteTime = purgeCompleteTime;
+    }
+
+    public Date getPurgeCompleteTime() {
+        return _purgeCompleteTime;
+    }
+}
+

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/DataStoreModuleTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/DataStoreModuleTest.java
@@ -13,6 +13,8 @@ import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
 import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
+import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
+import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
@@ -124,6 +126,8 @@ public class DataStoreModuleTest {
                 bind(CuratorFramework.class).annotatedWith(GlobalFullConsistencyZooKeeper.class).toInstance(curator);
                 bind(ClusterInfo.class).toInstance(new ClusterInfo("Test Cluster", "Test Metric Cluster"));
                 bind(MetricRegistry.class).asEagerSingleton();
+                bind(JobService.class).toInstance(mock(JobService.class));
+                bind(JobHandlerRegistry.class).toInstance(mock(JobHandlerRegistry.class));
 
                 install(new DataStoreModule(serviceMode));
             }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -185,6 +185,22 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${curator.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -66,6 +66,7 @@ import com.bazaarvoice.emodb.sor.DataStoreZooKeeper;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.client.DataStoreClient;
 import com.bazaarvoice.emodb.sor.client.DataStoreClientFactory;
+import com.bazaarvoice.emodb.sor.core.DataStoreAsyncModule;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.auth.AuthorizationConfiguration;
@@ -128,6 +129,7 @@ import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Asp
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.dataBus_module;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.dataCenter;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.dataStore_module;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.dataStore_web;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.full_consistency;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.job;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.leader_control;
@@ -173,6 +175,7 @@ public class EmoModule extends AbstractModule {
         evaluate(job, new JobSetup());
         evaluate(security, new SecuritySetup());
         evaluate(full_consistency, new FullConsistencySetup());
+        evaluate(dataStore_web, new DataStoreAsyncSetup());
     }
 
     private class CommonModuleSetup extends AbstractModule {
@@ -430,6 +433,12 @@ public class EmoModule extends AbstractModule {
         }
     }
 
+    private class DataStoreAsyncSetup extends AbstractModule {
+        @Override
+        protected void configure() {
+            install(new DataStoreAsyncModule());
+        }
+    }
 
     private class ReportSetup extends AbstractModule  {
         @Override

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -22,6 +22,7 @@ import com.bazaarvoice.emodb.queue.api.QueueService;
 import com.bazaarvoice.emodb.queue.client.DedupQueueServiceAuthenticator;
 import com.bazaarvoice.emodb.queue.client.QueueServiceAuthenticator;
 import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.core.DataStoreAsync;
 import com.bazaarvoice.emodb.web.auth.EncryptConfigurationApiKeyCommand;
 import com.bazaarvoice.emodb.web.cli.AllTablesReportCommand;
 import com.bazaarvoice.emodb.web.cli.ListCassandraCommand;
@@ -225,8 +226,9 @@ public class EmoService extends Application<EmoConfiguration> {
 
         DataStore dataStore = _injector.getInstance(DataStore.class);
         ResourceRegistry resources = _injector.getInstance(ResourceRegistry.class);
+        DataStoreAsync dataStoreAsync = _injector.getInstance(DataStoreAsync.class);
         // Start the System Of Record service
-        resources.addResource(_cluster, "emodb-sor-1", new DataStoreResource1(dataStore));
+        resources.addResource(_cluster, "emodb-sor-1", new DataStoreResource1(dataStore, dataStoreAsync));
     }
 
     private void evaluateBlobStore()

--- a/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
@@ -1,0 +1,155 @@
+package com.bazaarvoice.emodb.web.purge;
+
+
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.job.api.JobIdentifier;
+import com.bazaarvoice.emodb.job.api.JobRequest;
+import com.bazaarvoice.emodb.job.api.JobStatus;
+import com.bazaarvoice.emodb.job.api.JobType;
+import com.bazaarvoice.emodb.job.dao.InMemoryJobStatusDAO;
+import com.bazaarvoice.emodb.job.dao.JobStatusDAO;
+import com.bazaarvoice.emodb.job.handler.DefaultJobHandlerRegistry;
+import com.bazaarvoice.emodb.job.service.DefaultJobService;
+import com.bazaarvoice.emodb.queue.api.QueueService;
+import com.bazaarvoice.emodb.sor.api.Audit;
+import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.TableOptions;
+import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.core.DefaultDataStoreAsync;
+import com.bazaarvoice.emodb.sor.core.PurgeJob;
+import com.bazaarvoice.emodb.sor.core.PurgeRequest;
+import com.bazaarvoice.emodb.sor.core.PurgeResult;
+import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.bazaarvoice.emodb.web.resources.sor.AuditParam;
+import com.bazaarvoice.emodb.web.resources.sor.DataStoreResource1;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.io.Closeables;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.test.TestingServer;
+import org.joda.time.Duration;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.bazaarvoice.emodb.job.api.JobIdentifier.createNew;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertTrue;
+
+
+
+public class PurgeTest {
+    private static final String TABLE = "testtable";
+    private static final String TABLE2 = "testtable2";
+    private static final String TABLE3 = "testtable3";
+    private static final String KEY1 = "key1";
+    private static final String KEY2 = "key2";
+
+    private QueueService _queueService;
+    private DefaultJobHandlerRegistry _jobHandlerRegistry;
+    private JobStatusDAO _jobStatusDAO;
+    private DefaultJobService _service;
+    private TestingServer _testingServer;
+    private CuratorFramework _curator;
+
+    public DataStore _store;
+    public DataStoreResource1 _dataStoreResource;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        LifeCycleRegistry lifeCycleRegistry = mock(LifeCycleRegistry.class);
+        _queueService = mock(QueueService.class);
+        _jobHandlerRegistry = new DefaultJobHandlerRegistry();
+        _jobStatusDAO = new InMemoryJobStatusDAO();
+        _testingServer = new TestingServer();
+        _curator = CuratorFrameworkFactory.builder()
+                .connectString(_testingServer.getConnectString())
+                .retryPolicy(new RetryNTimes(3, 100))
+                .build();
+
+        _curator.start();
+
+        _service = new DefaultJobService(
+                lifeCycleRegistry, _queueService, "testqueue", _jobHandlerRegistry, _jobStatusDAO, _curator,
+                1, Duration.ZERO, 100, Duration.standardHours(1));
+
+        _store = new InMemoryDataStore(new MetricRegistry());
+        _dataStoreResource = new DataStoreResource1(_store, new DefaultDataStoreAsync(_store, _service, _jobHandlerRegistry));
+
+    }
+
+    @AfterMethod
+    public void shutDown() throws Exception {
+        Closeables.close(_curator, true);
+        Closeables.close(_testingServer, true);
+    }
+
+    @Test
+    public void serviceTest() {
+
+        // check can instantiate job type
+        JobRequest testPurgeJobRequest = new JobRequest<>(PurgeJob.INSTANCE, new PurgeRequest("test", newAudit("new job test")));
+        assertTrue(Objects.equals(testPurgeJobRequest.getType().getName(), "purge"));
+
+        //checking for PurgeJob registration
+        JobType jobType = testPurgeJobRequest.getType();
+        JobIdentifier newJobID = createNew(jobType);
+        checkNotNull(newJobID, "jobId");
+
+        // submitting a job to registry purge drops the table
+        JobIdentifier jobID = _service.submitJob(new JobRequest<>(PurgeJob.INSTANCE, new PurgeRequest(TABLE, newAudit("submitting purge job directly via submitJob"))));
+        JobStatus<PurgeRequest, PurgeResult> status = _service.getJobStatus(jobID);
+        assertTrue(status.getStatus().toString().equals("SUBMITTED"));
+    }
+
+    @Test
+    public void resourceTest() {
+
+        TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
+        _store.createTable(TABLE, options, Collections.<String,Object >emptyMap(), newAudit("create table"));
+        _store.createTable(TABLE2, options, Collections.<String,Object >emptyMap(), newAudit("create table"));
+        _store.createTable(TABLE3, options, Collections.<String,Object >emptyMap(), newAudit("create table"));
+        //checking tables has been created
+        assertTrue(_store.getTableExists(TABLE));
+        assertTrue(_store.getTableExists(TABLE2));
+
+        // write some data
+        _store.update(TABLE, KEY1, TimeUUIDs.newUUID(), Deltas.fromString("{\"name\":\"Bob\"}"), newAudit("submit"), WriteConsistency.STRONG);
+        _store.update(TABLE, KEY1, TimeUUIDs.newUUID(), Deltas.fromString("{..,\"state\":\"SUBMITTED\"}"), newAudit("begin moderation"), WriteConsistency.STRONG);
+        _store.update(TABLE, KEY2, TimeUUIDs.newUUID(), Deltas.fromString("{\"name\":\"Joe\"}"), newAudit("submit"), WriteConsistency.STRONG);
+        assertTrue(_store.getTableExists(TABLE2));
+
+        // unit test for purgeTableUnsafe
+        _store.purgeTableUnsafe(TABLE2, newAudit("checking purgeTableUnsafe"));
+        assertTrue(_store.getTableApproximateSize(TABLE2) == 0L);
+
+        // submitting a job to registry purge drops the table
+        JobIdentifier jobID = _service.submitJob(new JobRequest<>(PurgeJob.INSTANCE, new PurgeRequest(TABLE, newAudit("submitting purge job directly via submitJob"))));
+        Map<String, Object> purgeStatus = _dataStoreResource.getPurgeStatus(TABLE, jobID.toString());
+        assertTrue(purgeStatus.get("status").toString().equals("IN_PROGRESS"));
+
+        // calling job directly via calling purgeTableAsync on DataStoreResource1
+        Map<String, Object> jobID3Map = _dataStoreResource.purgeTableAsync(TABLE3, new AuditParam("audit=comment:'purgetest+comment'"));
+        Map<String, Object> purgeStatus3 = _dataStoreResource.getPurgeStatus(TABLE3, jobID3Map.get("id").toString());
+        assertTrue(purgeStatus3.get("status").toString().equals("IN_PROGRESS"));
+    }
+
+    private Audit newAudit(String comment) {
+        return new AuditBuilder().
+                setProgram("test").
+                setUser("root").
+                setLocalHost().
+                setComment(comment).
+                build();
+    }
+}


### PR DESCRIPTION
## Github Issue #

[8](https://github.com/bazaarvoice/emodb/issues/8)

## What Are We Doing Here?

This PR change the SoR "purge" operation to run asynchronously using the existing job framework.  

## How to Test and Verify

1. Create a table and populate it with one or more rows.
2. POST to  `sor/1/_table/<table>/purge` with an appropriate API key and audit record.  The response should include the ID of the purge.
3. GET `sor/1/_table/<table>/purgestatus?id=<id>` until the status is complete.
4. Verify that the table contains no records.

## Risk

Low, since purges are uncommon and only run by administrators.

### Level 

Low, for the same reason as above.

### Required Testing

Regression

### Risk Summary

The only real risk is that purges will break.  This is an uncommon feature and, should any issues arise, should not affect the normal operation of Emo.

## Code Review Checklist

- [ X] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ X] Pulled down the PR and performed verification of at least being able to
build and run.

- [ X] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ X] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [X ] PR has a valid summary, and a good description.

## Credits

I am not the author of this code.  It was written by [Andee Liao](https://github.com/andeeliao) during her internship at Bazaarvoice.  I am migrating this code on her behalf since it was not merged prior to the open-source forking of EmoDB and she has since gone back to school.