### PR TITLE
Add convenient start-local.sh, and update documentation

### DIFF
--- a/QuickStart.md
+++ b/QuickStart.md
@@ -1,19 +1,22 @@
 ### Starting EmoDB locally using only EmoDB binaries 
 
-To start EmoDB locally, simply download the binaries, and run the following:
- 
+To start EmoDB locally, simply download the [EmoDB binaries] (https://github.com/bazaarvoice/emodb/releases), and run the following:
+
 ```
-java -jar bin/emodb-web-local-*.jar server conf/config-local.yaml conf/config-ddl-local.yaml conf/cassandra.yaml -z
-```
+$> ./start-local.sh
+``` 
+
 The above will start the following services:
 
 -  In-memory Cassandra
 -  Zookeeper on port 2181
 -  EmoDB on port 8080/8081
 
-If you would like to use your own configured cassandra, then skip providing cassandra.yaml and update Emo's config file to point to the correct Cassandra node.
-
-To skip starting zookeeper, leave out `-z` switch. 
+If you would like to use your own configured cassandra, then start the local jar directly:
+```
+java -jar bin/emodb-web-local-*.jar server conf/config-local.yaml conf/config-ddl-local.yaml conf/cassandra.yaml -z
+```
+To skip starting a local zookeeper, leave out `-z` switch. 
 
 
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Quick Start
 
 #### Using binaries:
 
-1. Download the [EmoDB binaries] (https://github.com/bazaarvoice/emodb/releases)
+1. Download the tarball from [EmoDB binaries] (https://github.com/bazaarvoice/emodb/releases)
 
 2. Run the Emodb server locally. This will start zookeeper and cassandra locally.
     
-        $ bin/start-local.sh
+        $ ./start-local.sh
         ...
         INFO  [2012-05-14 19:12:19,802] org.eclipse.jetty.server.AbstractConnector: Started InstrumentedBlockingChannelConnector@0.0.0.0:8080
         INFO  [2012-05-14 19:12:19,805] org.eclipse.jetty.server.AbstractConnector: Started SocketConnector@0.0.0.0:8081
@@ -111,7 +111,7 @@ Quick Start
         $ cd web-local
         $ ./start-clean.sh
 
-### Examples
+### Quick Tutorial
 
 The following examples assume you have [jq] (https://stedolan.github.io/jq/) or an equivalent (see Recommended
 Software below).  It is optional-- `jq .` just formats the JSON responses to make them easier to read.

--- a/yum/dep.xml
+++ b/yum/dep.xml
@@ -34,5 +34,13 @@ http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 ">
                 <include>cassandra.yaml</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory>/</outputDirectory>
+            <fileMode>755</fileMode>
+            <includes>
+                <include>start-local.sh</include>
+            </includes>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/yum/start-local.sh
+++ b/yum/start-local.sh
@@ -12,6 +12,7 @@
 # schema and data will not be modified.
 #
 # Once the server is running you can access Emodb using the following commands:
+# Note: For local testing, we have enabled anonymous access. In production you should be using API Keys. Read more about it in "API Keys" section.
 #
 #   curl localhost:8081/ping
 #   curl localhost:8080/sor/1/_table

--- a/yum/start-local.sh
+++ b/yum/start-local.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# Starts the following servers locally:
+# - EmoDB (ports 8080, 8081)
+# - Cassandra (port 9160)
+# - ZooKeeper (port 2181)
+#
+# The first time this is run, Cassandra will be initialized with a default
+# schema and an empty # data set.  Data will be stored in "bin/data".
+# On subsequent runs where "bin/data/" already exists, the Cassandra
+# schema and data will not be modified.
+#
+# Once the server is running you can access Emodb using the following commands:
+#
+#   curl localhost:8081/ping
+#   curl localhost:8080/sor/1/_table
+#
+# For production, use the web jar not web-local, and also you shouldn't be providing cassandra.yaml or -z switch since you wouldn't want to start a local cassandra or zookeeper
+# java -jar bin/emodb-web.jar server conf/config-local.yaml conf/config-ddl-local.yaml
+#
+
+java -jar bin/emodb-web-local-*.jar server conf/config-local.yaml conf/config-ddl-local.yaml conf/cassandra.yaml -z


### PR DESCRIPTION
## Github Issue #

[13](https://github.com/bazaarvoice/emodb/issues/13)

## What Are We Doing Here?

Add a convenience script to start emo locally. Clean up documentation

## How to Test and Verify

1. Unzip the binary from yum/target
2. Run `./start-local.sh`
3. Verify everything works OK

## Risk

### Level 

`Low`

### Required Testing

`Smoke`

### Risk Summary

None

## Code Review Checklist

- [X] Tests are included. If not, make sure you leave us a line or two for the reason.

- [X] Pulled down the PR and performed verification of at least being able to
build and run.

- [X] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [X] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [X] PR has a valid summary, and a good description.

