### PR TITLE
Owner-aware databus and internal IDs for API keys

### DIFF
--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/EmoSecurityManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/EmoSecurityManager.java
@@ -1,0 +1,10 @@
+package com.bazaarvoice.emodb.auth;
+
+import org.apache.shiro.mgt.SecurityManager;
+
+/**
+ * Extension of the {@link SecurityManager} interface which adds methods for verifying permissions by internal ID
+ * for users not currently authenticated.
+ */
+public interface EmoSecurityManager extends SecurityManager, InternalAuthorizer {
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/InternalAuthorizer.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/InternalAuthorizer.java
@@ -1,0 +1,29 @@
+package com.bazaarvoice.emodb.auth;
+
+import org.apache.shiro.authz.Permission;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface for performing authorization internally within the system.  Unlike SecurityManager this interface is
+ * intended to be used primarily in contexts where the user is not authenticated.  The interface is intentionally
+ * limited to discourage bypassing the SecurityManager when dealing with authenticated users.
+ *
+ * Internal systems are encouraged to identify relationships such as resource ownership with internal IDs instead of
+ * public credentials like API keys for the following reasons:
+ *
+ * <ul>
+ *     <li>If the API key for a user is changed the internal ID remains constant.</li>
+ *     <li>They can safely log and store the internal ID of a user without risk of leaking plaintext credentials.</li>
+ * </ul>
+ */
+public interface InternalAuthorizer {
+
+    boolean hasPermissionByInternalId(String internalId, String permission);
+
+    boolean hasPermissionByInternalId(String internalId, Permission permission);
+
+    boolean hasPermissionsByInternalId(String internalId, String... permissions);
+
+    boolean hasPermissionsByInternalId(String internalId, Permission... permissions);
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/SecurityManagerBuilder.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/SecurityManagerBuilder.java
@@ -68,7 +68,7 @@ public class SecurityManagerBuilder {
         return this;
     }
 
-    public SecurityManager build() {
+    public EmoSecurityManager build() {
         checkNotNull(_authIdentityManager, "authIdentityManager not set");
         checkNotNull(_permissionManager, "permissionManager not set");
         if(_cacheManager == null) { // intended for test use

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKey.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKey.java
@@ -4,6 +4,7 @@ import com.bazaarvoice.emodb.auth.identity.AuthIdentity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.Hashing;
 
 import java.util.List;
 import java.util.Set;
@@ -13,12 +14,29 @@ import java.util.Set;
  */
 public class ApiKey extends AuthIdentity {
 
-    public ApiKey(String key, Set<String> roles) {
-        super(key, roles);
+    public ApiKey(String key, String internalId, Set<String> roles) {
+        super(key, internalId, roles);
     }
 
     @JsonCreator
-    public ApiKey(@JsonProperty("id") String key, @JsonProperty("roles") List<String> roles) {
-        this(key, ImmutableSet.copyOf(roles));
+    public ApiKey(@JsonProperty("id") String key,
+                  @JsonProperty("internalId") String internalId,
+                  @JsonProperty("roles") List<String> roles) {
+
+        // API keys have been in use since before internal IDs were introduced.  To grandfather in those keys we'll
+        // use a hash of the API key as the internal ID.
+        this(key, resolveInternalId(key, internalId), ImmutableSet.copyOf(roles));
+    }
+
+    private static String resolveInternalId(String key, String internalId) {
+        if (internalId != null) {
+            return internalId;
+        }
+        // SHA-256 is a little heavy but it has two advantages:
+        // 1.  It is the same algorithm currently used to store API keys by the permission manager so there isn't a
+        //     potential conflict between keys.
+        // 2.  The API keys are cached by Shiro so this conversion will only take place when the key needs to
+        //     be (re)loaded.
+        return Hashing.sha256().hashUnencodedChars(key).toString();
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyAuthenticationInfo.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyAuthenticationInfo.java
@@ -20,7 +20,8 @@ public class ApiKeyAuthenticationInfo implements AuthenticationInfo {
     public ApiKeyAuthenticationInfo(ApiKey apiKey, String realm) {
         checkNotNull(apiKey, "apiKey");
         checkNotNull(realm, "realm");
-        PrincipalWithRoles principal = new PrincipalWithRoles(apiKey.getId(), apiKey.getRoles());
+        // Identify the principal by API key
+        PrincipalWithRoles principal = new PrincipalWithRoles(apiKey.getId(), apiKey.getInternalId(), apiKey.getRoles());
         _principals = new SimplePrincipalCollection(principal, realm);
         // Use the API key as the credentials
         _credentials = apiKey.getId();
@@ -39,5 +40,24 @@ public class ApiKeyAuthenticationInfo implements AuthenticationInfo {
     @Override
     public String toString() {
         return format("%s{%s}", getClass().getSimpleName(), ((PrincipalWithRoles) _principals.getPrimaryPrincipal()).getName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ApiKeyAuthenticationInfo)) {
+            return false;
+        }
+
+        ApiKeyAuthenticationInfo that = (ApiKeyAuthenticationInfo) o;
+
+        return _principals.equals(that._principals) && _credentials.equals(that._credentials);
+    }
+
+    @Override
+    public int hashCode() {
+        return _principals.getPrimaryPrincipal().hashCode();
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyRealm.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyRealm.java
@@ -4,7 +4,15 @@ import com.bazaarvoice.emodb.auth.identity.AuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
 import com.bazaarvoice.emodb.auth.shiro.AnonymousCredentialsMatcher;
 import com.bazaarvoice.emodb.auth.shiro.AnonymousToken;
+import com.bazaarvoice.emodb.auth.shiro.InvalidatableCacheManager;
 import com.bazaarvoice.emodb.auth.shiro.PrincipalWithRoles;
+import com.bazaarvoice.emodb.auth.shiro.RolePermissionSet;
+import com.bazaarvoice.emodb.auth.shiro.SimpleRolePermissionSet;
+import com.bazaarvoice.emodb.auth.shiro.ValidatingCacheManager;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
@@ -17,26 +25,47 @@ import org.apache.shiro.cache.Cache;
 import org.apache.shiro.cache.CacheManager;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ApiKeyRealm extends AuthorizingRealm {
 
+    private static final String DEFAULT_ROLES_CACHE_SUFFIX = ".rolesCache";
+    private static final String DEFAULT_INTERNAL_AUTHORIZATION_CACHE_SUFFIX = ".internalAuthorizationCache";
+
+    private final Logger _log = LoggerFactory.getLogger(getClass());
+
     private final AuthIdentityManager<ApiKey> _authIdentityManager;
     private final PermissionManager _permissionManager;
     private final String _anonymousId;
+    private final boolean _clearCaches;
 
-    private static final String DEFAULT_ROLES_CACHE_SUFFIX = ".rolesCache";
-    private Cache<String, Set<Permission>> _rolesCache;
+    /**
+     * Internal AuthorizationInfo instance used to cache when an internal ID does not map to a user.
+     * Necessary because our cache implementation cannot store nulls.  This instance has no roles or permissions.
+     */
+    private final AuthorizationInfo _nullAuthorizationInfo = new SimpleAuthorizationInfo(ImmutableSet.<String>of());
+
+    // Cache for permissions by role.
+    private Cache<String, RolePermissionSet> _rolesCache;
+    // Cache for authorization info by user's internal ID.
+    private Cache<String, AuthorizationInfo> _internalAuthorizationCache;
+
     private String _rolesCacheName;
+    private String _internalAuthorizationCacheName;
 
     public ApiKeyRealm(String name, CacheManager cacheManager, AuthIdentityManager<ApiKey> authIdentityManager,
                        PermissionManager permissionManager, @Nullable String anonymousId) {
-        super(cacheManager, AnonymousCredentialsMatcher.anonymousOrMatchUsing(new SimpleCredentialsMatcher()));
+        super(null, AnonymousCredentialsMatcher.anonymousOrMatchUsing(new SimpleCredentialsMatcher()));
+
 
         _authIdentityManager = checkNotNull(authIdentityManager, "authIdentityManager");
         _permissionManager = checkNotNull(permissionManager, "permissionManager");
@@ -46,8 +75,94 @@ public class ApiKeyRealm extends AuthorizingRealm {
         setAuthenticationTokenClass(ApiKeyAuthenticationToken.class);
         setPermissionResolver(permissionManager.getPermissionResolver());
         setRolePermissionResolver(createRolePermissionResolver());
+        setCacheManager(prepareCacheManager(cacheManager));
         setAuthenticationCachingEnabled(true);
         setAuthorizationCachingEnabled(true);
+
+        // By default Shiro calls clearCache() for each user when they are logged out in order to prevent stale
+        // credentials from being cached.  However, if the cache manager implements InvalidatingCacheManager then it has
+        // its own internal listeners that will invalidate the cache on any updates, making this behavior unnecessarily
+        // expensive.
+        _clearCaches = cacheManager != null && !(cacheManager instanceof InvalidatableCacheManager);
+        _log.debug("Clearing of caches for realm {} is {}", name, _clearCaches ? "enabled" : "disabled");
+    }
+
+    /**
+     * If necessary, wraps the raw cache manager with a validating facade.
+     */
+    private CacheManager prepareCacheManager(CacheManager cacheManager) {
+        if (cacheManager == null || !(cacheManager instanceof InvalidatableCacheManager)) {
+            return cacheManager;
+        }
+
+        return new ValidatingCacheManager(cacheManager) {
+            @Nullable
+            @Override
+            protected CacheValidator<?, ?> getCacheValidatorForCache(String name) {
+                String cacheName = getAuthenticationCacheName();
+                if (cacheName != null && name.equals(cacheName)) {
+                    return new ValidatingCacheManager.CacheValidator<Object, AuthenticationInfo>(Object.class, AuthenticationInfo.class) {
+                        @Override
+                        public boolean isCurrentValue(Object key, AuthenticationInfo value) {
+                            String id;
+                            if (AnonymousToken.isAnonymousPrincipal(key)) {
+                                if (_anonymousId == null) {
+                                    return false;
+                                }
+                                id = _anonymousId;
+                            } else {
+                                // For all non-anonymous users "key" is an API key
+                                id = (String) key;
+                            }
+
+                            AuthenticationInfo authenticationInfo = getUncachedAuthenticationInfoForKey(id);
+                            return Objects.equal(authenticationInfo, value);
+                        }
+                    };
+                }
+
+                cacheName = getAuthorizationCacheName();
+                if (cacheName != null && name.equals(cacheName)) {
+                    return new ValidatingCacheManager.CacheValidator<Object, AuthorizationInfo>(Object.class, AuthorizationInfo.class) {
+                        @Override
+                        public boolean isCurrentValue(Object key, AuthorizationInfo value) {
+                            // Key is always a principal collection
+                            PrincipalCollection principalCollection = (PrincipalCollection) key;
+                            AuthorizationInfo authorizationInfo = getUncachedAuthorizationInfoFromPrincipals(principalCollection);
+                            // Only the roles are used for authorization
+                            return authorizationInfo != null && authorizationInfo.getRoles().equals(value.getRoles());
+                        }
+                    };
+                }
+
+                cacheName = getInternalAuthorizationCacheName();
+                if (cacheName != null && name.equals(cacheName)) {
+                    return new ValidatingCacheManager.CacheValidator<String, AuthorizationInfo>(String.class, AuthorizationInfo.class) {
+                        @Override
+                        public boolean isCurrentValue(String key, AuthorizationInfo value) {
+                            // Key is the internal ID
+                            AuthorizationInfo authorizationInfo = getUncachedAuthorizationInfoByInternalId(key);
+                            // Only the roles are used for authorization
+                            return authorizationInfo != null && authorizationInfo.getRoles().equals(value.getRoles());
+                        }
+                    };
+                }
+
+                cacheName = getRolesCacheName();
+                if (cacheName != null && name.equals(cacheName)) {
+                    return new ValidatingCacheManager.CacheValidator<String, RolePermissionSet>(String.class, RolePermissionSet.class) {
+                        @Override
+                        public boolean isCurrentValue(String key, RolePermissionSet value) {
+                            // The key is the role name
+                            Set<Permission> currentPermissions = _permissionManager.getAllForRole(key);
+                            return value.permissions().equals(currentPermissions);
+                        }
+                    };
+                }
+
+                return null;
+            }
+        };
     }
 
     @Override
@@ -55,6 +170,8 @@ public class ApiKeyRealm extends AuthorizingRealm {
         super.onInit();
         // Force creation of the roles cache on initialization
         getAvailableRolesCache();
+        // Create a cache for internal IDs
+        getAvailableInternalAuthorizationCache();
     }
 
     /**
@@ -86,11 +203,25 @@ public class ApiKeyRealm extends AuthorizingRealm {
             id = ((ApiKeyAuthenticationToken) token).getPrincipal();
         }
 
+        return getUncachedAuthenticationInfoForKey(id);
+    }
+
+    /**
+     * Gets the authentication info for an API key from the source (not from cache).
+     */
+    private AuthenticationInfo getUncachedAuthenticationInfoForKey(String id) {
         ApiKey apiKey = _authIdentityManager.getIdentity(id);
         if (apiKey == null) {
             return null;
         }
 
+        return createAuthenticationInfo(apiKey);
+    }
+
+    /**
+     * Simple method to build and AuthenticationInfo instance from an API key.
+     */
+    private ApiKeyAuthenticationInfo createAuthenticationInfo(ApiKey apiKey) {
         return new ApiKeyAuthenticationInfo(apiKey, getName());
     }
 
@@ -98,15 +229,37 @@ public class ApiKeyRealm extends AuthorizingRealm {
      * Gets the AuthorizationInfo that matches a token.  This method is only called if the info is not already
      * cached by the realm, so this method does not need to perform any further caching.
      */
-    @SuppressWarnings("unchecked")
     @Override
     protected AuthorizationInfo doGetAuthorizationInfo(PrincipalCollection principals) {
+
+        AuthorizationInfo authorizationInfo = getUncachedAuthorizationInfoFromPrincipals(principals);
+
+        Cache<String, AuthorizationInfo> internalAuthorizationCache = getAvailableInternalAuthorizationCache();
+        if (internalAuthorizationCache != null) {
+            // Proactively cache any internal ID authorization info not already in cache
+            for (PrincipalWithRoles principal : getPrincipalsFromPrincipalCollection(principals)) {
+                if (internalAuthorizationCache.get(principal.getInternalId()) == null) {
+                    cacheAuthorizationInfoByInternalId(principal.getInternalId(), authorizationInfo);
+                }
+            }
+        }
+
+        return authorizationInfo;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Collection<PrincipalWithRoles> getPrincipalsFromPrincipalCollection(PrincipalCollection principals) {
+        // Realm always returns PrincipalWithRoles for principals
+        return (Collection<PrincipalWithRoles>) principals.fromRealm(getName());
+    }
+
+    /**
+     * Gets the authorization info for an API key's principals from the source (not from cache).
+     */
+    private AuthorizationInfo getUncachedAuthorizationInfoFromPrincipals(PrincipalCollection principals) {
         SimpleAuthorizationInfo authInfo = new SimpleAuthorizationInfo();
 
-        // Realm always returns PrincipalWithRoles for principals
-        Collection<PrincipalWithRoles> realmPrincipals = (Collection<PrincipalWithRoles>) principals.fromRealm(getName());
-
-        for (PrincipalWithRoles principal : realmPrincipals) {
+        for (PrincipalWithRoles principal : getPrincipalsFromPrincipalCollection(principals)) {
             authInfo.addRoles(principal.getRoles());
         }
 
@@ -116,15 +269,25 @@ public class ApiKeyRealm extends AuthorizingRealm {
     @Override
     public void setName(String name) {
         super.setName(name);
+        // Set reasonable defaults for the role and internal authorization caches.
         _rolesCacheName = name + DEFAULT_ROLES_CACHE_SUFFIX;
-        getAvailableRolesCache();
+        _internalAuthorizationCacheName = name + DEFAULT_INTERNAL_AUTHORIZATION_CACHE_SUFFIX;
     }
 
     public String getRolesCacheName() {
         return _rolesCacheName;
     }
 
-    protected Cache<String, Set<Permission>> getAvailableRolesCache() {
+    public void setInternalAuthorizationCacheName(String name) {
+        _internalAuthorizationCacheName = name + DEFAULT_INTERNAL_AUTHORIZATION_CACHE_SUFFIX;
+        getAvailableInternalAuthorizationCache();
+    }
+
+    public String getInternalAuthorizationCacheName() {
+        return _internalAuthorizationCacheName;
+    }
+
+    protected Cache<String, RolePermissionSet> getAvailableRolesCache() {
         if(getCacheManager() == null) {
             return null;
         }
@@ -136,6 +299,22 @@ public class ApiKeyRealm extends AuthorizingRealm {
         return _rolesCache;
     }
 
+    public Cache<String, AuthorizationInfo> getInternalAuthorizationCache() {
+        return _internalAuthorizationCache;
+    }
+
+    protected Cache<String, AuthorizationInfo> getAvailableInternalAuthorizationCache() {
+        if (getCacheManager() == null) {
+            return null;
+        }
+
+        if (_internalAuthorizationCache == null) {
+            String cacheName = getInternalAuthorizationCacheName();
+            _internalAuthorizationCache = getCacheManager().getCache(cacheName);
+        }
+        return _internalAuthorizationCache;
+    }
+
     private RolePermissionResolver createRolePermissionResolver() {
         return new RolePermissionResolver () {
             @Override
@@ -145,24 +324,146 @@ public class ApiKeyRealm extends AuthorizingRealm {
         };
     }
 
+    /**
+     * Gets the permissions for a role.  If possible the permissions are cached for efficiency.
+     */
     protected Collection<Permission> getPermissions(String role) {
         if (role == null) {
             return null;
         }
-        Cache<String, Set<Permission>> cache = getAvailableRolesCache();
+        Cache<String, RolePermissionSet> cache = getAvailableRolesCache();
 
         if (cache == null) {
             return _permissionManager.getAllForRole(role);
         }
 
-        Set<Permission> cachedPermissions, permissions = cachedPermissions = cache.get(role);
-        while (cachedPermissions == null || ! cachedPermissions.equals(permissions)) {
-            if(permissions != null) {
-                cache.put(role, permissions);
-            }
-            permissions = _permissionManager.getAllForRole(role);
-            cachedPermissions = cache.get(role);
+        RolePermissionSet rolePermissionSet = cache.get(role);
+
+        if (rolePermissionSet == null) {
+            Set<Permission> permissions = _permissionManager.getAllForRole(role);
+            rolePermissionSet = new SimpleRolePermissionSet(permissions);
+            cache.put(role, rolePermissionSet);
         }
-        return permissions;
+
+        return rolePermissionSet.permissions();
+    }
+
+    /**
+     * Override default behavior to only clear cached authentication info if enabled.
+     */
+    @Override
+    protected void clearCachedAuthenticationInfo(PrincipalCollection principals) {
+        if (_clearCaches) {
+            super.clearCachedAuthenticationInfo(principals);
+        }
+    }
+
+    /**
+     * Override default behavior to only clear cached authorization info if enabled.
+     */
+    @Override
+    protected void clearCachedAuthorizationInfo(PrincipalCollection principals) {
+        if (_clearCaches) {
+            super.clearCachedAuthorizationInfo(principals);
+        }
+    }
+
+    /**
+     * Gets the authorization info for a user by their internal ID.  If possible the value is cached for
+     * efficient lookup.
+     */
+    @Nullable
+    private AuthorizationInfo getAuthorizationInfoByInternalId(String internalId) {
+        AuthorizationInfo authorizationInfo;
+
+        // Search the cache first
+        Cache<String, AuthorizationInfo> internalAuthorizationCache = getAvailableInternalAuthorizationCache();
+
+        if (internalAuthorizationCache != null) {
+            authorizationInfo = internalAuthorizationCache.get(internalId);
+
+            if (authorizationInfo != null) {
+                // Check whether it is the stand-in "null" cached value
+                if (authorizationInfo != _nullAuthorizationInfo) {
+                    _log.debug("Authorization info found cached for internal id {}", internalId);
+                    return authorizationInfo;
+                } else {
+                    _log.debug("Authorization info previously cached as not found for internal id {}", internalId);
+                    return null;
+                }
+            }
+        }
+
+        authorizationInfo = getUncachedAuthorizationInfoByInternalId(internalId);
+        cacheAuthorizationInfoByInternalId(internalId, authorizationInfo);
+        return authorizationInfo;
+    }
+
+    /**
+     * If possible, this method caches the authorization info for an API key by its internal ID.  This may be called
+     * either by an explicit call to get the authorization info by internal ID or as a side effect of loading the
+     * authorization info by API key and proactive caching by internal ID.
+     */
+    private void cacheAuthorizationInfoByInternalId(String internalId, AuthorizationInfo authorizationInfo) {
+        Cache<String, AuthorizationInfo> internalAuthorizationCache = getAvailableInternalAuthorizationCache();
+
+        if (internalAuthorizationCache != null) {
+            internalAuthorizationCache.put(internalId, authorizationInfo);
+        }
+    }
+
+    /**
+     * Gets the authorization info for an API key's internal ID from the source (not from cache).
+     */
+    private AuthorizationInfo getUncachedAuthorizationInfoByInternalId(String internalId) {
+        // Retrieve the roles by internal ID
+        Set<String> roles = _authIdentityManager.getRolesByInternalId(internalId);
+        if (roles == null) {
+            _log.debug("Authorization info requested for non-existent internal id {}", internalId);
+            return _nullAuthorizationInfo;
+        }
+
+        return new SimpleAuthorizationInfo(ImmutableSet.copyOf(roles));
+    }
+
+    /**
+     * Test for whether an API key has a specific permission using its internal ID.
+     */
+    public boolean hasPermissionByInternalId(String internalId, String permission) {
+        Permission resolvedPermission = getPermissionResolver().resolvePermission(permission);
+        return hasPermissionByInternalId(internalId, resolvedPermission);
+    }
+
+    /**
+     * Test for whether an API key has a specific permission using its internal ID.
+     */
+    public boolean hasPermissionByInternalId(String internalId, Permission permission) {
+        return hasPermissionsByInternalId(internalId, ImmutableList.of(permission));
+    }
+
+    /**
+     * Test for whether an API key has specific permissions using its internal ID.
+     */
+    public boolean hasPermissionsByInternalId(String internalId, String... permissions) {
+        List<Permission> resolvedPermissions = Lists.newArrayListWithCapacity(permissions.length);
+        for (String permission : permissions) {
+            resolvedPermissions.add(getPermissionResolver().resolvePermission(permission));
+        }
+        return hasPermissionsByInternalId(internalId, resolvedPermissions);
+    }
+
+    /**
+     * Test for whether an API key has specific permissions using its internal ID.
+     */
+    public boolean hasPermissionsByInternalId(String internalId, Permission... permissions) {
+        return hasPermissionsByInternalId(internalId, Arrays.asList(permissions));
+    }
+
+    /**
+     * Test for whether an API key has specific permissions using its internal ID.
+     */
+    public boolean hasPermissionsByInternalId(String internalId, Collection<Permission> permissions) {
+        AuthorizationInfo authorizationInfo = getAuthorizationInfoByInternalId(internalId);
+        return authorizationInfo != null && isPermittedAll(permissions, authorizationInfo);
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKeySecurityManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKeySecurityManager.java
@@ -1,12 +1,18 @@
 package com.bazaarvoice.emodb.auth.apikey;
 
+import com.bazaarvoice.emodb.auth.EmoSecurityManager;
+import com.google.common.collect.ImmutableList;
+import org.apache.shiro.authz.Permission;
 import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.realm.Realm;
 import org.apache.shiro.subject.SubjectContext;
 
-public class ApiKeySecurityManager extends DefaultSecurityManager {
+import java.util.List;
+
+public class ApiKeySecurityManager extends DefaultSecurityManager implements EmoSecurityManager {
 
     public ApiKeySecurityManager(ApiKeyRealm realm) {
-        super(realm);
+        super(ImmutableList.<Realm>of(realm));
     }
 
     /**
@@ -17,5 +23,30 @@ public class ApiKeySecurityManager extends DefaultSecurityManager {
         SubjectContext subjectContext = super.createSubjectContext();
         subjectContext.setSecurityManager(this);
         return subjectContext;
+    }
+
+    private ApiKeyRealm getRealm() {
+        // We explicitly set "realms" to a List in the constructor so the following unchecked cast is valid.
+        return (ApiKeyRealm) ((List<Realm>) getRealms()).get(0);
+    }
+
+    @Override
+    public boolean hasPermissionByInternalId(String internalId, String permission) {
+        return getRealm().hasPermissionByInternalId(internalId, permission);
+    }
+
+    @Override
+    public boolean hasPermissionByInternalId(String internalId, Permission permission) {
+        return getRealm().hasPermissionByInternalId(internalId, permission);
+    }
+
+    @Override
+    public boolean hasPermissionsByInternalId(String internalId, String... permissions) {
+        return getRealm().hasPermissionsByInternalId(internalId, permissions);
+    }
+
+    @Override
+    public boolean hasPermissionsByInternalId(String internalId, Permission... permissions) {
+        return getRealm().hasPermissionsByInternalId(internalId, permissions);
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentity.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentity.java
@@ -14,7 +14,32 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 abstract public class AuthIdentity {
 
-    // ID of the identity
+    /**
+     * Each identity is associated with an internal ID which is never exposed outside the system.  This is done
+     * for several reasons:
+     *
+     * <ol>
+     *     <li>
+     *         Parts of the system may need associate resources with an ID.  For example, each databus subscription
+     *         is associated with an API key.  By using an internal ID these parts of the system don't need to
+     *         be concerned with safely storing the API key, since the internal ID is essentially a reference to
+     *         the key.
+     *     </li>
+     *     <li>
+     *         Parts of the system may need to determine whether an ID has permission to perform certain actions
+     *         without actually logging the user in.  Databus fanout is a prime example of this.  Using internal IDs
+     *         in the interface allows those parts of the system to validate authorization for permission without
+     *         the ability to impersonate that user by logging them in.
+     *     </li>
+     *     <li>
+     *         If an ID is compromised an administrator may want to replace it with a new ID without
+     *         changing all internal references to that ID.
+     *     </li>
+     * </ol>
+     */
+    private final String _internalId;
+
+    // Client-facing ID of the identity
     private final String _id;
     // Roles assigned to the identity
     private final Set<String> _roles;
@@ -26,14 +51,20 @@ abstract public class AuthIdentity {
     private Date _issued;
 
 
-    protected AuthIdentity(String id, Set<String> roles) {
+    protected AuthIdentity(String id, String internalId, Set<String> roles) {
         checkArgument(!Strings.isNullOrEmpty(id), "id");
+        checkArgument(!Strings.isNullOrEmpty(internalId), "internalId");
         _id = id;
+        _internalId = internalId;
         _roles = ImmutableSet.copyOf(checkNotNull(roles, "roles"));
     }
 
     public String getId() {
         return _id;
+    }
+
+    public String getInternalId() {
+        return _internalId;
     }
 
     public Set<String> getRoles() {

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentityManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentityManager.java
@@ -1,5 +1,7 @@
 package com.bazaarvoice.emodb.auth.identity;
 
+import java.util.Set;
+
 /**
  * Manager for identities.
  */
@@ -19,4 +21,9 @@ public interface AuthIdentityManager<T extends AuthIdentity> {
      * Deletes an identity.
      */
     void deleteIdentity(String id);
+
+    /**
+     * Gets the roles associated with an identity by its internal ID.
+     */
+    Set<String> getRolesByInternalId(String internalId);
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/InMemoryAuthIdentityManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/InMemoryAuthIdentityManager.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.auth.identity;
 import com.google.common.collect.Maps;
 
 import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -30,6 +31,17 @@ public class InMemoryAuthIdentityManager<T extends AuthIdentity> implements Auth
     public void deleteIdentity(String id) {
         checkNotNull(id, "id");
         _identityMap.remove(id);
+    }
+
+    @Override
+    public Set<String> getRolesByInternalId(String internalId) {
+        checkNotNull(internalId, "internalId");
+        for (T identity : _identityMap.values()) {
+            if (internalId.equals(identity.getInternalId())) {
+                return identity.getRoles();
+            }
+        }
+        return null;
     }
 
     public void reset() {

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/jersey/Subject.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/jersey/Subject.java
@@ -24,6 +24,10 @@ public class Subject {
         return ((PrincipalWithRoles) _principals.getPrimaryPrincipal()).getName();
     }
 
+    public String getInternalId() {
+        return ((PrincipalWithRoles) _principals.getPrimaryPrincipal()).getInternalId();
+    }
+
     public boolean hasRole(String role) {
         return _securityManager.hasRole(_principals, role);
     }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/AnonymousToken.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/AnonymousToken.java
@@ -21,6 +21,13 @@ public class AnonymousToken implements AuthenticationToken {
         return token == _instance;
     }
 
+    /**
+     * Efficient check for whether a principal is anonymous by performing instance comparison with the singleton.
+     */
+    public static boolean isAnonymousPrincipal(Object principal) {
+        return principal == ANONYMOUS;
+    }
+
     private AnonymousToken() {
         // empty
     }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/GuavaCacheManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/GuavaCacheManager.java
@@ -126,16 +126,10 @@ public class GuavaCacheManager extends AbstractCacheManager implements Invalidat
         @Override
         public Object remove(Object key)
                 throws CacheException {
-
-            // at runtime, key will be:
-            // for authorization cache: org.apache.shiro.subject.SimplePrincipalCollection
-            // for authentication cache: com.bazaarvoice.emodb.auth.shiro.GuavaCacheManager
-            // So, we need to access the API key from these objects.
-
-            // We will not invalidate here, because we have our own invalidation scheme
-            // that is based on capturing the invalidation event from the admin task that mutates keys.
-
-            return null;
+            String stringKey = extractStringKey(key);
+            Object oldValue = _cache.getIfPresent(stringKey);
+            _cache.invalidate(key);
+            return oldValue;
         }
 
         @Override

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/PrincipalWithRoles.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/PrincipalWithRoles.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.auth.shiro;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import org.eclipse.jetty.security.DefaultUserIdentity;
 import org.eclipse.jetty.server.UserIdentity;
@@ -11,17 +12,23 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class PrincipalWithRoles implements Principal {
     private final String _id;
+    private final String _internalId;
     private final Set<String> _roles;
     private UserIdentity _userIdentity;
 
-    public PrincipalWithRoles(String id, Set<String> roles) {
+    public PrincipalWithRoles(String id, String internalId, Set<String> roles) {
         _id = checkNotNull(id, "id");
+        _internalId = checkNotNull(internalId, "internalId");
         _roles = checkNotNull(roles, "roles");
     }
 
     @Override
     public String getName() {
         return _id;
+    }
+
+    public String getInternalId() {
+        return _internalId;
     }
 
     public Set<String> getRoles() {
@@ -45,5 +52,26 @@ public class PrincipalWithRoles implements Principal {
                     this, roles);
         }
         return _userIdentity;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PrincipalWithRoles)) {
+            return false;
+        }
+
+        PrincipalWithRoles that = (PrincipalWithRoles) o;
+
+        return _id.equals(that._id) &&
+                _internalId.equals(that._internalId) &&
+                _roles.equals(that._roles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(_id, _internalId);
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/RolePermissionSet.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/RolePermissionSet.java
@@ -1,0 +1,14 @@
+package com.bazaarvoice.emodb.auth.shiro;
+
+import org.apache.shiro.authz.Permission;
+
+import java.util.Set;
+
+/**
+ * Interface for a set of role permissions.  Used instead of <code>Set&lt;Permission&gt;</code> to allow for a
+ * type-safe self-validating implementation used by validating caches.
+ */
+public interface RolePermissionSet {
+
+    public Set<Permission> permissions();
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/SimpleRolePermissionSet.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/SimpleRolePermissionSet.java
@@ -1,0 +1,34 @@
+package com.bazaarvoice.emodb.auth.shiro;
+
+
+import org.apache.shiro.authz.Permission;
+
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Trivial implementation of {@link RolePermissionSet} using a Set.
+ */
+public class SimpleRolePermissionSet implements RolePermissionSet {
+
+    private Set<Permission> _permissions;
+
+    public SimpleRolePermissionSet(Set<Permission> permissions) {
+        _permissions = checkNotNull(permissions, "permissions");
+    }
+
+    public Set<Permission> permissions() {
+        return _permissions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o || (o instanceof RolePermissionSet && ((RolePermissionSet) o).permissions().equals(_permissions));
+    }
+
+    @Override
+    public int hashCode() {
+        return _permissions.hashCode();
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/ValidatingCacheManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/ValidatingCacheManager.java
@@ -1,0 +1,200 @@
+package com.bazaarvoice.emodb.auth.shiro;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.shiro.cache.Cache;
+import org.apache.shiro.cache.CacheException;
+import org.apache.shiro.cache.CacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Useful helper class when using invalidation caches.  There is a potential race condition due to the way Shiro
+ * caches values and the way the EmoDB cache invalidation system works.  The following example describes the issue:
+ *
+ * <ol>
+ *     <li>The realm returns authentication credentials for an API key.</li>
+ *     <li>The API key is deleted, causing the authentication cache to be invalidated.</li>
+ *     <li>The stale authentication credentials for the API key are still in memory and put in the cache.</li>
+ * </ol>
+ *
+ * Since the cache never expires the incorrect API key authentication credentials are cached indefinitely.
+ *
+ * To combat this the cache manager can be wrapped in a ValidatingCacheManager.  This manager will
+ * read the value from source the first time it is accessed.  If it differs from the cached value it will remove the
+ * value from cache and return null.  If it matches the cached value then all subsequent reads simply
+ * return the cached value, relying on cache invalidation if the value changes.
+ *
+ * With this scheme the above scenario is safe; when the stale authentication credentials are read from the cache in
+ * the third step they are validated, found to be stale and removed from cache.
+ */
+abstract public class ValidatingCacheManager implements CacheManager {
+
+    private final Logger _log = LoggerFactory.getLogger(getClass());
+
+    private final CacheManager _delegate;
+
+    public ValidatingCacheManager(CacheManager delegate) {
+        _delegate = checkNotNull(delegate, "delegate");
+    }
+
+    /**
+     * Subclasses should return the cache validator for the cache with the given name.  If no validator is required
+     * then it should return null.
+     */
+    @Nullable
+    abstract protected CacheValidator<?,?> getCacheValidatorForCache(String name);
+
+    @Override
+    public <K, V> Cache<K, V> getCache(String name) throws CacheException {
+        //noinspection unchecked
+        CacheValidator<K, V> cacheValidator = (CacheValidator<K, V>) getCacheValidatorForCache(name);
+
+        if (cacheValidator != null) {
+            return new ValidatingCache<>(name, cacheValidator);
+        }
+
+        // Return delegate cache with no validation on first get.
+        return _delegate.getCache(name);
+    }
+
+    /**
+     * Cache implementation that uses validating entries to validate values on the first read.
+     */
+    private class ValidatingCache<K, V> implements Cache<K, V> {
+        private final String _name;
+        private final Cache<K, ValidatingEntry> _cache;
+        private final CacheValidator<K, V> _cacheValidator;
+
+        private ValidatingCache(String name, CacheValidator<K, V> cacheValidator) {
+            _name = checkNotNull(name, "name");
+            _cache = _delegate.getCache(name);
+            _cacheValidator = cacheValidator;
+            _log.debug("Created validating cache for {} of <{}, {}>", name, cacheValidator.getKeyType(), cacheValidator.getValueType());
+        }
+
+        @Override
+        public V get(K key) throws CacheException {
+            ValidatingEntry entry = _cache.get(key);
+            if (entry == null) {
+                return null;
+            }
+            return entry.getValue(key);
+        }
+
+        @Override
+        public V put(K key, V value) throws CacheException {
+            ValidatingEntry oldEntry = _cache.put(key, new ValidatingEntry(value));
+            if (oldEntry == null) {
+                return null;
+            }
+            return oldEntry.getCachedValue();
+        }
+
+        @Override
+        public V remove(K key) throws CacheException {
+            ValidatingEntry oldEntry = _cache.remove(key);
+            if (oldEntry == null) {
+                return null;
+            }
+            return oldEntry.getCachedValue();
+        }
+
+        @Override
+        public void clear() throws CacheException {
+            _cache.clear();
+        }
+
+        @Override
+        public int size() {
+            return _cache.size();
+        }
+
+        @Override
+        public Set<K> keys() {
+            return _cache.keys();
+        }
+
+        @Override
+        public Collection<V> values() {
+            ImmutableList.Builder<V> values = ImmutableList.builder();
+
+            for (K key : _cache.keys()) {
+                ValidatingEntry entry = _cache.get(key);
+                V value;
+                if (entry != null && (value = entry.getValue(key)) != null) {
+                    values.add(value);
+                }
+            }
+
+            return values.build();
+        }
+
+        /**
+         * Entry implementation which validates the cached value the first time it is read.  If the cache value
+         * fails validation it is removed from cache.
+         */
+        private class ValidatingEntry {
+            private final V _cachedValue;
+            private volatile boolean _validated = false;
+
+            private ValidatingEntry(V cachedValue) {
+                _cachedValue = cachedValue;
+            }
+
+            public V getValue(K key) {
+                if (!_validated) {
+                    synchronized(this) {
+                        if (!_validated) {
+                            if (!_cacheValidator.getKeyType().isInstance(key) ||
+                                    !_cacheValidator.getValueType().isInstance(_cachedValue) ||
+                                    !_cacheValidator.isCurrentValue(key, _cachedValue)) {
+                                _cache.remove(key);
+                                _log.debug("Validation failed for key {} in cache {}; cached value evicted", key, _name);
+                                return null;
+                            }
+
+                            _log.debug("Validation passed for key {} in cache {}", key, _name);
+                            _validated = true;
+                        }
+                    }
+                }
+
+                return _cachedValue;
+            }
+
+            public V getCachedValue() {
+                return _cachedValue;
+            }
+        }
+    }
+
+    /**
+     * Base class for defining the validation for whether a cached value is current or stale.  Client classes are expected
+     * to create their own implementations to be returned by {@link #getCacheValidatorForCache(String)}.
+     */
+    abstract public static class CacheValidator<CVK, CVV> {
+        private final Class<CVK> _keyType;
+        private final Class<CVV> _valueType;
+
+        public CacheValidator(Class<CVK> keyType, Class<CVV> valueType) {
+            _keyType = checkNotNull(keyType, "keyType");
+            _valueType = checkNotNull(valueType, "valueType");
+        }
+
+        public Class<CVK> getKeyType() {
+            return _keyType;
+        }
+
+        public Class<CVV> getValueType() {
+            return _valueType;
+        }
+
+        abstract public boolean isCurrentValue(CVK key, CVV value);
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/util/CredentialEncrypter.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/util/CredentialEncrypter.java
@@ -45,7 +45,7 @@ public class CredentialEncrypter {
     }
 
     /**
-     * Convenience constructor to initialize from the a string converted to a UTF-8 byte array.
+     * Convenience constructor to initialize from a string converted to a UTF-8 byte array.
      */
     public CredentialEncrypter(String initializationString) {
         this(checkNotNull(initializationString, "initializationString").getBytes(Charsets.UTF_8));

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/CacheManagingAuthIdentityManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/CacheManagingAuthIdentityManager.java
@@ -2,6 +2,8 @@ package com.bazaarvoice.emodb.auth.identity;
 
 import com.bazaarvoice.emodb.auth.shiro.InvalidatableCacheManager;
 
+import java.util.Set;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -35,5 +37,11 @@ public class CacheManagingAuthIdentityManager<T extends AuthIdentity> implements
         checkNotNull(id);
         _manager.deleteIdentity(id);
         _cacheManager.invalidateAll();
+    }
+
+    @Override
+    public Set<String> getRolesByInternalId(String internalId) {
+        checkNotNull(internalId, "internalId");
+        return _manager.getRolesByInternalId(internalId);
     }
 }

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/DeferringAuthIdentityManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/DeferringAuthIdentityManager.java
@@ -2,11 +2,13 @@ package com.bazaarvoice.emodb.auth.identity;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -19,18 +21,24 @@ public class DeferringAuthIdentityManager<T extends AuthIdentity> implements Aut
 
     private final AuthIdentityManager<T> _manager;
     private final Map<String, T> _identityMap;
+    private final Map<String, T> _internalIdMap;
 
     public DeferringAuthIdentityManager(AuthIdentityManager<T> manager, @Nullable List<T> identities) {
         _manager = checkNotNull(manager);
         if (identities == null) {
             _identityMap = ImmutableMap.of();
+            _internalIdMap = ImmutableMap.of();
         } else {
-            _identityMap = Maps.uniqueIndex(identities, new Function<T, String>() {
-                @Override
-                public String apply(T identity) {
-                    return identity.getId();
-                }
-            });
+            ImmutableMap.Builder<String, T> identityMapBuilder = ImmutableMap.builder();
+            ImmutableMap.Builder<String, T> internalIdMapBuilder = ImmutableMap.builder();
+
+            for (T identity : identities) {
+                identityMapBuilder.put(identity.getId(), identity);
+                internalIdMapBuilder.put(identity.getInternalId(), identity);
+            }
+
+            _identityMap = identityMapBuilder.build();
+            _internalIdMap = internalIdMapBuilder.build();
         }
     }
 
@@ -49,7 +57,9 @@ public class DeferringAuthIdentityManager<T extends AuthIdentity> implements Aut
     public void updateIdentity(T identity) {
         checkNotNull(identity);
         String id = checkNotNull(identity.getId());
+        String internalId = checkNotNull(identity.getInternalId());
         checkArgument(!_identityMap.containsKey(id), "Cannot update static identity: %s", id);
+        checkArgument(!_internalIdMap.containsKey(internalId), "Cannot use internal ID from static identity: %s", internalId);
         _manager.updateIdentity(identity);
     }
 
@@ -58,5 +68,16 @@ public class DeferringAuthIdentityManager<T extends AuthIdentity> implements Aut
         checkNotNull(id);
         checkArgument(!_identityMap.containsKey(id), "Cannot delete static identity: %s", id);
         _manager.deleteIdentity(id);
+    }
+
+    @Override
+    public Set<String> getRolesByInternalId(String internalId) {
+        checkNotNull(internalId, "internalId");
+
+        T identity = _internalIdMap.get(internalId);
+        if (identity != null) {
+            return identity.getRoles();
+        }
+        return _manager.getRolesByInternalId(internalId);
     }
 }

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/TableAuthIdentityManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/TableAuthIdentityManager.java
@@ -2,20 +2,30 @@ package com.bazaarvoice.emodb.auth.identity;
 
 import com.bazaarvoice.emodb.common.json.JsonHelper;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.AuditBuilder;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.api.ReadConsistency;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.api.Update;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
+import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.HashFunction;
 
 import javax.annotation.Nullable;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -26,41 +36,54 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class TableAuthIdentityManager<T extends AuthIdentity> implements AuthIdentityManager<T> {
 
+    private final static String ID = "id";
+    private final static String MASKED_ID = "maskedId";
+    private final static String HASHED_ID = "hashedId";
+
     private final Class<T> _authIdentityClass;
     private final DataStore _dataStore;
-    private final String _tableName;
+    private final String _identityTableName;
+    private final String _internalIdIndexTableName;
     private final String _placement;
     private final HashFunction _hash;
-    private volatile boolean _tableValidated;
+    private volatile boolean _tablesValidated;
 
-    public TableAuthIdentityManager(Class<T> authIdentityClass, DataStore dataStore, String tableName, String placement) {
-        this(authIdentityClass, dataStore, tableName, placement, null);
+    public TableAuthIdentityManager(Class<T> authIdentityClass, DataStore dataStore, String identityTableName,
+                                    String internalIdIndexTableName, String placement) {
+        this(authIdentityClass, dataStore, identityTableName, internalIdIndexTableName, placement, null);
     }
 
-    public TableAuthIdentityManager(Class<T> authIdentityClass, DataStore dataStore, String tableName, String placement,
-                                    @Nullable HashFunction hash) {
+    public TableAuthIdentityManager(Class<T> authIdentityClass, DataStore dataStore, String identityTableName,
+                                    String internalIdIndexTableName, String placement, @Nullable HashFunction hash) {
         _authIdentityClass = checkNotNull(authIdentityClass, "authIdentityClass");
         _dataStore = checkNotNull(dataStore, "client");
-        _tableName = checkNotNull(tableName, "tableName");
+        _identityTableName = checkNotNull(identityTableName, "identityTableName");
+        _internalIdIndexTableName = checkNotNull(internalIdIndexTableName, "internalIdIndexTableName");
         _placement = checkNotNull(placement, "placement");
         _hash = hash;
+
+        checkArgument(!_identityTableName.equals(internalIdIndexTableName), "Identity and internal ID index tables must be distinct");
     }
 
     @Override
     public T getIdentity(String id) {
         checkNotNull(id, "id");
-        validateTable();
+        validateTables();
 
         String hashedId = hash(id);
-        Map<String, Object> map = _dataStore.get(_tableName, hashedId);
-        if (Intrinsic.isDeleted(map)) {
+        Map<String, Object> map = _dataStore.get(_identityTableName, hashedId);
+        return convertDataStoreEntryToIdentity(id, map);
+    }
+
+    private T convertDataStoreEntryToIdentity(String id, Map<String, Object> map) {
+        if (map == null || Intrinsic.isDeleted(map)) {
             return null;
         }
 
         // The entry is stored without the original ID, so add it back
         map.keySet().removeAll(Intrinsic.DATA_FIELDS);
-        map.remove("maskedId");
-        map.put("id", id);
+        map.remove(MASKED_ID);
+        map.put(ID, id);
 
         return JsonHelper.convert(map, _authIdentityClass);
     }
@@ -69,55 +92,132 @@ public class TableAuthIdentityManager<T extends AuthIdentity> implements AuthIde
     public void updateIdentity(T identity) {
         checkNotNull(identity, "identity");
         String id = checkNotNull(identity.getId(), "id");
-        validateTable();
+        String internalId = checkNotNull(identity.getInternalId(), "internalId");
+        validateTables();
+
+        UUID changeId = TimeUUIDs.newUUID();
+        Audit audit = new AuditBuilder().setLocalHost().setComment("update identity").build();
 
         String hashedId = hash(id);
         Map<String, Object> map = JsonHelper.convert(identity, new TypeReference<Map<String,Object>>(){});
 
         // Strip the ID and replace it with a masked version
-        map.remove("id");
-        map.put("maskedId", mask(id));
+        map.remove(ID);
+        map.put(MASKED_ID, mask(id));
 
-        _dataStore.update(
-                _tableName,
-                hashedId,
-                TimeUUIDs.newUUID(),
-                Deltas.literal(map),
-                new AuditBuilder().setLocalHost().setComment("update identity").build(),
-                WriteConsistency.GLOBAL);
+        Update identityUpdate = new Update(_identityTableName, hashedId, changeId, Deltas.literal(map), audit, WriteConsistency.GLOBAL);
+
+        map = ImmutableMap.<String, Object>of(HASHED_ID, hashedId);
+        Update internalIdUpdate = new Update(_internalIdIndexTableName, internalId, changeId, Deltas.literal(map), audit, WriteConsistency.GLOBAL);
+
+        // Update the identity and internal ID index in a single update
+        _dataStore.updateAll(ImmutableList.of(identityUpdate, internalIdUpdate));
     }
 
     @Override
     public void deleteIdentity(String id) {
         checkNotNull(id, "id");
-        validateTable();
+        validateTables();
 
         String hashedId = hash(id);
 
         _dataStore.update(
-                _tableName,
+                _identityTableName,
                 hashedId,
                 TimeUUIDs.newUUID(),
                 Deltas.delete(),
                 new AuditBuilder().setLocalHost().setComment("delete identity").build(),
                 WriteConsistency.GLOBAL);
+
+        // Don't delete the entry from the internal ID index table; it will be lazily deleted next time it is used.
+        // Otherwise there may be a race condition when an API key is migrated.
     }
 
-    private void validateTable() {
-        if (_tableValidated) {
+    @Override
+    public Set<String> getRolesByInternalId(String internalId) {
+        checkNotNull(internalId, "internalId");
+
+        // The actual ID is stored using a one-way hash so it is not recoverable.  Use a dummy value to satisfy
+        // the requirement for constructing the identity; we only need the roles from the identity anyway.
+        final String STUB_ID = "ignore";
+
+        T identity = null;
+
+        // First try using the index table to determine the hashed ID.
+        Map<String, Object> internalIdRecord = _dataStore.get(_internalIdIndexTableName, internalId);
+        if (!Intrinsic.isDeleted(internalIdRecord)) {
+            String hashedId = (String) internalIdRecord.get(HASHED_ID);
+            Map<String, Object> identityEntry = _dataStore.get(_identityTableName, hashedId);
+            identity = convertDataStoreEntryToIdentity(STUB_ID, identityEntry);
+
+            if (identity == null || !identity.getInternalId().equals(internalId)) {
+                // Disregard the value
+                identity = null;
+
+                // The internal ID index table entry was stale.  Delete it.
+                Delta deleteIndexRecord = Deltas.conditional(
+                        Conditions.mapBuilder()
+                                .matches(HASHED_ID, Conditions.equal(hashedId))
+                                .build(),
+                        Deltas.delete());
+
+                _dataStore.update(_internalIdIndexTableName, internalId, TimeUUIDs.newUUID(), deleteIndexRecord,
+                        new AuditBuilder().setLocalHost().setComment("delete stale identity").build());
+            }
+        }
+
+        if (identity == null) {
+            // This should be rare, but if the record was not found or was stale in the index table then scan for it.
+
+            Iterator<Map<String, Object>> entries = _dataStore.scan(_identityTableName, null, Long.MAX_VALUE, ReadConsistency.STRONG);
+            while (entries.hasNext() && identity == null) {
+                Map<String, Object> entry = entries.next();
+                T potentialIdentity = convertDataStoreEntryToIdentity(STUB_ID, entry);
+                if (potentialIdentity != null && internalId.equals(potentialIdentity.getInternalId())) {
+                    // We found the identity
+                    identity = potentialIdentity;
+
+                    // Update the internal ID index.  There is a possible race condition if the identity is being
+                    // migrated concurrent to this update.  If that happens, however, the next time it is read the
+                    // index will be incorrect and it will be lazily updated at that time.
+                    Delta updateIndexRecord = Deltas.literal(ImmutableMap.of(HASHED_ID, Intrinsic.getId(entry)));
+                    _dataStore.update(_internalIdIndexTableName, internalId, TimeUUIDs.newUUID(), updateIndexRecord,
+                            new AuditBuilder().setLocalHost().setComment("update identity").build());
+                }
+            }
+        }
+
+        if (identity != null) {
+            return identity.getRoles();
+        }
+
+        // Identity not found, return null
+        return null;
+    }
+
+    private void validateTables() {
+        if (_tablesValidated) {
             return;
         }
 
         synchronized(this) {
-            if (!_dataStore.getTableExists(_tableName)) {
+            if (!_dataStore.getTableExists(_identityTableName)) {
                 _dataStore.createTable(
-                        _tableName,
+                        _identityTableName,
                         new TableOptionsBuilder().setPlacement(_placement).build(),
                         ImmutableMap.<String, Object>of(),
                         new AuditBuilder().setLocalHost().setComment("create identity table").build());
             }
 
-            _tableValidated = true;
+            if (!_dataStore.getTableExists(_internalIdIndexTableName)) {
+                _dataStore.createTable(
+                        _internalIdIndexTableName,
+                        new TableOptionsBuilder().setPlacement(_placement).build(),
+                        ImmutableMap.<String, Object>of(),
+                        new AuditBuilder().setLocalHost().setComment("create internal ID table").build());
+            }
+
+            _tablesValidated = true;
         }
     }
 

--- a/auth/auth-test/src/test/java/com/bazaarvoice/emodb/auth/CachingTest.java
+++ b/auth/auth-test/src/test/java/com/bazaarvoice/emodb/auth/CachingTest.java
@@ -84,8 +84,8 @@ public class CachingTest {
         _permissionCaching = new CacheManagingPermissionManager(permissionDAO, _cacheManager);
         _permissionManager = spy(_permissionCaching);
 
-        authIdentityDAO.updateIdentity(new ApiKey("testkey", ImmutableSet.of("testrole")));
-        authIdentityDAO.updateIdentity(new ApiKey("othertestkey", ImmutableSet.of("testrole")));
+        authIdentityDAO.updateIdentity(new ApiKey("testkey", "id0", ImmutableSet.of("testrole")));
+        authIdentityDAO.updateIdentity(new ApiKey("othertestkey", "id1", ImmutableSet.of("testrole")));
 
         permissionDAO.updateForRole("testrole", new PermissionUpdateRequest().permit("city|get|Madrid", "country|get|Spain"));
 
@@ -105,7 +105,7 @@ public class CachingTest {
     public void testGetOneKey() throws Exception {
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
-        verify(_authIdentityManager).getIdentity("testkey");
+        verify(_authIdentityManager, times(2)).getIdentity("testkey");
         verify(_permissionManager, times(INVOCATIONS_PER_ROLE * 1)).getAllForRole("testrole");
         verify(_permissionManager).getPermissionResolver();
         verifyNoMoreInteractions(_permissionManager, _authIdentityManager);
@@ -116,7 +116,7 @@ public class CachingTest {
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
         testGetWithMatchingPermissions("othertestkey", "Spain", "Madrid");
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
-        verify(_authIdentityManager).getIdentity("testkey");
+        verify(_authIdentityManager, times(2)).getIdentity("testkey");
         verify(_authIdentityManager).getIdentity("othertestkey");
         verify(_permissionManager, times(INVOCATIONS_PER_ROLE * 1)).getAllForRole("testrole");
         verify(_permissionManager).getPermissionResolver();
@@ -130,7 +130,7 @@ public class CachingTest {
         _cacheManager.invalidateAll();
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
-        verify(_authIdentityManager, times(2)).getIdentity("testkey");
+        verify(_authIdentityManager, times(4)).getIdentity("testkey");
     }
 
     @Test
@@ -140,10 +140,10 @@ public class CachingTest {
         _permissionCaching.updateForRole("othertestrole", new PermissionUpdateRequest().permit("city|get|Austin", "country|get|USA"));
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
-        _authIdentityCaching.updateIdentity(new ApiKey("othertestkey", ImmutableSet.of("othertestrole")));
+        _authIdentityCaching.updateIdentity(new ApiKey("othertestkey", "id1", ImmutableSet.of("othertestrole")));
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
-        verify(_authIdentityManager, times(3)).getIdentity("testkey");
+        verify(_authIdentityManager, times(6)).getIdentity("testkey");
         verify(_permissionManager, times(INVOCATIONS_PER_ROLE * 3)).getAllForRole("testrole");
         verify(_permissionManager).getPermissionResolver();
         verifyNoMoreInteractions(_permissionManager, _authIdentityManager);
@@ -158,7 +158,7 @@ public class CachingTest {
         testGetWithMatchingPermissions("testkey", "USA", "Austin");
         testGetWithMatchingPermissions("testkey", "USA", "Austin");
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
-        verify(_authIdentityManager, times(2)).getIdentity("testkey");
+        verify(_authIdentityManager, times(4)).getIdentity("testkey");
         verify(_permissionManager, times(INVOCATIONS_PER_ROLE * 2)).getAllForRole("testrole");
         verify(_permissionManager).getPermissionResolver();
         verifyNoMoreInteractions(_permissionManager, _authIdentityManager);
@@ -173,7 +173,7 @@ public class CachingTest {
         testGetWithMissingPermissions("othertestkey", "USA", "Austin");
         testGetWithMissingPermissions("othertestkey", "USA", "Austin");
         _permissionCaching.updateForRole("othertestrole", new PermissionUpdateRequest().permit("city|get|Austin", "country|get|USA"));
-        _authIdentityCaching.updateIdentity(new ApiKey("othertestkey", ImmutableSet.of("testrole", "othertestrole")));
+        _authIdentityCaching.updateIdentity(new ApiKey("othertestkey", "id1", ImmutableSet.of("testrole", "othertestrole")));
 
         testGetWithMatchingPermissions("othertestkey", "USA", "Austin"); // +1 othertestkey, +1 othertestrole
         testGetWithMatchingPermissions("othertestkey", "USA", "Austin");
@@ -182,8 +182,8 @@ public class CachingTest {
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid"); // +1 testkey
         testGetWithMatchingPermissions("testkey", "Spain", "Madrid");
 
-        verify(_authIdentityManager, times(2)).getIdentity("testkey");
-        verify(_authIdentityManager, times(2)).getIdentity("othertestkey");
+        verify(_authIdentityManager, times(4)).getIdentity("testkey");
+        verify(_authIdentityManager, times(4)).getIdentity("othertestkey");
         verify(_permissionManager, times(INVOCATIONS_PER_ROLE * 2)).getAllForRole("testrole");
         verify(_permissionManager, times(INVOCATIONS_PER_ROLE * 1)).getAllForRole("othertestrole");
         verify(_permissionManager).getPermissionResolver();

--- a/auth/auth-test/src/test/java/com/bazaarvoice/emodb/auth/ResourcePermissionsTest.java
+++ b/auth/auth-test/src/test/java/com/bazaarvoice/emodb/auth/ResourcePermissionsTest.java
@@ -164,7 +164,7 @@ public class ResourcePermissionsTest {
     }
 
     private void testGetWithMissingPermission(PermissionCheck permissionCheck) throws Exception {
-        _authIdentityDAO.updateIdentity(new ApiKey("testkey", ImmutableSet.of("testrole")));
+        _authIdentityDAO.updateIdentity(new ApiKey("testkey", "id0", ImmutableSet.of("testrole")));
         _permissionDAO.updateForRole("testrole", new PermissionUpdateRequest().permit("country|get|Spain"));
 
         ClientResponse response = getCountryAndCity(permissionCheck, "Spain", "Madrid", "testkey");
@@ -187,7 +187,7 @@ public class ResourcePermissionsTest {
     }
 
     private void testGetWithMatchingPermissions(PermissionCheck permissionCheck) throws Exception {
-        _authIdentityDAO.updateIdentity(new ApiKey("testkey", ImmutableSet.of("testrole")));
+        _authIdentityDAO.updateIdentity(new ApiKey("testkey", "id0", ImmutableSet.of("testrole")));
         _permissionDAO.updateForRole("testrole",
                 new PermissionUpdateRequest().permit("city|get|Madrid", "country|get|Spain"));
 
@@ -211,7 +211,7 @@ public class ResourcePermissionsTest {
     }
 
     private void testGetWithMatchingWildcardPermissions(PermissionCheck permissionCheck) throws Exception {
-        _authIdentityDAO.updateIdentity(new ApiKey("testkey", ImmutableSet.of("testrole")));
+        _authIdentityDAO.updateIdentity(new ApiKey("testkey", "id0", ImmutableSet.of("testrole")));
         _permissionDAO.updateForRole("testrole",
                 new PermissionUpdateRequest().permit("city|get|*", "country|*|*"));
 
@@ -235,7 +235,7 @@ public class ResourcePermissionsTest {
     }
 
     private void testGetWithNonMatchingWildcardPermission(PermissionCheck permissionCheck) throws Exception {
-        _authIdentityDAO.updateIdentity(new ApiKey("testkey", ImmutableSet.of("testrole")));
+        _authIdentityDAO.updateIdentity(new ApiKey("testkey", "id0", ImmutableSet.of("testrole")));
         _permissionDAO.updateForRole("testrole",
                 new PermissionUpdateRequest().permit("city|get|Madrid", "country|*|Portugal"));
 
@@ -259,7 +259,7 @@ public class ResourcePermissionsTest {
     }
 
     private void testGetWithEscapedPermission(PermissionCheck permissionCheck) throws Exception {
-        _authIdentityDAO.updateIdentity(new ApiKey("testkey", ImmutableSet.of("testrole")));
+        _authIdentityDAO.updateIdentity(new ApiKey("testkey", "id0", ImmutableSet.of("testrole")));
         _permissionDAO.updateForRole("testrole",
                 new PermissionUpdateRequest().permit("city|get|Pipe\\|Town", "country|get|Star\\*Nation"));
 
@@ -283,7 +283,7 @@ public class ResourcePermissionsTest {
     }
 
     private void testAnonymousWithPermission(PermissionCheck permissionCheck) throws Exception {
-        _authIdentityDAO.updateIdentity(new ApiKey("anon", ImmutableSet.of("anonrole")));
+        _authIdentityDAO.updateIdentity(new ApiKey("anon", "id1", ImmutableSet.of("anonrole")));
         _permissionDAO.updateForRole("anonrole",
                 new PermissionUpdateRequest().permit("city|get|Madrid", "country|get|Spain"));
 

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/UnauthorizedSubscriptionException.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/UnauthorizedSubscriptionException.java
@@ -1,0 +1,34 @@
+package com.bazaarvoice.emodb.databus.api;
+
+import com.bazaarvoice.emodb.common.api.UnauthorizedException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Thrown when an unauthorized databus operation is performed on a subscription, such when a subscription created with
+ * one API key is polled using a different key.
+ */
+@JsonIgnoreProperties({"cause", "localizedMessage", "stackTrace", "message", "suppressed"})
+public class UnauthorizedSubscriptionException extends UnauthorizedException {
+    private final String _subscription;
+
+    public UnauthorizedSubscriptionException() {
+        _subscription = null;
+    }
+
+    public UnauthorizedSubscriptionException(String subscription) {
+        super(subscription);
+        _subscription = subscription;
+    }
+
+    @JsonCreator
+    public UnauthorizedSubscriptionException(@JsonProperty("reason") String message, @JsonProperty("subscription") String subscription) {
+        super(message);
+        _subscription = subscription;
+    }
+
+    public String getSubscription() {
+        return _subscription;
+    }
+}

--- a/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusClient.java
+++ b/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusClient.java
@@ -13,6 +13,7 @@ import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
+import com.bazaarvoice.emodb.databus.api.UnauthorizedSubscriptionException;
 import com.bazaarvoice.emodb.databus.api.UnknownMoveException;
 import com.bazaarvoice.emodb.databus.api.UnknownReplayException;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -419,6 +420,13 @@ public class DatabusClient implements AuthDatabus {
         } else if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode() &&
                 UnknownReplayException.class.getName().equals(exceptionType)) {
             return response.getEntity(UnknownReplayException.class);
+        } else if (response.getStatus() == Response.Status.FORBIDDEN.getStatusCode() &&
+                UnauthorizedSubscriptionException.class.getName().equals(exceptionType)) {
+            if (response.hasEntity()) {
+                return (RuntimeException) response.getEntity(UnauthorizedSubscriptionException.class).initCause(e);
+            } else {
+                return (RuntimeException) new UnauthorizedSubscriptionException().initCause(e);
+            }
         } else if (response.getStatus() == Response.Status.FORBIDDEN.getStatusCode() &&
                 UnauthorizedException.class.getName().equals(exceptionType)) {
             if (response.hasEntity()) {

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
@@ -19,12 +19,14 @@ import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.core.CanaryManager;
 import com.bazaarvoice.emodb.databus.core.DatabusChannelConfiguration;
 import com.bazaarvoice.emodb.databus.core.DatabusEventStore;
+import com.bazaarvoice.emodb.databus.core.DatabusFactory;
 import com.bazaarvoice.emodb.databus.core.DedupMigrationTask;
 import com.bazaarvoice.emodb.databus.core.DefaultDatabus;
 import com.bazaarvoice.emodb.databus.core.DefaultFanoutManager;
 import com.bazaarvoice.emodb.databus.core.DefaultRateLimitedLogFactory;
 import com.bazaarvoice.emodb.databus.core.FanoutManager;
 import com.bazaarvoice.emodb.databus.core.MasterFanout;
+import com.bazaarvoice.emodb.databus.core.OwnerAwareDatabus;
 import com.bazaarvoice.emodb.databus.core.RateLimitedLogFactory;
 import com.bazaarvoice.emodb.databus.core.SubscriptionEvaluator;
 import com.bazaarvoice.emodb.databus.core.SystemQueueMonitorManager;
@@ -86,15 +88,17 @@ import static com.google.common.base.Preconditions.checkArgument;
  * <li> @{@link Global} {@link CuratorFramework}
  * <li> Jersey {@link Client}
  * <li> @{@link ReplicationKey} String
+ * <li> @{@link SystemInternalId} String
  * <li> DataStore {@link DataProvider}
  * <li> DataStore {@link EventBus}
  * <li> DataStore {@link DataStoreConfiguration}
+ * <li> {@link com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer}
  * <li> @{@link DefaultJoinFilter} Supplier&lt;{@link Condition}&gt;
  * <li> {@link Clock}
  * </ul>
  * Exports the following:
  * <ul>
- * <li> {@link Databus}
+ * <li> {@link DatabusFactory}
  * <li> {@link DatabusEventStore}
  * <li> {@link ReplicationSource}
  * </ul>
@@ -150,8 +154,9 @@ public class DatabusModule extends PrivateModule {
         expose(DatabusEventStore.class);
 
         // Bind the Databus instance that the rest of the application will consume
-        bind(Databus.class).to(DefaultDatabus.class).asEagerSingleton();
-        expose(Databus.class);
+        bind(OwnerAwareDatabus.class).to(DefaultDatabus.class).asEagerSingleton();
+        bind(DatabusFactory.class).asEagerSingleton();
+        expose(DatabusFactory.class);
 
         // Bind the cross-data center outbound replication end point
         bind(ReplicationSource.class).to(DefaultReplicationSource.class).asEagerSingleton();

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/SystemInternalId.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/SystemInternalId.java
@@ -1,0 +1,16 @@
+package com.bazaarvoice.emodb.databus;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface SystemInternalId {
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/auth/ConstantDatabusAuthorizer.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/auth/ConstantDatabusAuthorizer.java
@@ -1,0 +1,42 @@
+package com.bazaarvoice.emodb.databus.auth;
+
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
+
+/**
+ * Simple {@link DatabusAuthorizer} implementation that either permits or denies all requests based on the provided
+ * value.
+ */
+public class ConstantDatabusAuthorizer implements DatabusAuthorizer {
+
+    private final ConstantDatabusAuthorizerForOwner _authorizer;
+
+    public static final ConstantDatabusAuthorizer ALLOW_ALL = new ConstantDatabusAuthorizer(true);
+    public static final ConstantDatabusAuthorizer DENY_ALL = new ConstantDatabusAuthorizer(false);
+
+    private ConstantDatabusAuthorizer(boolean authorize) {
+        _authorizer = new ConstantDatabusAuthorizerForOwner(authorize);
+    }
+
+    @Override
+    public DatabusAuthorizerByOwner owner(String ownerId) {
+        return _authorizer;
+    }
+
+    private class ConstantDatabusAuthorizerForOwner implements DatabusAuthorizerByOwner {
+        private final boolean _authorize;
+
+        private ConstantDatabusAuthorizerForOwner(boolean authorize) {
+            _authorize = authorize;
+        }
+
+        @Override
+        public boolean canAccessSubscription(OwnedSubscription subscription) {
+            return _authorize;
+        }
+
+        @Override
+        public boolean canReceiveEventsFromTable(String table) {
+            return _authorize;
+        }
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/auth/DatabusAuthorizer.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/auth/DatabusAuthorizer.java
@@ -1,0 +1,28 @@
+package com.bazaarvoice.emodb.databus.auth;
+
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
+
+/**
+ * This interface defines the interactions for authorizing databus subscription and fanout operations.
+ * In all cases the ownerId is the internal ID for a user.
+ */
+public interface DatabusAuthorizer {
+
+    DatabusAuthorizerByOwner owner(String ownerId);
+
+    interface DatabusAuthorizerByOwner {
+        /**
+         * Checks whether an owner has permission to resubscribe to or poll the provided subscription.  Typically used
+         * in response to API subscribe and poll requests, respectively.
+         */
+        boolean canAccessSubscription(OwnedSubscription subscription);
+
+        /**
+         * Checks whether an owner has permission to receive databus events on a given table when polling.  Typically
+         * used during fanout to ensure the owner doesn't receive updates for documents he wouldn't have permission to read
+         * directly using the DataStore.
+         */
+        boolean canReceiveEventsFromTable(String table);
+
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/auth/FilteredDatabusAuthorizer.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/auth/FilteredDatabusAuthorizer.java
@@ -1,0 +1,81 @@
+package com.bazaarvoice.emodb.databus.auth;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Implementation of DatabusAuthorizer that overrides authorization for specific owners.  All other owners
+ * are optionally proxied to another instance.
+ */
+public class FilteredDatabusAuthorizer implements DatabusAuthorizer {
+
+    private final Map<String, DatabusAuthorizer> _ownerOverrides;
+    private final DatabusAuthorizer _authorizer;
+
+    private FilteredDatabusAuthorizer(Map<String, DatabusAuthorizer> ownerOverrides,
+                                      DatabusAuthorizer authorizer) {
+        _ownerOverrides = checkNotNull(ownerOverrides, "ownerOverrides");
+        _authorizer = checkNotNull(authorizer, "authorizer");
+    }
+
+    @Override
+    public DatabusAuthorizerByOwner owner(String ownerId) {
+        // TODO:  To grandfather in subscriptions before API keys were enforced the following code
+        //        always defers to the default authorizer if there is no owner.  This code should be
+        //        replaced with the commented-out version once enough time has passed for all grandfathered-in
+        //        subscriptions to have been renewed and therefore have an owner attached.
+        //
+        // return Objects.firstNonNull(_ownerOverrides.get(ownerId), _authorizer).owner(ownerId);
+
+        DatabusAuthorizer authorizer = null;
+        if (ownerId != null) {
+            authorizer = _ownerOverrides.get(ownerId);
+        }
+        if (authorizer == null) {
+            authorizer = _authorizer;
+        }
+        return authorizer.owner(ownerId);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder class for creating a FilteredDatabusAuthorizer.
+     */
+    public static class Builder {
+        private final Map<String, DatabusAuthorizer> _ownerOverrides = Maps.newHashMap();
+        private DatabusAuthorizer _defaultAuthorizer;
+
+        private Builder() {
+            // no-op
+        }
+
+        public Builder withAuthorizerForOwner(String ownerId, DatabusAuthorizer authorizer) {
+            checkArgument(!_ownerOverrides.containsKey(ownerId), "Cannot assign multiple rules for owner");
+            _ownerOverrides.put(ownerId, authorizer);
+            return this;
+        }
+
+        public Builder withDefaultAuthorizer(DatabusAuthorizer defaultAuthorizer) {
+            checkArgument(_defaultAuthorizer == null, "Cannot assign multiple default authorizers");
+            _defaultAuthorizer = defaultAuthorizer;
+            return this;
+        }
+
+        public FilteredDatabusAuthorizer build() {
+            if (_defaultAuthorizer == null) {
+                // Unless specified the default behavior is to deny all access to subscriptions and tables
+                // not explicitly permitted.
+                _defaultAuthorizer = ConstantDatabusAuthorizer.DENY_ALL;
+            }
+            return new FilteredDatabusAuthorizer(_ownerOverrides, _defaultAuthorizer);
+        }
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/auth/SystemProcessDatabusAuthorizer.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/auth/SystemProcessDatabusAuthorizer.java
@@ -1,0 +1,44 @@
+package com.bazaarvoice.emodb.databus.auth;
+
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * {@link DatabusAuthorizer} for system processes, such as the canary and databus replay.
+ */
+public class SystemProcessDatabusAuthorizer implements DatabusAuthorizer {
+
+    private final Logger _log = LoggerFactory.getLogger(getClass());
+
+    private final String _systemOwnerId;
+
+    private final DatabusAuthorizerByOwner _processAuthorizer = new DatabusAuthorizerByOwner() {
+        @Override
+        public boolean canAccessSubscription(OwnedSubscription subscription) {
+            // System should only access its own subscriptions
+            return _systemOwnerId.equals(subscription.getOwnerId());
+        }
+
+        @Override
+        public boolean canReceiveEventsFromTable(String table) {
+            // System needs to be able to poll on updates to all tables
+            return true;
+        }
+    };
+
+    public SystemProcessDatabusAuthorizer(String systemOwnerId) {
+        _systemOwnerId = checkNotNull(systemOwnerId, "systemOwnerId");
+    }
+
+    @Override
+    public DatabusAuthorizerByOwner owner(String ownerId) {
+        if (_systemOwnerId.equals(ownerId)) {
+            return _processAuthorizer;
+        }
+        _log.warn("Non-system owner attempted authorization from system authorizer: {}", ownerId);
+        return ConstantDatabusAuthorizer.DENY_ALL.owner(ownerId);
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/CanaryManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/CanaryManager.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.bazaarvoice.emodb.databus.SystemInternalId;
 import com.bazaarvoice.emodb.databus.ChannelNames;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.event.owner.OstrichOwnerFactory;
@@ -37,7 +38,8 @@ public class CanaryManager {
     public CanaryManager(final LifeCycleRegistry lifeCycle,
                          @DatabusClusterInfo Collection<ClusterInfo> clusterInfo,
                          Placements placements,
-                         final Databus databus,
+                         final DatabusFactory databusFactory,
+                         final @SystemInternalId String systemInternalId,
                          final RateLimitedLogFactory logFactory,
                          OstrichOwnerGroupFactory ownerGroupFactory,
                          final MetricRegistry metricRegistry) {
@@ -84,6 +86,7 @@ public class CanaryManager {
             public Service create(String clusterName) {
                 ClusterInfo cluster = checkNotNull(clusterInfoMap.get(clusterName), clusterName);
                 Condition condition = checkNotNull(clusterToConditionMap.get(clusterName), clusterName);
+                Databus databus = databusFactory.forOwner(systemInternalId);
                 return new Canary(cluster, condition, databus, logFactory, metricRegistry);
             }
         }, null);

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusFactory.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusFactory.java
@@ -1,0 +1,147 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import com.bazaarvoice.emodb.databus.api.Databus;
+import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.Subscription;
+import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
+import com.bazaarvoice.emodb.sor.condition.Condition;
+import org.joda.time.Duration;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * When used internally within the EmoDB server databus operations require the context of the owner which is making each
+ * databus request as provided by {@link OwnerAwareDatabus}.  However, it is inconvenient to use nominally
+ * different interfaces throughout the system and to require passing around an owner ID throughout the stack in order
+ * to use OwnerAwareDatabus.
+ *
+ * The purpose of DatabusFactory is to provide a proxy for providing {@link Databus} interface access to the
+ * OwnerAwareDatabus based on the owner ID passed to {@link #forOwner(String)}.
+ */
+public class DatabusFactory {
+
+    private final OwnerAwareDatabus _ownerAwareDatabus;
+
+    @Inject
+    public DatabusFactory(OwnerAwareDatabus ownerAwareDatabus) {
+        _ownerAwareDatabus = ownerAwareDatabus;
+    }
+
+    public Databus forOwner(final String ownerId) {
+        checkNotNull(ownerId, "ownerId");
+
+        /**
+         * Proxy class for Databus that simply inserts the owner ID where appropriate.
+         */
+        return new Databus() {
+            @Override
+            public Iterator<Subscription> listSubscriptions(@Nullable String fromSubscriptionExclusive, long limit) {
+                return _ownerAwareDatabus.listSubscriptions(ownerId, fromSubscriptionExclusive, limit);
+            }
+
+            @Override
+            public void subscribe(String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl) {
+                _ownerAwareDatabus.subscribe(ownerId, subscription, tableFilter, subscriptionTtl, eventTtl);
+            }
+
+            @Override
+            public void subscribe(String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl, boolean ignoreSuppressedEvents) {
+                _ownerAwareDatabus.subscribe(ownerId, subscription, tableFilter, subscriptionTtl, eventTtl, ignoreSuppressedEvents);
+            }
+
+            @Override
+            public void unsubscribe(String subscription) {
+                _ownerAwareDatabus.unsubscribe(ownerId, subscription);
+            }
+
+            @Override
+            public Subscription getSubscription(String subscription) throws UnknownSubscriptionException {
+                return _ownerAwareDatabus.getSubscription(ownerId, subscription);
+            }
+
+            @Override
+            public long getEventCount(String subscription) {
+                return _ownerAwareDatabus.getEventCount(ownerId, subscription);
+            }
+
+            @Override
+            public long getEventCountUpTo(String subscription, long limit) {
+                return _ownerAwareDatabus.getEventCountUpTo(ownerId, subscription, limit);
+            }
+
+            @Override
+            public long getClaimCount(String subscription) {
+                return _ownerAwareDatabus.getClaimCount(ownerId, subscription);
+            }
+
+            @Override
+            public List<Event> peek(String subscription, int limit) {
+                return _ownerAwareDatabus.peek(ownerId, subscription, limit);
+            }
+
+            @Override
+            public List<Event> poll(String subscription, Duration claimTtl, int limit) {
+                return _ownerAwareDatabus.poll(ownerId, subscription, claimTtl, limit);
+            }
+
+            @Override
+            public void renew(String subscription, Collection<String> eventKeys, Duration claimTtl) {
+                _ownerAwareDatabus.renew(ownerId, subscription, eventKeys, claimTtl);
+            }
+
+            @Override
+            public void acknowledge(String subscription, Collection<String> eventKeys) {
+                _ownerAwareDatabus.acknowledge(ownerId, subscription, eventKeys);
+            }
+
+            @Override
+            public String replayAsync(String subscription) {
+                return _ownerAwareDatabus.replayAsync(ownerId, subscription);
+            }
+
+            @Override
+            public String replayAsyncSince(String subscription, Date since) {
+                return _ownerAwareDatabus.replayAsyncSince(ownerId, subscription, since);
+            }
+
+            @Override
+            public ReplaySubscriptionStatus getReplayStatus(String reference) {
+                return _ownerAwareDatabus.getReplayStatus(ownerId, reference);
+            }
+
+            @Override
+            public String moveAsync(String from, String to) {
+                return _ownerAwareDatabus.moveAsync(ownerId, from, to);
+            }
+
+            @Override
+            public MoveSubscriptionStatus getMoveStatus(String reference) {
+                return _ownerAwareDatabus.getMoveStatus(ownerId, reference);
+            }
+
+            @Override
+            public void injectEvent(String subscription, String table, String key) {
+                _ownerAwareDatabus.injectEvent(ownerId, subscription, table, key);
+            }
+
+            @Override
+            public void unclaimAll(String subscription) {
+                _ownerAwareDatabus.unclaimAll(ownerId, subscription);
+            }
+
+            @Override
+            public void purge(String subscription) {
+                _ownerAwareDatabus.purge(ownerId, subscription);
+            }
+        };
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -5,16 +5,19 @@ import com.bazaarvoice.emodb.common.dropwizard.time.ClockTicker;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.databus.ChannelNames;
 import com.bazaarvoice.emodb.databus.DefaultJoinFilter;
-import com.bazaarvoice.emodb.databus.api.Databus;
+import com.bazaarvoice.emodb.databus.SystemInternalId;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Names;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
+import com.bazaarvoice.emodb.databus.api.UnauthorizedSubscriptionException;
 import com.bazaarvoice.emodb.databus.api.UnknownMoveException;
 import com.bazaarvoice.emodb.databus.api.UnknownReplayException;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
+import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.event.api.EventData;
 import com.bazaarvoice.emodb.event.api.EventSink;
 import com.bazaarvoice.emodb.event.core.SizeCacheKey;
@@ -75,7 +78,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-public class DefaultDatabus implements Databus, Managed {
+public class DefaultDatabus implements OwnerAwareDatabus, Managed {
     /** How long should poll loop, searching for events before giving up and returning. */
     private static final Duration MAX_POLL_TIME = Duration.millis(100);
 
@@ -94,6 +97,8 @@ public class DefaultDatabus implements Databus, Managed {
     private final DataProvider _dataProvider;
     private final SubscriptionEvaluator _subscriptionEvaluator;
     private final JobService _jobService;
+    private final DatabusAuthorizer _databusAuthorizer;
+    private final String _systemOwnerId;
     private final Meter _peekedMeter;
     private final Meter _polledMeter;
     private final Meter _renewedMeter;
@@ -103,6 +108,7 @@ public class DefaultDatabus implements Databus, Managed {
     private final Meter _redundantMeter;
     private final Meter _discardedMeter;
     private final Meter _consolidatedMeter;
+    private final Meter _unownedSubscriptionMeter;
     private final LoadingCache<SizeCacheKey, Map.Entry<Long, Long>> _eventSizeCache;
     private final Supplier<Condition> _defaultJoinFilterCondition;
     private final Ticker _ticker;
@@ -112,14 +118,18 @@ public class DefaultDatabus implements Databus, Managed {
     public DefaultDatabus(LifeCycleRegistry lifeCycle, EventBus eventBus, DataProvider dataProvider,
                           SubscriptionDAO subscriptionDao, DatabusEventStore eventStore,
                           SubscriptionEvaluator subscriptionEvaluator, JobService jobService,
-                          JobHandlerRegistry jobHandlerRegistry, MetricRegistry metricRegistry,
-                          @DefaultJoinFilter Supplier<Condition> defaultJoinFilterCondition, Clock clock) {
+                          JobHandlerRegistry jobHandlerRegistry, DatabusAuthorizer databusAuthorizer,
+                          @SystemInternalId String systemOwnerId,
+                          @DefaultJoinFilter Supplier<Condition> defaultJoinFilterCondition,
+                          MetricRegistry metricRegistry, Clock clock) {
         _eventBus = eventBus;
         _subscriptionDao = subscriptionDao;
         _eventStore = eventStore;
         _dataProvider = dataProvider;
         _subscriptionEvaluator = subscriptionEvaluator;
         _jobService = jobService;
+        _databusAuthorizer = databusAuthorizer;
+        _systemOwnerId = systemOwnerId;
         _defaultJoinFilterCondition = defaultJoinFilterCondition;
         _ticker = ClockTicker.getTicker(clock);
         _clock = clock;
@@ -132,6 +142,7 @@ public class DefaultDatabus implements Databus, Managed {
         _redundantMeter = newEventMeter("redundant", metricRegistry);
         _discardedMeter = newEventMeter("discarded", metricRegistry);
         _consolidatedMeter = newEventMeter("consolidated", metricRegistry);
+        _unownedSubscriptionMeter = newEventMeter("unowned", metricRegistry);
         _eventSizeCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(15, TimeUnit.SECONDS)
                 .maximumSize(2000)
@@ -161,6 +172,10 @@ public class DefaultDatabus implements Databus, Managed {
                             public MoveSubscriptionResult run(MoveSubscriptionRequest request)
                                     throws Exception {
                                 try {
+                                    // Last chance to verify the subscriptions' owner before doing anything mutative
+                                    checkSubscriptionOwner(request.getOwnerId(), request.getFrom());
+                                    checkSubscriptionOwner(request.getOwnerId(), request.getTo());
+
                                     _eventStore.move(request.getFrom(), request.getTo());
                                 } catch (ReadOnlyQueueException e) {
                                     // The from queue is not owned by this server.
@@ -184,6 +199,9 @@ public class DefaultDatabus implements Databus, Managed {
                             public ReplaySubscriptionResult run(ReplaySubscriptionRequest request)
                                     throws Exception {
                                 try {
+                                    // Last chance to verify the subscription's owner before doing anything mutative
+                                    checkSubscriptionOwner(request.getOwnerId(), request.getSubscription());
+
                                     replay(request.getSubscription(), request.getSince());
                                 } catch (ReadOnlyQueueException e) {
                                     // The subscription is not owned by this server.
@@ -207,7 +225,7 @@ public class DefaultDatabus implements Databus, Managed {
 
     private void createDatabusReplaySubscription() {
         // Create a master databus replay subscription where the events expire every 50 hours (2 days + 2 hours)
-        subscribe(ChannelNames.getMasterReplayChannel(), Conditions.alwaysTrue(),
+        subscribe(_systemOwnerId, ChannelNames.getMasterReplayChannel(), Conditions.alwaysTrue(),
                 Duration.standardDays(3650), DatabusChannelConfiguration.REPLAY_TTL, false);
     }
 
@@ -232,23 +250,23 @@ public class DefaultDatabus implements Databus, Managed {
     }
 
     @Override
-    public Iterator<Subscription> listSubscriptions(@Nullable String fromSubscriptionExclusive, long limit) {
+    public Iterator<Subscription> listSubscriptions(final String ownerId, @Nullable String fromSubscriptionExclusive, long limit) {
         checkArgument(limit > 0, "Limit must be >0");
 
         // We always have all the subscriptions cached in memory so fetch them all.
-        Collection<Subscription> subscriptions = _subscriptionDao.getAllSubscriptions();
+        Collection<OwnedSubscription> subscriptions = _subscriptionDao.getAllSubscriptions();
 
-        // Ignore internal subscriptions (eg. "__system_bus:canary").
-        subscriptions = Collections2.filter(subscriptions, new Predicate<Subscription>() {
+        // Ignore subscriptions not accessible by the owner.
+        subscriptions = Collections2.filter(subscriptions, new Predicate<OwnedSubscription>() {
             @Override
-            public boolean apply(Subscription subscription) {
-                return !subscription.getName().startsWith("__");
+            public boolean apply(OwnedSubscription subscription) {
+                return _databusAuthorizer.owner(ownerId).canAccessSubscription(subscription);
             }
         });
 
         // Sort them by name.  They're stored sorted in Cassandra so this should be a no-op, but
         // do the sort anyway so we're not depending on internals of the subscription DAO.
-        List<Subscription> sorted = new Ordering<Subscription>() {
+        List<? extends Subscription> sorted = new Ordering<Subscription>() {
             @Override
             public int compare(Subscription left, Subscription right) {
                 return left.getName().compareTo(right.getName());
@@ -271,23 +289,26 @@ public class DefaultDatabus implements Databus, Managed {
             sorted = sorted.subList(0, (int) limit);
         }
 
-        return sorted.iterator();
+        //noinspection unchecked
+        return (Iterator<Subscription>) sorted.iterator();
     }
 
     @Override
-    public void subscribe(String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl) {
-        subscribe(subscription, tableFilter, subscriptionTtl, eventTtl, true);
+    public void subscribe(String ownerId, String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl) {
+        subscribe(ownerId, subscription, tableFilter, subscriptionTtl, eventTtl, true);
     }
 
     @Override
-    public void subscribe(String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl,
-                          boolean includeDefaultJoinFilter) {
-        // This call should be depracated soon.
+    public void subscribe(String ownerId, String subscription, Condition tableFilter, Duration subscriptionTtl,
+                          Duration eventTtl, boolean includeDefaultJoinFilter) {
+        // This call should be deprecated soon.
         checkLegalSubscriptionName(subscription);
+        checkSubscriptionOwner(ownerId, subscription);
         checkNotNull(tableFilter, "tableFilter");
         checkArgument(subscriptionTtl.isLongerThan(Duration.ZERO), "SubscriptionTtl must be >0");
         checkArgument(eventTtl.isLongerThan(Duration.ZERO), "EventTtl must be >0");
         TableFilterValidator.checkAllowed(tableFilter);
+
         if (includeDefaultJoinFilter) {
             // If the default join filter condition is set (that is, isn't "alwaysTrue()") then add it to the filter
             Condition defaultJoinFilterCondition = _defaultJoinFilterCondition.get();
@@ -303,22 +324,30 @@ public class DefaultDatabus implements Databus, Managed {
         // except for resetting the ttl, recreating a subscription that already exists has no effect.
         // assume that multiple servers that manage the same subscriptions can each attempt to create
         // the subscription at startup.
-        _subscriptionDao.insertSubscription(subscription, tableFilter, subscriptionTtl, eventTtl);
+        _subscriptionDao.insertSubscription(ownerId, subscription, tableFilter, subscriptionTtl, eventTtl);
     }
 
     @Override
-    public void unsubscribe(String subscription) {
+    public void unsubscribe(String ownerId, String subscription) {
         checkLegalSubscriptionName(subscription);
+        checkSubscriptionOwner(ownerId, subscription);
 
         _subscriptionDao.deleteSubscription(subscription);
         _eventStore.purge(subscription);
     }
 
     @Override
-    public Subscription getSubscription(String name) throws UnknownSubscriptionException {
+    public Subscription getSubscription(String ownerId, String name) throws UnknownSubscriptionException {
         checkLegalSubscriptionName(name);
 
-        Subscription subscription = _subscriptionDao.getSubscription(name);
+        OwnedSubscription subscription = getSubscriptionByName(name);
+        checkSubscriptionOwner(ownerId, subscription);
+
+        return subscription;
+    }
+
+    private OwnedSubscription getSubscriptionByName(String name) {
+        OwnedSubscription subscription = _subscriptionDao.getSubscription(name);
         if (subscription == null) {
             throw new UnknownSubscriptionException(name);
         }
@@ -335,12 +364,14 @@ public class DefaultDatabus implements Databus, Managed {
     }
 
     @Override
-    public long getEventCount(String subscription) {
-        return getEventCountUpTo(subscription, Long.MAX_VALUE);
+    public long getEventCount(String ownerId, String subscription) {
+        return getEventCountUpTo(ownerId, subscription, Long.MAX_VALUE);
     }
 
     @Override
-    public long getEventCountUpTo(String subscription, long limit) {
+    public long getEventCountUpTo(String ownerId, String subscription, long limit) {
+        checkSubscriptionOwner(ownerId, subscription);
+
         // We get the size from cache as a tuple of size, and the limit used to estimate that size
         // So, the key is the size, and value is the limit used to estimate the size
         SizeCacheKey sizeCacheKey = new SizeCacheKey(subscription, limit);
@@ -361,16 +392,18 @@ public class DefaultDatabus implements Databus, Managed {
     }
 
     @Override
-    public long getClaimCount(String subscription) {
+    public long getClaimCount(String ownerId, String subscription) {
         checkLegalSubscriptionName(subscription);
+        checkSubscriptionOwner(ownerId, subscription);
 
         return _eventStore.getClaimCount(subscription);
     }
 
     @Override
-    public List<Event> peek(final String subscription, int limit) {
+    public List<Event> peek(String ownerId, final String subscription, int limit) {
         checkLegalSubscriptionName(subscription);
         checkArgument(limit > 0, "Limit must be >0");
+        checkSubscriptionOwner(ownerId, subscription);
 
         List<Event> events = peekOrPoll(subscription, null, limit);
         _peekedMeter.mark(events.size());
@@ -378,10 +411,11 @@ public class DefaultDatabus implements Databus, Managed {
     }
 
     @Override
-    public List<Event> poll(final String subscription, final Duration claimTtl, int limit) {
+    public List<Event> poll(String ownerId, final String subscription, final Duration claimTtl, int limit) {
         checkLegalSubscriptionName(subscription);
         checkArgument(claimTtl.getMillis() >= 0, "ClaimTtl must be >=0");
         checkArgument(limit > 0, "Limit must be >0");
+        checkSubscriptionOwner(ownerId, subscription);
 
         List<Event> events = peekOrPoll(subscription, claimTtl, limit);
         _polledMeter.mark(events.size());
@@ -541,36 +575,39 @@ public class DefaultDatabus implements Databus, Managed {
     }
 
     @Override
-    public void renew(String subscription, Collection<String> eventKeys, Duration claimTtl) {
+    public void renew(String ownerId, String subscription, Collection<String> eventKeys, Duration claimTtl) {
         checkLegalSubscriptionName(subscription);
         checkNotNull(eventKeys, "eventKeys");
         checkArgument(claimTtl.getMillis() >= 0, "ClaimTtl must be >=0");
+        checkSubscriptionOwner(ownerId, subscription);
 
         _eventStore.renew(subscription, EventKeyFormat.decodeAll(eventKeys), claimTtl, true);
         _renewedMeter.mark(eventKeys.size());
     }
 
     @Override
-    public void acknowledge(String subscription, Collection<String> eventKeys) {
+    public void acknowledge(String ownerId, String subscription, Collection<String> eventKeys) {
         checkLegalSubscriptionName(subscription);
         checkNotNull(eventKeys, "eventKeys");
+        checkSubscriptionOwner(ownerId, subscription);
 
         _eventStore.delete(subscription, EventKeyFormat.decodeAll(eventKeys), true);
         _ackedMeter.mark(eventKeys.size());
     }
 
     @Override
-    public String replayAsync(String subscription) {
-        return replayAsyncSince(subscription, null);
+    public String replayAsync(String ownerId, String subscription) {
+        return replayAsyncSince(ownerId, subscription, null);
     }
 
     @Override
-    public String replayAsyncSince(String subscription, Date since) {
+    public String replayAsyncSince(String ownerId, String subscription, Date since) {
         checkLegalSubscriptionName(subscription);
+        checkSubscriptionOwner(ownerId, subscription);
 
         JobIdentifier<ReplaySubscriptionRequest, ReplaySubscriptionResult> jobId =
                 _jobService.submitJob(
-                        new JobRequest<>(ReplaySubscriptionJob.INSTANCE, new ReplaySubscriptionRequest(subscription, since)));
+                        new JobRequest<>(ReplaySubscriptionJob.INSTANCE, new ReplaySubscriptionRequest(ownerId, subscription, since)));
 
         return jobId.toString();
     }
@@ -580,18 +617,25 @@ public class DefaultDatabus implements Databus, Managed {
         checkState(since == null || new DateTime(since).plus(DatabusChannelConfiguration.REPLAY_TTL).isAfterNow(),
                 "Since timestamp is outside the replay TTL.");
         String source = ChannelNames.getMasterReplayChannel();
-        final Subscription destination = getSubscription(subscription);
+        final OwnedSubscription destination = getSubscriptionByName(subscription);
+        final DatabusAuthorizer.DatabusAuthorizerByOwner authorizer = _databusAuthorizer.owner(destination.getOwnerId());
 
         _eventStore.copy(source, subscription, new Predicate<ByteBuffer>() {
             @Override
-            public boolean apply(ByteBuffer eventData) {
-                return _subscriptionEvaluator.matches(destination, eventData);
+            public boolean apply(ByteBuffer eventDataBytes) {
+                try {
+                    SubscriptionEvaluator.MatchEventData eventData = _subscriptionEvaluator.getMatchEventData(eventDataBytes);
+                    return _subscriptionEvaluator.matches(destination, eventData)
+                            && authorizer.canReceiveEventsFromTable(eventData.getTable().getName());
+                } catch (UnknownTableException e) {
+                    return false;
+                }
             }
         }, since);
     }
 
     @Override
-    public ReplaySubscriptionStatus getReplayStatus(String reference) {
+    public ReplaySubscriptionStatus getReplayStatus(String ownerId, String reference) {
         checkNotNull(reference, "reference");
 
         JobIdentifier<ReplaySubscriptionRequest, ReplaySubscriptionResult> jobId;
@@ -613,6 +657,8 @@ public class DefaultDatabus implements Databus, Managed {
             throw new IllegalStateException("Replay request details not found: " + jobId);
         }
 
+        checkSubscriptionOwner(ownerId, request.getSubscription());
+
         switch (status.getStatus()) {
             case FINISHED:
                 return new ReplaySubscriptionStatus(request.getSubscription(), ReplaySubscriptionStatus.Status.COMPLETE);
@@ -626,18 +672,21 @@ public class DefaultDatabus implements Databus, Managed {
     }
 
     @Override
-    public String moveAsync(String from, String to) {
+    public String moveAsync(String ownerId, String from, String to) {
         checkLegalSubscriptionName(from);
         checkLegalSubscriptionName(to);
+        checkSubscriptionOwner(ownerId, from);
+        checkSubscriptionOwner(ownerId, to);
 
         JobIdentifier<MoveSubscriptionRequest, MoveSubscriptionResult> jobId =
-                _jobService.submitJob(new JobRequest<>(MoveSubscriptionJob.INSTANCE, new MoveSubscriptionRequest(from, to)));
+                _jobService.submitJob(new JobRequest<>(
+                        MoveSubscriptionJob.INSTANCE, new MoveSubscriptionRequest(ownerId, from, to)));
 
         return jobId.toString();
     }
 
     @Override
-    public MoveSubscriptionStatus getMoveStatus(String reference) {
+    public MoveSubscriptionStatus getMoveStatus(String ownerId, String reference) {
         checkNotNull(reference, "reference");
 
         JobIdentifier<MoveSubscriptionRequest, MoveSubscriptionResult> jobId;
@@ -659,6 +708,8 @@ public class DefaultDatabus implements Databus, Managed {
             throw new IllegalStateException("Move request details not found: " + jobId);
         }
 
+        checkSubscriptionOwner(ownerId, request.getFrom());
+
         switch (status.getStatus()) {
             case FINISHED:
                 return new MoveSubscriptionStatus(request.getFrom(), request.getTo(), MoveSubscriptionStatus.Status.COMPLETE);
@@ -672,23 +723,26 @@ public class DefaultDatabus implements Databus, Managed {
     }
 
     @Override
-    public void injectEvent(String subscription, String table, String key) {
+    public void injectEvent(String ownerId, String subscription, String table, String key) {
         // Pick a changeId UUID that's guaranteed to be older than the compaction cutoff so poll()'s calls to
         // AnnotatedContent.isChangeDeltaPending() and isChangeDeltaRedundant() will always return false.
+        checkSubscriptionOwner(ownerId, subscription);
         UpdateRef ref = new UpdateRef(table, key, TimeUUIDs.minimumUuid(), ImmutableSet.<String>of());
         _eventStore.add(subscription, UpdateRefSerializer.toByteBuffer(ref));
     }
 
     @Override
-    public void unclaimAll(String subscription) {
+    public void unclaimAll(String ownerId, String subscription) {
         checkLegalSubscriptionName(subscription);
+        checkSubscriptionOwner(ownerId, subscription);
 
         _eventStore.unclaimAll(subscription);
     }
 
     @Override
-    public void purge(String subscription) {
+    public void purge(String ownerId, String subscription) {
         checkLegalSubscriptionName(subscription);
+        checkSubscriptionOwner(ownerId, subscription);
 
         _eventStore.purge(subscription);
     }
@@ -698,6 +752,25 @@ public class DefaultDatabus implements Databus, Managed {
                 "Subscription name must be a lowercase ASCII string between 1 and 255 characters in length. " +
                         "Allowed punctuation characters are -.:@_ and the subscription name may not start with a single underscore character. " +
                         "An example of a valid subscription name would be 'polloi:review'.");
+    }
+
+    private void checkSubscriptionOwner(String ownerId, String subscription) {
+        // Verify the subscription either doesn't exist or is already owned by the same owner.  In practice this is
+        // predominantly cached by SubscriptionDAO so performance should be good.
+        checkSubscriptionOwner(ownerId, _subscriptionDao.getSubscription(subscription));
+    }
+
+    private void checkSubscriptionOwner(String ownerId, OwnedSubscription subscription) {
+        checkNotNull(ownerId, "ownerId");
+        if (subscription != null) {
+            // Grandfather-in subscriptions created before ownership was introduced.  This should be a temporary issue
+            // since the subscriptions will need to renew at some point or expire.
+            if (subscription.getOwnerId() == null) {
+                _unownedSubscriptionMeter.mark();
+            } else if (!_databusAuthorizer.owner(ownerId).canAccessSubscription(subscription)) {
+                throw new UnauthorizedSubscriptionException("Not subscriber", subscription.getName());
+            }
+        }
     }
 
     /** EventStore sink that doesn't count adjacent events for the same table/key against the peek/poll limit. */

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
@@ -6,7 +6,6 @@ import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
 import com.bazaarvoice.emodb.databus.ChannelNames;
 import com.bazaarvoice.emodb.databus.DatabusZooKeeper;
-import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
 import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.databus.repl.ReplicationEventSource;
@@ -44,19 +43,16 @@ public class DefaultFanoutManager implements FanoutManager {
     private final LeaderServiceTask _dropwizardTask;
     private final RateLimitedLogFactory _logFactory;
     private final SubscriptionEvaluator _subscriptionEvaluator;
-    private final DatabusAuthorizer _databusAuthorizer;
     private final MetricRegistry _metricRegistry;
 
     @Inject
     public DefaultFanoutManager(final EventStore eventStore, final SubscriptionDAO subscriptionDao,
-                                SubscriptionEvaluator subscriptionEvaluator,
-                                DatabusAuthorizer databusAuthorizer, DataCenters dataCenters,
+                                SubscriptionEvaluator subscriptionEvaluator, DataCenters dataCenters,
                                 @DatabusZooKeeper CuratorFramework curator, @SelfHostAndPort HostAndPort self,
                                 LeaderServiceTask dropwizardTask, RateLimitedLogFactory logFactory, MetricRegistry metricRegistry) {
         _eventStore = checkNotNull(eventStore, "eventStore");
         _subscriptionDao = checkNotNull(subscriptionDao, "subscriptionDao");
         _subscriptionEvaluator = checkNotNull(subscriptionEvaluator, "subscriptionEvaluator");
-        _databusAuthorizer = checkNotNull(databusAuthorizer, "databusAuthorizer");
         _dataCenters = checkNotNull(dataCenters, "dataCenters");
         _curator = checkNotNull(curator, "curator");
         _selfId = checkNotNull(self, "self").toString();
@@ -101,7 +97,7 @@ public class DefaultFanoutManager implements FanoutManager {
                     public Service get() {
                         return new DefaultFanout(name, eventSource, eventSink, replicateOutbound, sleepWhenIdle,
                                 subscriptionsSupplier, _dataCenters.getSelf(), _logFactory, _subscriptionEvaluator,
-                                _databusAuthorizer, _metricRegistry);
+                                _metricRegistry);
                     }
                 });
         ServiceFailureListener.listenTo(leaderService, _metricRegistry);

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
@@ -6,8 +6,9 @@ import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
 import com.bazaarvoice.emodb.databus.ChannelNames;
 import com.bazaarvoice.emodb.databus.DatabusZooKeeper;
-import com.bazaarvoice.emodb.databus.api.Subscription;
+import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.databus.repl.ReplicationEventSource;
 import com.bazaarvoice.emodb.databus.repl.ReplicationSource;
 import com.bazaarvoice.emodb.datacenter.api.DataCenter;
@@ -43,16 +44,19 @@ public class DefaultFanoutManager implements FanoutManager {
     private final LeaderServiceTask _dropwizardTask;
     private final RateLimitedLogFactory _logFactory;
     private final SubscriptionEvaluator _subscriptionEvaluator;
+    private final DatabusAuthorizer _databusAuthorizer;
     private final MetricRegistry _metricRegistry;
 
     @Inject
     public DefaultFanoutManager(final EventStore eventStore, final SubscriptionDAO subscriptionDao,
-                                SubscriptionEvaluator subscriptionEvaluator, DataCenters dataCenters,
+                                SubscriptionEvaluator subscriptionEvaluator,
+                                DatabusAuthorizer databusAuthorizer, DataCenters dataCenters,
                                 @DatabusZooKeeper CuratorFramework curator, @SelfHostAndPort HostAndPort self,
                                 LeaderServiceTask dropwizardTask, RateLimitedLogFactory logFactory, MetricRegistry metricRegistry) {
         _eventStore = checkNotNull(eventStore, "eventStore");
         _subscriptionDao = checkNotNull(subscriptionDao, "subscriptionDao");
-        _subscriptionEvaluator = subscriptionEvaluator;
+        _subscriptionEvaluator = checkNotNull(subscriptionEvaluator, "subscriptionEvaluator");
+        _databusAuthorizer = checkNotNull(databusAuthorizer, "databusAuthorizer");
         _dataCenters = checkNotNull(dataCenters, "dataCenters");
         _curator = checkNotNull(curator, "curator");
         _selfId = checkNotNull(self, "self").toString();
@@ -83,9 +87,9 @@ public class DefaultFanoutManager implements FanoutManager {
                 return null;
             }
         };
-        final Supplier<Collection<Subscription>> subscriptionsSupplier = new Supplier<Collection<Subscription>>() {
+        final Supplier<Collection<OwnedSubscription>> subscriptionsSupplier = new Supplier<Collection<OwnedSubscription>>() {
             @Override
-            public Collection<Subscription> get() {
+            public Collection<OwnedSubscription> get() {
                 return _subscriptionDao.getAllSubscriptions();
             }
         };
@@ -96,7 +100,8 @@ public class DefaultFanoutManager implements FanoutManager {
                     @Override
                     public Service get() {
                         return new DefaultFanout(name, eventSource, eventSink, replicateOutbound, sleepWhenIdle,
-                                subscriptionsSupplier, _dataCenters.getSelf(), _logFactory, _subscriptionEvaluator, _metricRegistry);
+                                subscriptionsSupplier, _dataCenters.getSelf(), _logFactory, _subscriptionEvaluator,
+                                _databusAuthorizer, _metricRegistry);
                     }
                 });
         ServiceFailureListener.listenTo(leaderService, _metricRegistry);

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/MoveSubscriptionRequest.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/MoveSubscriptionRequest.java
@@ -7,13 +7,21 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class MoveSubscriptionRequest {
 
+    private final String _ownerId;
     private final String _from;
     private final String _to;
 
     @JsonCreator
-    public MoveSubscriptionRequest(@JsonProperty ("from") String from, @JsonProperty ("to") String to) {
+    public MoveSubscriptionRequest(@JsonProperty ("ownerId") String ownerId,
+                                   @JsonProperty ("from") String from,
+                                   @JsonProperty ("to") String to) {
+        _ownerId = checkNotNull(ownerId, "ownerId");
         _from = checkNotNull(from, "from");
         _to = checkNotNull(to, "to");
+    }
+
+    public String getOwnerId() {
+        return _ownerId;
     }
 
     public String getFrom() {

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OwnerAwareDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OwnerAwareDatabus.java
@@ -1,0 +1,85 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.Subscription;
+import com.bazaarvoice.emodb.databus.api.UnauthorizedSubscriptionException;
+import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
+import com.bazaarvoice.emodb.sor.condition.Condition;
+import org.joda.time.Duration;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Parallel interface for {@link com.bazaarvoice.emodb.databus.api.Databus} that includes the owner's internal ID
+ * with each request.  This class is intended for internal use only and should not be exposed outside the databus
+ * module.  External systems that require a databus connection should get one using
+ * {@link DatabusFactory#forOwner(String)}.
+ */
+public interface OwnerAwareDatabus {
+
+    Iterator<Subscription> listSubscriptions(String ownerId, @Nullable String fromSubscriptionExclusive, long limit);
+
+    void subscribe(String ownerId, String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl)
+        throws UnauthorizedSubscriptionException;
+
+    @Deprecated
+    void subscribe(String ownerId, String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl, boolean ignoreSuppressedEvents)
+        throws UnauthorizedSubscriptionException;
+
+    void unsubscribe(String ownerId, String subscription)
+        throws UnauthorizedSubscriptionException;
+
+    Subscription getSubscription(String ownerId, String subscription)
+            throws UnknownSubscriptionException, UnauthorizedSubscriptionException;
+
+    long getEventCount(String ownerId, String subscription)
+        throws UnauthorizedSubscriptionException;
+
+    long getEventCountUpTo(String ownerId, String subscription, long limit)
+        throws UnauthorizedSubscriptionException;
+
+    long getClaimCount(String ownerId, String subscription)
+        throws UnauthorizedSubscriptionException;
+
+    List<Event> peek(String ownerId, String subscription, int limit)
+        throws UnauthorizedSubscriptionException;
+
+    List<Event> poll(String ownerId, String subscription, Duration claimTtl, int limit)
+        throws UnauthorizedSubscriptionException;
+
+    void renew(String ownerId, String subscription, Collection<String> eventKeys, Duration claimTtl)
+        throws UnauthorizedSubscriptionException;
+
+    void acknowledge(String ownerId, String subscription, Collection<String> eventKeys)
+        throws UnauthorizedSubscriptionException;
+
+    String replayAsync(String ownerId, String subscription)
+        throws UnauthorizedSubscriptionException;
+
+    String replayAsyncSince(String ownerId, String subscription, Date since)
+        throws UnauthorizedSubscriptionException;
+
+    ReplaySubscriptionStatus getReplayStatus(String ownerId, String reference)
+        throws UnauthorizedSubscriptionException;
+
+    String moveAsync(String ownerId, String from, String to)
+        throws UnauthorizedSubscriptionException;
+
+    MoveSubscriptionStatus getMoveStatus(String ownerId, String reference)
+        throws UnauthorizedSubscriptionException;
+
+    void injectEvent(String ownerId, String subscription, String table, String key)
+        throws UnauthorizedSubscriptionException;
+
+    void unclaimAll(String ownerId, String subscription)
+        throws UnauthorizedSubscriptionException;
+
+    void purge(String ownerId, String subscription)
+        throws UnauthorizedSubscriptionException;
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/ReplaySubscriptionRequest.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/ReplaySubscriptionRequest.java
@@ -14,17 +14,23 @@ import static com.google.common.base.Preconditions.checkNotNull;
 @JsonIgnoreProperties (ignoreUnknown = true)
 public class ReplaySubscriptionRequest {
 
+    private String _ownerId;
     private String _subscription;
     @Nullable
     private Date _since;
 
     @JsonCreator
-    public ReplaySubscriptionRequest(@JsonProperty ("subscription") String subscription,
+    public ReplaySubscriptionRequest(@JsonProperty ("ownerId") String ownerId,
+                                     @JsonProperty ("subscription") String subscription,
                                      @JsonProperty ("since") @Nullable Date since) {
+        _ownerId = checkNotNull(ownerId, "ownerId");
         _subscription = checkNotNull(subscription, "subscription");
         _since = since;
     }
 
+    public String getOwnerId() {
+        return _ownerId;
+    }
 
     public String getSubscription() {
         return _subscription;

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
@@ -6,7 +6,8 @@ import com.bazaarvoice.emodb.sor.condition.eval.ConditionEvaluator;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.emodb.sor.core.UpdateRef;
 import com.bazaarvoice.emodb.table.db.Table;
-import com.google.common.collect.Lists;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
@@ -32,14 +33,14 @@ public class SubscriptionEvaluator {
         _rateLimitedLog = logFactory.from(_log);
     }
 
-    public Collection<Subscription> matches(Collection<Subscription> subscriptions, MatchEventData eventData) {
-        Collection<Subscription> filteredSubscriptions = Lists.newArrayList();
-        for (Subscription subscription : subscriptions) {
-            if (matches(subscription, eventData)) {
-                filteredSubscriptions.add(subscription);
-            }
-        }
-        return filteredSubscriptions;
+    public <S extends Subscription> Iterable<S> matches(Iterable<S> subscriptions, final MatchEventData eventData) {
+        return FluentIterable.from(subscriptions)
+                .filter(new Predicate<Subscription>() {
+                    @Override
+                    public boolean apply(Subscription subscription) {
+                        return matches(subscription, eventData);
+                    }
+                });
     }
 
     public boolean matches(Subscription subscription, ByteBuffer eventData) {
@@ -53,7 +54,7 @@ public class SubscriptionEvaluator {
         return matches(subscription, matchEventData);
     }
 
-    private boolean matches(Subscription subscription, MatchEventData eventData) {
+    public boolean matches(Subscription subscription, MatchEventData eventData) {
         Table table = eventData.getTable();
         try {
             Map<String, Object> json;

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/db/SubscriptionDAO.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/db/SubscriptionDAO.java
@@ -1,6 +1,6 @@
 package com.bazaarvoice.emodb.databus.db;
 
-import com.bazaarvoice.emodb.databus.api.Subscription;
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import org.joda.time.Duration;
 
@@ -9,12 +9,13 @@ import java.util.Collection;
 
 public interface SubscriptionDAO {
 
-    void insertSubscription(String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl);
+    void insertSubscription(String ownerId, String subscription, Condition tableFilter, Duration subscriptionTtl,
+                            Duration eventTtl);
 
     void deleteSubscription(String subscription);
 
     @Nullable
-    Subscription getSubscription(String subscription);
+    OwnedSubscription getSubscription(String subscription);
 
-    Collection<Subscription> getAllSubscriptions();
+    Collection<OwnedSubscription> getAllSubscriptions();
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/model/DefaultOwnedSubscription.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/model/DefaultOwnedSubscription.java
@@ -1,0 +1,59 @@
+package com.bazaarvoice.emodb.databus.model;
+
+import com.bazaarvoice.emodb.databus.api.DefaultSubscription;
+import com.bazaarvoice.emodb.databus.api.Subscription;
+import com.bazaarvoice.emodb.sor.condition.Condition;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.joda.time.Duration;
+
+import java.util.Date;
+
+/**
+ * Default implementation of {@link OwnedSubscription}.  The JSON serialized version of this class does not include
+ * any ownership information so it is safe to return to client-facing interfaces where a {@link Subscription}
+ * is expected.
+ */
+public class DefaultOwnedSubscription implements OwnedSubscription {
+    private final Subscription _subscription;
+    private final String _ownerID;
+
+    public DefaultOwnedSubscription(String name, Condition tableFilter,
+                                    Date expiresAt, Duration eventTtl,
+                                    String ownerID) {
+        _subscription = new DefaultSubscription(name, tableFilter, expiresAt, eventTtl);
+        _ownerID = ownerID;
+    }
+
+    @Override
+    public String getOwnerId() {
+        return _ownerID;
+    }
+
+    @Override
+    public String getName() {
+        return _subscription.getName();
+    }
+
+    @Override
+    public Condition getTableFilter() {
+        return _subscription.getTableFilter();
+    }
+
+    @Override
+    public Date getExpiresAt() {
+        return _subscription.getExpiresAt();
+    }
+
+    @Override
+    public Duration getEventTtl() {
+        return _subscription.getEventTtl();
+    }
+
+    /**
+     * The JSON representation should not include any ownership attributes.
+     */
+    @JsonValue
+    public Subscription getSubscription() {
+        return _subscription;
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/model/OwnedSubscription.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/model/OwnedSubscription.java
@@ -1,0 +1,12 @@
+package com.bazaarvoice.emodb.databus.model;
+
+import com.bazaarvoice.emodb.databus.api.Subscription;
+
+/**
+ * Extension of {@link Subscription} that includes ownership information not part of the public API that are required
+ * for proper maintenance and evaluation.
+ */
+public interface OwnedSubscription extends Subscription {
+
+    String getOwnerId();
+}

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
@@ -11,7 +11,8 @@ import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.SimpleLifeCycleRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
-import com.bazaarvoice.emodb.databus.api.Databus;
+import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
+import com.bazaarvoice.emodb.databus.core.DatabusFactory;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
 import com.bazaarvoice.emodb.job.api.JobService;
@@ -54,14 +55,14 @@ public class DatabusModuleTest {
     public void testWebServer() {
         Injector injector = createInjector(EmoServiceMode.STANDARD_ALL);
 
-        assertNotNull(injector.getInstance(Databus.class));
+        assertNotNull(injector.getInstance(DatabusFactory.class));
     }
 
     @Test
     public void testCliTool() {
         Injector injector = createInjector(EmoServiceMode.CLI_TOOL);
 
-        assertNotNull(injector.getInstance(Databus.class));
+        assertNotNull(injector.getInstance(DatabusFactory.class));
     }
 
     private Injector createInjector(final EmoServiceMode serviceMode) {
@@ -103,12 +104,14 @@ public class DatabusModuleTest {
                 bind(CuratorFramework.class).annotatedWith(DatabusZooKeeper.class).toInstance(curator);
                 bind(HostDiscovery.class).annotatedWith(DatabusHostDiscovery.class).toInstance(mock(HostDiscovery.class));
                 bind(String.class).annotatedWith(ReplicationKey.class).toInstance("password");
+                bind(String.class).annotatedWith(SystemInternalId.class).toInstance("system");
                 bind(new TypeLiteral<Collection<ClusterInfo>>(){}).annotatedWith(DatabusClusterInfo.class)
                         .toInstance(ImmutableList.of(new ClusterInfo("Test Cluster", "Test Metric Cluster")));
                 bind(JobService.class).toInstance(mock(JobService.class));
                 bind(JobHandlerRegistry.class).toInstance(mock(JobHandlerRegistry.class));
                 bind(new TypeLiteral<Supplier<Condition>>(){}).annotatedWith(DefaultJoinFilter.class)
                         .toInstance(Suppliers.ofInstance(Conditions.alwaysFalse()));
+                bind(DatabusAuthorizer.class).toInstance(mock(DatabusAuthorizer.class));
 
                 MetricRegistry metricRegistry = new MetricRegistry();
                 bind(MetricRegistry.class).toInstance(metricRegistry);

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
@@ -2,8 +2,9 @@ package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
-import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.auth.ConstantDatabusAuthorizer;
+import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
 import com.bazaarvoice.emodb.event.api.EventData;
 import com.bazaarvoice.emodb.event.api.EventSink;
@@ -58,9 +59,9 @@ public class ConsolidationTest {
             }
         };
         Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
-        Databus databus = newDatabus(eventStore, new TestDataProvider().add(content));
+        OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
-        List<Event> events = databus.poll("test-subscription", Duration.standardSeconds(30), 1);
+        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -87,9 +88,9 @@ public class ConsolidationTest {
             }
         };
         Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
-        Databus databus = newDatabus(eventStore, new TestDataProvider().add(content));
+        OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
-        List<Event> events = databus.poll("test-subscription", Duration.standardSeconds(30), 1);
+        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -118,9 +119,9 @@ public class ConsolidationTest {
             }
         };
         Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
-        Databus databus = newDatabus(eventStore, new TestDataProvider().add(content));
+        OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
-        List<Event> events = databus.poll("test-subscription", Duration.standardSeconds(30), 1);
+        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -152,9 +153,9 @@ public class ConsolidationTest {
             }
         };
         Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
-        Databus databus = newDatabus(eventStore, new TestDataProvider().add(content));
+        OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
-        List<Event> events = databus.poll("test-subscription", Duration.standardSeconds(30), 1);
+        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -202,7 +203,7 @@ public class ConsolidationTest {
         DefaultDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content), clock);
 
         // Use a limit of 2 to force multiple calls to the event store.
-        List<Event> events = databus.poll("test-subscription", Duration.standardSeconds(30), 2);
+        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 2);
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -227,9 +228,10 @@ public class ConsolidationTest {
         SubscriptionEvaluator subscriptionEvaluator = mock(SubscriptionEvaluator.class);
         JobService jobService = mock(JobService.class);
         JobHandlerRegistry jobHandlerRegistry = mock(JobHandlerRegistry.class);
+        DatabusAuthorizer databusAuthorizer = ConstantDatabusAuthorizer.ALLOW_ALL;
         return new DefaultDatabus(lifeCycle, eventBus, dataProvider, subscriptionDao, eventStore, subscriptionEvaluator,
-                jobService, jobHandlerRegistry, new MetricRegistry(), Suppliers.ofInstance(Conditions.alwaysFalse()),
-                clock);
+                jobService, jobHandlerRegistry,  databusAuthorizer, "replication",
+                Suppliers.ofInstance(Conditions.alwaysFalse()), new MetricRegistry(), clock);
     }
 
     private static EventData newEvent(final String id, String table, String key, UUID changeId) {

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusChannelConfigurationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusChannelConfigurationTest.java
@@ -1,9 +1,9 @@
 package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.databus.ChannelNames;
-import com.bazaarvoice.emodb.databus.api.DefaultSubscription;
-import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
+import com.bazaarvoice.emodb.databus.model.DefaultOwnedSubscription;
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -18,9 +18,9 @@ import static org.testng.Assert.assertEquals;
 public class DatabusChannelConfigurationTest {
     @Test
     public void testGetTTLForReplay() {
-        Subscription replaySubscription = new DefaultSubscription(ChannelNames.getMasterReplayChannel(),
+        OwnedSubscription replaySubscription = new DefaultOwnedSubscription(ChannelNames.getMasterReplayChannel(),
                 Conditions.alwaysTrue(), new Date(DateTime.now().plus(Duration.standardDays(3650)).getMillis()),
-                DatabusChannelConfiguration.REPLAY_TTL);
+                DatabusChannelConfiguration.REPLAY_TTL, "id");
         SubscriptionDAO mockSubscriptionDao = mock(SubscriptionDAO.class);
         when(mockSubscriptionDao.getSubscription(ChannelNames.getMasterReplayChannel())).thenReturn(replaySubscription);
         DatabusChannelConfiguration dbusConf =

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutTest.java
@@ -1,0 +1,169 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.databus.ChannelNames;
+import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
+import com.bazaarvoice.emodb.databus.model.DefaultOwnedSubscription;
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
+import com.bazaarvoice.emodb.datacenter.api.DataCenter;
+import com.bazaarvoice.emodb.event.api.EventData;
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
+import com.bazaarvoice.emodb.sor.core.DataProvider;
+import com.bazaarvoice.emodb.sor.core.UpdateRef;
+import com.bazaarvoice.emodb.table.db.Table;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Date;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+@SuppressWarnings("unchecked")
+public class DefaultFanoutTest {
+
+    private DefaultFanout _defaultFanout;
+    private Supplier<Collection<OwnedSubscription>> _subscriptionsSupplier;
+    private DataCenter _currentDataCenter;
+    private DataCenter _remoteDataCenter;
+    private DataProvider _dataProvider;
+    private DatabusAuthorizer _databusAuthorizer;
+    private String _remoteChannel;
+    private Multimap<String, ByteBuffer> _eventsSinked;
+
+    @BeforeMethod
+    private void setUp() {
+        _eventsSinked = ArrayListMultimap.create();
+
+        Function<Multimap<String, ByteBuffer>, Void> eventSink = new Function<Multimap<String, ByteBuffer>, Void>() {
+            @Override
+            public Void apply(Multimap<String, ByteBuffer> input) {
+                _eventsSinked.putAll(input);
+                return null;
+            }
+        };
+
+        _subscriptionsSupplier = mock(Supplier.class);
+        _currentDataCenter = mock(DataCenter.class);
+        when(_currentDataCenter.getName()).thenReturn("local");
+        _remoteDataCenter = mock(DataCenter.class);
+        when(_remoteDataCenter.getName()).thenReturn("remote");
+        _remoteChannel = ChannelNames.getReplicationFanoutChannel(_remoteDataCenter);
+
+        RateLimitedLogFactory rateLimitedLogFactory = mock(RateLimitedLogFactory.class);
+        when(rateLimitedLogFactory.from(any(Logger.class))).thenReturn(mock(RateLimitedLog.class));
+
+        _dataProvider = mock(DataProvider.class);
+        _databusAuthorizer = mock(DatabusAuthorizer.class);
+
+        SubscriptionEvaluator subscriptionEvaluator = new SubscriptionEvaluator(_dataProvider, rateLimitedLogFactory);
+
+        _defaultFanout = new DefaultFanout("test", mock(EventSource.class), eventSink, true, Duration.standardSeconds(1),
+                _subscriptionsSupplier, _currentDataCenter, rateLimitedLogFactory, subscriptionEvaluator,
+                _databusAuthorizer, new MetricRegistry());
+    }
+
+    @Test
+    public void testMatchingTable() {
+        addTable("matching-table");
+
+        OwnedSubscription subscription = new DefaultOwnedSubscription(
+                "test", Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("matching-table")),
+                new Date(), Duration.standardDays(1), "owner0");
+
+        EventData event = newEvent("id0", "matching-table", "key0");
+
+        when(_subscriptionsSupplier.get()).thenReturn(ImmutableList.of(subscription));
+        DatabusAuthorizer.DatabusAuthorizerByOwner authorizerByOwner = mock(DatabusAuthorizer.DatabusAuthorizerByOwner.class);
+        when(authorizerByOwner.canReceiveEventsFromTable("matching-table")).thenReturn(true);
+        when(_databusAuthorizer.owner("owner0")).thenReturn(authorizerByOwner);
+
+        _defaultFanout.copyEvents(ImmutableList.of(event));
+
+        assertEquals(_eventsSinked,
+                ImmutableMultimap.of("test", event.getData(), _remoteChannel, event.getData()));
+    }
+
+    @Test
+    public void testNotMatchingTable() {
+        addTable("other-table");
+
+        OwnedSubscription subscription = new DefaultOwnedSubscription(
+                "test", Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("not-matching-table")),
+                new Date(), Duration.standardDays(1), "owner0");
+
+        EventData event = newEvent("id0", "other-table", "key0");
+
+        when(_subscriptionsSupplier.get()).thenReturn(ImmutableList.of(subscription));
+        DatabusAuthorizer.DatabusAuthorizerByOwner authorizerByOwner = mock(DatabusAuthorizer.DatabusAuthorizerByOwner.class);
+        when(authorizerByOwner.canReceiveEventsFromTable("matching-table")).thenReturn(true);
+        when(_databusAuthorizer.owner("owner0")).thenReturn(authorizerByOwner);
+
+        _defaultFanout.copyEvents(ImmutableList.of(event));
+
+        // Event does not match subscription, should only go to remote fanout
+        assertEquals(_eventsSinked,
+                ImmutableMultimap.of(_remoteChannel, event.getData()));
+    }
+
+    @Test
+    public void testUnauthorizedFanout() {
+        addTable("unauthorized-table");
+
+        OwnedSubscription subscription = new DefaultOwnedSubscription(
+                "test", Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("unauthorized-table")),
+                new Date(), Duration.standardDays(1), "owner0");
+
+        EventData event = newEvent("id0", "unauthorized-table", "key0");
+
+        when(_subscriptionsSupplier.get()).thenReturn(ImmutableList.of(subscription));
+        DatabusAuthorizer.DatabusAuthorizerByOwner authorizerByOwner = mock(DatabusAuthorizer.DatabusAuthorizerByOwner.class);
+        when(authorizerByOwner.canReceiveEventsFromTable("matching-table")).thenReturn(false);
+        when(_databusAuthorizer.owner("owner0")).thenReturn(authorizerByOwner);
+
+        _defaultFanout.copyEvents(ImmutableList.of(event));
+
+        // Event is not authorized for owner, should only go to remote fanout
+        assertEquals(_eventsSinked,
+                ImmutableMultimap.of(_remoteChannel, event.getData()));
+
+    }
+
+    private void addTable(String tableName) {
+        Table table = mock(Table.class);
+        when(table.getName()).thenReturn(tableName);
+        when(table.getAttributes()).thenReturn(ImmutableMap.<String, Object>of());
+        when(table.getOptions()).thenReturn(new TableOptionsBuilder().setPlacement("placement").build());
+        // Put in another data center to force replication
+        when(table.getDataCenters()).thenReturn(ImmutableList.of(_currentDataCenter, _remoteDataCenter));
+        when(_dataProvider.getTable(tableName)).thenReturn(table);
+    }
+
+    private EventData newEvent(String id, String table, String key) {
+        EventData eventData = mock(EventData.class);
+        when(eventData.getId()).thenReturn(id);
+
+        UpdateRef updateRef = new UpdateRef(table, key, TimeUUIDs.newUUID(), ImmutableSet.<String>of());
+        ByteBuffer data = UpdateRefSerializer.toByteBuffer(updateRef);
+        when(eventData.getData()).thenReturn(data);
+
+        return eventData;
+    }
+}

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutTest.java
@@ -73,11 +73,12 @@ public class DefaultFanoutTest {
         _dataProvider = mock(DataProvider.class);
         _databusAuthorizer = mock(DatabusAuthorizer.class);
 
-        SubscriptionEvaluator subscriptionEvaluator = new SubscriptionEvaluator(_dataProvider, rateLimitedLogFactory);
+        SubscriptionEvaluator subscriptionEvaluator = new SubscriptionEvaluator(
+                _dataProvider, _databusAuthorizer, rateLimitedLogFactory);
 
         _defaultFanout = new DefaultFanout("test", mock(EventSource.class), eventSink, true, Duration.standardSeconds(1),
                 _subscriptionsSupplier, _currentDataCenter, rateLimitedLogFactory, subscriptionEvaluator,
-                _databusAuthorizer, new MetricRegistry());
+                new MetricRegistry());
     }
 
     @Test

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ReplayRequestTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ReplayRequestTest.java
@@ -15,12 +15,13 @@ public class ReplayRequestTest {
     @Test
     public void testReplayRequestJson() {
         String json = "{" +
-                "\"subscription\":\"test\"}";
+                "\"ownerId\":\"123\",\"subscription\":\"test\"}";
         ReplaySubscriptionRequest request = JsonHelper.fromJson(json, ReplaySubscriptionRequest.class);
         assertEquals(JsonHelper.asJson(request), json, "Json representation without 'since' looks good");
         SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZZ");
         dateFmt.setTimeZone(TimeZone.getTimeZone("UTC"));
         String jsonWithSince = "{" +
+                "\"ownerId\":\"123\"," +
                 "\"subscription\":\"test\"," +
                 "\"since\":\"" + dateFmt.format(new Date()) + "\"}";
         request = JsonHelper.fromJson(jsonWithSince, ReplaySubscriptionRequest.class);

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluatorTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluatorTest.java
@@ -1,8 +1,9 @@
 package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
-import com.bazaarvoice.emodb.databus.api.DefaultSubscription;
-import com.bazaarvoice.emodb.databus.api.Subscription;
+import com.bazaarvoice.emodb.databus.auth.ConstantDatabusAuthorizer;
+import com.bazaarvoice.emodb.databus.model.DefaultOwnedSubscription;
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
@@ -31,14 +32,14 @@ public class SubscriptionEvaluatorTest {
         when(dataProvider.getTable(anyString())).thenReturn(new InMemoryTable("table1",
                 new TableOptionsBuilder().setPlacement("app_global:ugc").build(), Maps.<String, Object>newHashMap()));
         SubscriptionEvaluator subscriptionEvaluator = new SubscriptionEvaluator(dataProvider,
-                mock(RateLimitedLogFactory.class));
+                ConstantDatabusAuthorizer.ALLOW_ALL, mock(RateLimitedLogFactory.class));
         UpdateRef updateRef = new UpdateRef("table1", "some-key", TimeUUIDs.newUUID(), ImmutableSet.of("ignore", "ETL"));
 
         // Subscription that skips "ignore" events
         // Condition is only based on tags - the events should not contain any "ignore" tags
         Condition skipIgnoreEvents = Conditions.not(Conditions.mapBuilder().matches(UpdateRef.TAGS_NAME, Conditions.containsAny("ignore")).build());
-        Subscription skipIgnoreSubscription = new DefaultSubscription("test-tags", skipIgnoreEvents,
-                DateTime.now().withDurationAdded(Duration.standardDays(1), 1).toDate(), Duration.standardHours(1));
+        OwnedSubscription skipIgnoreSubscription = new DefaultOwnedSubscription("test-tags", skipIgnoreEvents,
+                DateTime.now().withDurationAdded(Duration.standardDays(1), 1).toDate(), Duration.standardHours(1), "id");
         assertFalse(subscriptionEvaluator.matches(skipIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef)));
         // The following databus event should match, as it doesn't have "ignore" tag
         UpdateRef updateRef2 = new UpdateRef("table1", "some-key", TimeUUIDs.newUUID(), ImmutableSet.of("ETL"));
@@ -48,13 +49,28 @@ public class SubscriptionEvaluatorTest {
 
         // Subscription that explicitly asks for "ignore" events
         Condition getIgnoreEvents = Conditions.mapBuilder().matches(UpdateRef.TAGS_NAME, Conditions.containsAny("ignore")).build();
-        Subscription getIgnoreSubscription = new DefaultSubscription("test-tags", getIgnoreEvents,
-                DateTime.now().withDurationAdded(Duration.standardDays(1), 1).toDate(), Duration.standardHours(1));
+        OwnedSubscription getIgnoreSubscription = new DefaultOwnedSubscription("test-tags", getIgnoreEvents,
+                DateTime.now().withDurationAdded(Duration.standardDays(1), 1).toDate(), Duration.standardHours(1), "id");
         assertTrue(subscriptionEvaluator.matches(getIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef)));
         // The following databus event should *not* match, as it doesn't have "ignore" tag
         updateRef2 = new UpdateRef("table1", "some-key", TimeUUIDs.newUUID(), ImmutableSet.of("ETL"));
         assertFalse(subscriptionEvaluator.matches(getIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef2)));
         updateRef3 = new UpdateRef("table1", "some-key", TimeUUIDs.newUUID(), ImmutableSet.<String>of());
         assertFalse(subscriptionEvaluator.matches(getIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef3)));
+    }
+
+    @Test
+    public void testUnauthorized() {
+        DataProvider dataProvider = mock(DataProvider.class);
+        when(dataProvider.getTable(anyString())).thenReturn(new InMemoryTable("table1",
+                new TableOptionsBuilder().setPlacement("app_global:ugc").build(), Maps.<String, Object>newHashMap()));
+        SubscriptionEvaluator subscriptionEvaluator = new SubscriptionEvaluator(dataProvider,
+                ConstantDatabusAuthorizer.DENY_ALL, mock(RateLimitedLogFactory.class));
+        UpdateRef updateRef = new UpdateRef("table1", "some-key", TimeUUIDs.newUUID(), ImmutableSet.of("ignore", "ETL"));
+
+        // No condition, even alwaysTrue(), matches when the authorizer doesn't have permission
+        OwnedSubscription allSubscription = new DefaultOwnedSubscription("all", Conditions.alwaysTrue(),
+                DateTime.now().withDurationAdded(Duration.standardDays(1), 1).toDate(), Duration.standardHours(1), "id");
+        assertFalse(subscriptionEvaluator.matches(allSubscription, UpdateRefSerializer.toByteBuffer(updateRef)));
     }
 }

--- a/datacenter/src/main/java/com/bazaarvoice/emodb/datacenter/core/DefaultDataCenters.java
+++ b/datacenter/src/main/java/com/bazaarvoice/emodb/datacenter/core/DefaultDataCenters.java
@@ -38,6 +38,16 @@ public class DefaultDataCenters implements DataCenters {
         refresh();
     }
 
+    /**
+     * DefaultDataCenters doesn't actually directly require DataCenterAnnouncer.  However, it is frequently the case
+     * that classes that depend on DefaultDataCenters will only operate correctly if the DataCenterAnnouncer has been
+     * started first.  The following false dependency forces this injection order when appropriate.
+     */
+    @Inject(optional=true)
+    private void injectDataCenterAnnouncer(DataCenterAnnouncer ignore) {
+        // no-op
+    }
+
     @Override
     public void refresh() {
         _cache = Suppliers.memoizeWithExpiration(new Supplier<CachedInfo>() {
@@ -65,7 +75,7 @@ public class DefaultDataCenters implements DataCenters {
 
     private DataCenter get(String name) {
         DataCenter dataCenter = _cache.get().get(name);
-        checkArgument(dataCenter != null, "Unknown data center: {}", name);
+        checkArgument(dataCenter != null, "Unknown data center: %s", name);
         return dataCenter;
     }
 

--- a/quality/integration/src/test/java/test/integration/auth/ApiKeyAdminTaskTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/ApiKeyAdminTaskTest.java
@@ -50,7 +50,7 @@ public class ApiKeyAdminTaskTest {
 
         _task = new ApiKeyAdminTask(securityManager, mock(TaskRegistry.class), _authIdentityManager,
                 HostAndPort.fromParts("0.0.0.0", 8080), ImmutableSet.of("reservedrole"));
-        _authIdentityManager.updateIdentity(new ApiKey("test-admin", ImmutableSet.of(DefaultRoles.admin.toString())));
+        _authIdentityManager.updateIdentity(new ApiKey("test-admin", "id_admin", ImmutableSet.of(DefaultRoles.admin.toString())));
     }
 
     @AfterMethod
@@ -83,7 +83,7 @@ public class ApiKeyAdminTaskTest {
     public void testUpdateApiKey() throws Exception {
         String key = "updateapikeytestkey";
 
-        _authIdentityManager.updateIdentity(new ApiKey(key, ImmutableSet.of("role1", "role2", "role3")));
+        _authIdentityManager.updateIdentity(new ApiKey(key, "id_update", ImmutableSet.of("role1", "role2", "role3")));
 
         _task.execute(ImmutableMultimap.<String, String>builder()
                 .put(ApiKeyRequest.AUTHENTICATION_PARAM, "test-admin")
@@ -102,7 +102,7 @@ public class ApiKeyAdminTaskTest {
     public void testMigrateApiKey() throws Exception {
         String key = "migrateapikeytestkey";
 
-        _authIdentityManager.updateIdentity(new ApiKey(key, ImmutableSet.of("role1", "role2")));
+        _authIdentityManager.updateIdentity(new ApiKey(key, "id_migrate", ImmutableSet.of("role1", "role2")));
         assertNotNull(_authIdentityManager.getIdentity(key));
 
         StringWriter output = new StringWriter();
@@ -115,6 +115,7 @@ public class ApiKeyAdminTaskTest {
         ApiKey apiKey = _authIdentityManager.getIdentity(newKey);
         assertNotNull(apiKey);
         assertEquals(apiKey.getRoles(), ImmutableSet.of("role1", "role2"));
+        assertEquals(apiKey.getInternalId(), "id_migrate");
         assertNull(_authIdentityManager.getIdentity(key));
     }
 
@@ -122,7 +123,7 @@ public class ApiKeyAdminTaskTest {
     public void testDeleteApiKey() throws Exception {
         String key = "deleteapikeytestkey";
 
-        _authIdentityManager.updateIdentity(new ApiKey(key, ImmutableSet.of("role1", "role2")));
+        _authIdentityManager.updateIdentity(new ApiKey(key, "id_delete", ImmutableSet.of("role1", "role2")));
         assertNotNull(_authIdentityManager.getIdentity(key));
 
         _task.execute(ImmutableMultimap.of(

--- a/quality/integration/src/test/java/test/integration/auth/RoleAdminTaskTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/RoleAdminTaskTest.java
@@ -56,7 +56,7 @@ public class RoleAdminTaskTest {
                         null));
 
         _task = new RoleAdminTask(securityManager, _permissionManager, mock(TaskRegistry.class));
-        _authIdentityManager.updateIdentity(new ApiKey("test-admin", ImmutableSet.of(DefaultRoles.admin.toString())));
+        _authIdentityManager.updateIdentity(new ApiKey("test-admin", "id_admin", ImmutableSet.of(DefaultRoles.admin.toString())));
     }
 
     @AfterMethod

--- a/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
@@ -100,10 +100,10 @@ public class BlobStoreJerseyTest extends ResourceTest {
 
     private ResourceTestRule setupResourceTestRule() {
         final InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB, ImmutableSet.of("blob-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_UNAUTHORIZED, ImmutableSet.of("unauthorized-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB_A, ImmutableSet.of("blob-role-a")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB_B, ImmutableSet.of("blob-role-b")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB, "id0", ImmutableSet.of("blob-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_UNAUTHORIZED, "id1", ImmutableSet.of("unauthorized-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB_A, "id2", ImmutableSet.of("blob-role-a")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB_B, "id3", ImmutableSet.of("blob-role-b")));
 
         final EmoPermissionResolver permissionResolver = new EmoPermissionResolver(mock(DataStore.class), _server);
         final InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);

--- a/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
@@ -97,8 +97,8 @@ public class DatabusJerseyTest extends ResourceTest {
     @Rule
     public ResourceTestRule _resourceTestRule = setupResourceTestRule(
             Collections.<Object>singletonList(new DatabusResource1(_server, DatabusAuthenticator.proxied(_proxy), mock(DatabusEventStore.class), new DatabusResourcePoller(new MetricRegistry()))),
-            new ApiKey(APIKEY_DATABUS, ImmutableSet.of("databus-role")),
-            new ApiKey(APIKEY_UNAUTHORIZED, ImmutableSet.of("unauthorized-role")),
+            new ApiKey(APIKEY_DATABUS, "bus", ImmutableSet.of("databus-role")),
+            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", ImmutableSet.of("unauthorized-role")),
             "databus");
 
     @After

--- a/quality/integration/src/test/java/test/integration/databus/ReplicationJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/ReplicationJerseyTest.java
@@ -38,8 +38,8 @@ public class ReplicationJerseyTest extends ResourceTest {
 
     @Rule
     public ResourceTestRule _resourceTestRule = setupReplicationResourceTestRule(ImmutableList.<Object>of(new ReplicationResource1(_server)),
-            new ApiKey(APIKEY_REPLICATION, ImmutableSet.of("replication-role")),
-            new ApiKey(APIKEY_UNAUTHORIZED, ImmutableSet.of("unauthorized-role")));
+            new ApiKey(APIKEY_REPLICATION, "repl", ImmutableSet.of("replication-role")),
+            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", ImmutableSet.of("unauthorized-role")));
 
     protected static ResourceTestRule setupReplicationResourceTestRule(List<Object> resourceList, ApiKey apiKey, ApiKey unauthorizedKey) {
         InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();

--- a/quality/integration/src/test/java/test/integration/exceptions/ExceptionMapperJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/exceptions/ExceptionMapperJerseyTest.java
@@ -39,8 +39,8 @@ public class ExceptionMapperJerseyTest extends ResourceTest {
 
     @Rule
     public ResourceTestRule _resourceTestRule = setupResourceTestRule(Collections.<Object>singletonList(new ExceptionResource()),
-            new ApiKey("unused", ImmutableSet.<String>of()),
-            new ApiKey("also-unused", ImmutableSet.<String>of()),
+            new ApiKey("unused", "id0", ImmutableSet.<String>of()),
+            new ApiKey("also-unused", "id1", ImmutableSet.<String>of()),
             "exception");
 
     @Test

--- a/quality/integration/src/test/java/test/integration/queue/DedupQueueJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/queue/DedupQueueJerseyTest.java
@@ -52,8 +52,8 @@ public class DedupQueueJerseyTest extends ResourceTest {
 
     @Rule
     public ResourceTestRule _resourceTestRule = setupResourceTestRule(Collections.<Object>singletonList(new DedupQueueResource1(_server, DedupQueueServiceAuthenticator.proxied(_proxy))),
-            new ApiKey(APIKEY_QUEUE, ImmutableSet.of("queue-role")),
-            new ApiKey(APIKEY_UNAUTHORIZED, ImmutableSet.of("unauthorized-role")),
+            new ApiKey(APIKEY_QUEUE, "queue", ImmutableSet.of("queue-role")),
+            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", ImmutableSet.of("unauthorized-role")),
             "queue");
 
     @After

--- a/quality/integration/src/test/java/test/integration/queue/QueueJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/queue/QueueJerseyTest.java
@@ -54,8 +54,8 @@ public class QueueJerseyTest extends ResourceTest {
 
     @Rule
     public ResourceTestRule _resourceTestRule = setupResourceTestRule(Collections.<Object>singletonList(new QueueResource1(_server, QueueServiceAuthenticator.proxied(_proxy))),
-            new ApiKey(APIKEY_QUEUE, ImmutableSet.of("queue-role")),
-            new ApiKey(APIKEY_UNAUTHORIZED, ImmutableSet.of("unauthorized-role")),
+            new ApiKey(APIKEY_QUEUE, "queue", ImmutableSet.of("queue-role")),
+            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", ImmutableSet.of("unauthorized-role")),
             "queue");
 
     @After

--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -118,13 +118,13 @@ public class DataStoreJerseyTest extends ResourceTest {
 
     private ResourceTestRule setupDataStoreResourceTestRule() {
         InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_TABLE, ImmutableSet.of("table-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_READ_TABLES_A, ImmutableSet.of("tables-a-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_READ_TABLES_B, ImmutableSet.of("tables-b-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_FACADE, ImmutableSet.of("facade-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_REVIEWS_ONLY, ImmutableSet.of("reviews-only-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_STANDARD, ImmutableSet.of("standard")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_STANDARD_UPDATE, ImmutableSet.of("update-with-events")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_TABLE, "id0", ImmutableSet.of("table-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_READ_TABLES_A, "id1", ImmutableSet.of("tables-a-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_READ_TABLES_B, "id2", ImmutableSet.of("tables-b-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_FACADE, "id3", ImmutableSet.of("facade-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_REVIEWS_ONLY, "id4", ImmutableSet.of("reviews-only-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_STANDARD, "id5", ImmutableSet.of("standard")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_STANDARD_UPDATE, "id5", ImmutableSet.of("update-with-events")));
 
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(_server, mock(BlobStore.class));
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);

--- a/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
@@ -100,7 +100,7 @@ public class AdHocThrottleTest extends ResourceTest {
 
     private ResourceTestRule setupDataStoreResourceTestRule() {
         InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
-        authIdentityManager.updateIdentity(new ApiKey(API_KEY, ImmutableList.of("all-sor-role")));
+        authIdentityManager.updateIdentity(new ApiKey(API_KEY, "id", ImmutableList.of("all-sor-role")));
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(_dataStore, mock(BlobStore.class));
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         permissionManager.updateForRole(

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -34,10 +34,12 @@ import com.bazaarvoice.emodb.databus.DatabusHostDiscovery;
 import com.bazaarvoice.emodb.databus.DatabusModule;
 import com.bazaarvoice.emodb.databus.DatabusZooKeeper;
 import com.bazaarvoice.emodb.databus.DefaultJoinFilter;
+import com.bazaarvoice.emodb.databus.SystemInternalId;
 import com.bazaarvoice.emodb.databus.api.AuthDatabus;
-import com.bazaarvoice.emodb.databus.api.Databus;
-import com.bazaarvoice.emodb.databus.client.DatabusAuthenticator;
-import com.bazaarvoice.emodb.databus.core.TrustedDatabus;
+import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
+import com.bazaarvoice.emodb.databus.auth.FilteredDatabusAuthorizer;
+import com.bazaarvoice.emodb.databus.auth.SystemProcessDatabusAuthorizer;
+import com.bazaarvoice.emodb.databus.core.DatabusFactory;
 import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.DataCenterModule;
 import com.bazaarvoice.emodb.job.JobConfiguration;
@@ -73,13 +75,17 @@ import com.bazaarvoice.emodb.sor.core.DataStoreAsyncModule;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.auth.AuthorizationConfiguration;
+import com.bazaarvoice.emodb.web.auth.OwnerDatabusAuthorizer;
 import com.bazaarvoice.emodb.web.auth.SecurityModule;
 import com.bazaarvoice.emodb.web.partition.PartitionAwareClient;
 import com.bazaarvoice.emodb.web.partition.PartitionAwareServiceFactory;
 import com.bazaarvoice.emodb.web.plugins.DefaultPluginServerMetadata;
 import com.bazaarvoice.emodb.web.report.ReportsModule;
+import com.bazaarvoice.emodb.web.resources.databus.DatabusClientSubjectProxy;
+import com.bazaarvoice.emodb.web.resources.databus.DatabusClientSubjectProxyServiceFactory;
 import com.bazaarvoice.emodb.web.resources.databus.DatabusRelayClientFactory;
 import com.bazaarvoice.emodb.web.resources.databus.DatabusResourcePoller;
+import com.bazaarvoice.emodb.web.resources.databus.LocalDatabusClientSubjectProxy;
 import com.bazaarvoice.emodb.web.resources.databus.LongPollingExecutorServices;
 import com.bazaarvoice.emodb.web.scanner.ScanUploadModule;
 import com.bazaarvoice.emodb.web.scanner.ScannerZooKeeper;
@@ -334,6 +340,8 @@ public class EmoModule extends AbstractModule {
             bind(DatabusConfiguration.class).toInstance(_configuration.getDatabusConfiguration());
             // Used by the databus resource to support long polling
             bind(DatabusResourcePoller.class).asEagerSingleton();
+            bind(OwnerDatabusAuthorizer.class).asEagerSingleton();
+
             // Bind the suppressed event condition setting as the supplier
             bind(new TypeLiteral<Supplier<Condition>>(){}).annotatedWith(DefaultJoinFilter.class)
                     .to(Key.get(new TypeLiteral<Setting<Condition>>(){}, DefaultJoinFilter.class));
@@ -370,32 +378,49 @@ public class EmoModule extends AbstractModule {
             return DatabusRelayClientFactory.forClusterAndHttpClient(_configuration.getCluster(), jerseyClient);
         }
 
+        @Provides @Singleton
+        MultiThreadedServiceFactory<DatabusClientSubjectProxy> provideSubjectDatabusFactoryServiceFactory(
+                MultiThreadedServiceFactory<AuthDatabus> authDatabusServiceFactory) {
+            // Proxy the AuthDatabus service factory into another service factory that will authorize the caller
+            // indirectly using a Subject's API key.
+            return new DatabusClientSubjectProxyServiceFactory(authDatabusServiceFactory);
+        }
+
         @Provides @Singleton @DatabusHostDiscovery
-        HostDiscovery provideDatabusHostDiscovery(MultiThreadedServiceFactory<AuthDatabus> serviceFactory,
+        HostDiscovery provideDatabusHostDiscovery(MultiThreadedServiceFactory<DatabusClientSubjectProxy> serviceFactory,
                                                   @Global CuratorFramework curator, LifeCycleRegistry lifeCycle) {
             return lifeCycle.manage(new ZooKeeperHostDiscovery(curator, serviceFactory.getServiceName(), _environment.metrics()));
         }
 
         /** Create an SOA Databus client for forwarding non-partition-aware clients to the right server. */
         @Provides @Singleton @PartitionAwareClient
-        DatabusAuthenticator provideDatabusClient(MultiThreadedServiceFactory<AuthDatabus> serviceFactory,
+        DatabusClientSubjectProxy provideDatabusClient(MultiThreadedServiceFactory<DatabusClientSubjectProxy> serviceFactory,
                                      @DatabusHostDiscovery HostDiscovery hostDiscovery,
-                                     Databus databus, @SelfHostAndPort HostAndPort self, MetricRegistry metricRegistry, HealthCheckRegistry healthCheckRegistry) {
-            AuthDatabus client = ServicePoolBuilder.create(AuthDatabus.class)
+                                     DatabusFactory databusFactory, @SelfHostAndPort HostAndPort self, MetricRegistry metricRegistry, HealthCheckRegistry healthCheckRegistry) {
+            DatabusClientSubjectProxy client = ServicePoolBuilder.create(DatabusClientSubjectProxy.class)
                     .withHostDiscovery(hostDiscovery)
                     .withServiceFactory(
-                            new PartitionAwareServiceFactory<>(serviceFactory, new TrustedDatabus(databus), self, healthCheckRegistry))
+                            new PartitionAwareServiceFactory<>(serviceFactory, new LocalDatabusClientSubjectProxy(databusFactory), self, healthCheckRegistry))
                     .withMetricRegistry(metricRegistry)
                     .withCachingPolicy(ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy())
                     .buildProxy(new ExponentialBackoffRetry(5, 50, 1000, TimeUnit.MILLISECONDS));
             _environment.lifecycle().manage(new ManagedServicePoolProxy(client));
-            return DatabusAuthenticator.proxied(client);
+            return client;
         }
 
         /** Provide ZooKeeper namespaced to Databus data. */
         @Provides @Singleton @DatabusZooKeeper
         CuratorFramework provideDatabusZooKeeperConnection(@Global CuratorFramework curator) {
             return withComponentNamespace(curator, "bus");
+        }
+
+        @Provides @Singleton
+        DatabusAuthorizer provideDatabusAuthorizer(OwnerDatabusAuthorizer ownerDatabusAuthorizer,
+                                                   @SystemInternalId String systemInternalId) {
+            return FilteredDatabusAuthorizer.builder()
+                    .withDefaultAuthorizer(ownerDatabusAuthorizer)
+                    .withAuthorizerForOwner(systemInternalId, new SystemProcessDatabusAuthorizer(systemInternalId))
+                    .build();
         }
 
         @Provides @Singleton @DefaultJoinFilter

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -11,9 +11,8 @@ import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
 import com.bazaarvoice.emodb.common.json.CustomJsonObjectMapperFactory;
 import com.bazaarvoice.emodb.common.json.ISO8601DateFormat;
 import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
-import com.bazaarvoice.emodb.databus.api.Databus;
-import com.bazaarvoice.emodb.databus.client.DatabusAuthenticator;
 import com.bazaarvoice.emodb.databus.core.DatabusEventStore;
+import com.bazaarvoice.emodb.databus.core.DatabusFactory;
 import com.bazaarvoice.emodb.databus.repl.ReplicationSource;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.plugin.lifecycle.ServerStartedListener;
@@ -36,6 +35,7 @@ import com.bazaarvoice.emodb.web.partition.PartitionAwareClient;
 import com.bazaarvoice.emodb.web.report.ReportLoader;
 import com.bazaarvoice.emodb.web.resources.FaviconResource;
 import com.bazaarvoice.emodb.web.resources.blob.BlobStoreResource1;
+import com.bazaarvoice.emodb.web.resources.databus.DatabusClientSubjectProxy;
 import com.bazaarvoice.emodb.web.resources.databus.DatabusResource1;
 import com.bazaarvoice.emodb.web.resources.databus.DatabusResourcePoller;
 import com.bazaarvoice.emodb.web.resources.databus.ReplicationResource1;
@@ -250,8 +250,8 @@ public class EmoService extends Application<EmoConfiguration> {
             return;
         }
 
-        Databus databus = _injector.getInstance(Databus.class);
-        DatabusAuthenticator databusClient = _injector.getInstance(Key.get(DatabusAuthenticator.class, PartitionAwareClient.class));
+        DatabusFactory databus = _injector.getInstance(DatabusFactory.class);
+        DatabusClientSubjectProxy databusClient = _injector.getInstance(Key.get(DatabusClientSubjectProxy.class, PartitionAwareClient.class));
         DatabusEventStore databusEventStore = _injector.getInstance(DatabusEventStore.class);
         ReplicationSource replicationSource = _injector.getInstance(ReplicationSource.class);
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
@@ -8,11 +8,15 @@ import javax.validation.constraints.NotNull;
 public class AuthorizationConfiguration {
 
     private final static String DEFAULT_IDENTITY_TABLE = "__auth:keys";
+    private final static String DEFAULT_INTERNAL_ID_INDEX_TABLE = "__auth:internal_ids";
     private final static String DEFAULT_PERMISSION_TABLE = "__auth:permissions";
 
     // Table for storing API keys
     @NotNull
     private String _identityTable = DEFAULT_IDENTITY_TABLE;
+    // Table for storing index of internal IDs to hashed identity keys
+    @NotNull
+    private String _internalIdIndexTable = DEFAULT_INTERNAL_ID_INDEX_TABLE;
     // Table for storing permissions
     @NotNull
     private String _permissionsTable = DEFAULT_PERMISSION_TABLE;
@@ -34,6 +38,15 @@ public class AuthorizationConfiguration {
 
     public AuthorizationConfiguration setIdentityTable(String identityTable) {
         _identityTable = identityTable;
+        return this;
+    }
+
+    public String getInternalIdIndexTable() {
+        return _internalIdIndexTable;
+    }
+
+    public AuthorizationConfiguration setInternalIdIndexTable(String internalIdIndexTable) {
+        _internalIdIndexTable = internalIdIndexTable;
         return this;
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
@@ -120,6 +120,7 @@ public enum DefaultRoles {
 
     // Reserved role for replication databus traffic between data centers
     replication (
+            ImmutableSet.of(sor_read),
             Permissions.replicateDatabus()),
 
     // Reserved role for anonymous access

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/OwnerDatabusAuthorizer.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/OwnerDatabusAuthorizer.java
@@ -1,0 +1,237 @@
+package com.bazaarvoice.emodb.web.auth;
+
+import com.bazaarvoice.emodb.auth.InternalAuthorizer;
+import com.bazaarvoice.emodb.databus.auth.ConstantDatabusAuthorizer;
+import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
+import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
+import com.bazaarvoice.emodb.web.auth.resource.NamedResource;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Objects;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.inject.Inject;
+import org.apache.shiro.authz.Permission;
+import org.apache.shiro.authz.permission.PermissionResolver;
+import org.joda.time.Duration;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Implementation of {@link DatabusAuthorizer} which checks the owner's permissions for all operations.
+ */
+public class OwnerDatabusAuthorizer implements DatabusAuthorizer {
+
+    private final static int DEFAULT_PERMISSION_CHECK_CACHE_SIZE = 1000;
+    private final static Duration DEFAULT_PERMISSION_CHECK_CACHE_TIMEOUT = Duration.standardSeconds(2);
+    private final static Duration MAX_PERMISSION_CHECK_CACHE_TIMEOUT = Duration.standardSeconds(5);
+    private final static int DEFAULT_READ_PERMISSION_CACHE_SIZE = 200;
+
+    private final InternalAuthorizer _internalAuthorizer;
+
+    /**
+     * The most expensive operation performed by this implementation happens during {@link OwnerDatabusAuthorizerForOwner#canReceiveEventsFromTable(String)}
+     * when it checks whether an owner has read permission on a table.  The {@link InternalAuthorizer} implementation is
+     * typically efficient and caches as much information as possible to make the evaluation quickly.  However, this method
+     * is called as part of the databus fanout process and thus happens at high scale, so every bit of efficiency
+     * achieved for this computation is beneficial.
+     *
+     * There is typically high temporal locality for this method call, since an owner may have multiple subscriptions and
+     * updates to a single table are commonly clustered.  For this reason caching the permissions reduce the average
+     * time for the method.  However, if the permissions for an owner are modified then any cached results may no longer
+     * be valid.  For this reason the results are cached for only a brief period.  This means that when a user's permissions
+     * change it may take several seconds for affected tables' data to be included in or excluded from that user's
+     * subscriptions.  However, given the eventually consistent nature of EmoDB and the efficiency gained by caching
+     * this is a tolerable trade-off.
+     */
+     private final LoadingCache<OwnerTableCacheKey, Boolean> _permissionCheckCache;
+
+    /**
+     * As described previously calls to {@link OwnerDatabusAuthorizerForOwner#canReceiveEventsFromTable(String)} are
+     * typically temporally clustered by table.  Instantiation the read permission for a table is relatively inexpensive
+     * but again for the sake of efficiency during databus fanout should be minimized.  Unlike with the previous cache,
+     * however, the permission instance is not tied to any particular user and can be cached indefinitely with no
+     * negative efffects.  For this reason the permissions are cached separately to reduce frequent permission resolution.
+     */
+    private final LoadingCache<String, Permission> _readPermissionCache;
+
+    private final PermissionResolver _permissionResolver;
+
+    @Inject
+    public OwnerDatabusAuthorizer(InternalAuthorizer internalAuthorizer, final PermissionResolver permissionResolver,
+                                  MetricRegistry metricRegistry) {
+        this(internalAuthorizer, permissionResolver, metricRegistry, DEFAULT_PERMISSION_CHECK_CACHE_SIZE,
+                DEFAULT_PERMISSION_CHECK_CACHE_TIMEOUT, DEFAULT_READ_PERMISSION_CACHE_SIZE);
+    }
+
+    public OwnerDatabusAuthorizer(InternalAuthorizer internalAuthorizer, final PermissionResolver permissionResolver,
+                                  MetricRegistry metricRegistry, int permissionCheckCacheSize,
+                                  Duration permissionCheckCacheTimeout, int readPermissionCacheSize) {
+        _internalAuthorizer = checkNotNull(internalAuthorizer, "internalAuthorizer");
+        _permissionResolver = checkNotNull(permissionResolver, "permissionResolver");
+
+        if (permissionCheckCacheSize > 0) {
+            checkNotNull(permissionCheckCacheTimeout, "permissionCheckCacheTimeout");
+            checkArgument(!permissionCheckCacheTimeout.isLongerThan(MAX_PERMISSION_CHECK_CACHE_TIMEOUT),
+                    "Permission check cache timeout is too long");
+
+            _permissionCheckCache = CacheBuilder.newBuilder()
+                    .maximumSize(permissionCheckCacheSize)
+                    .expireAfterWrite(permissionCheckCacheTimeout.getMillis(), TimeUnit.MILLISECONDS)
+                    .recordStats()
+                    .build(new CacheLoader<OwnerTableCacheKey, Boolean>() {
+                        @Override
+                        public Boolean load(OwnerTableCacheKey key) throws Exception {
+                            return ownerCanReadTable(key._ownerId, key._table);
+                        }
+                    });
+
+            if (metricRegistry != null) {
+                // Getting the full benefits of permission check caching requires tuning.  Publish statistics to
+                // give visibility into performance.
+                metricRegistry.register(MetricRegistry.name("bv.emodb.databus", "authorizer", "read-permission-cache", "hits"),
+                        new Gauge<Long>() {
+                            @Override
+                            public Long getValue() {
+                                return _permissionCheckCache.stats().hitCount();
+                            }
+                        });
+
+                metricRegistry.register(MetricRegistry.name("bv.emodb.databus", "authorizer", "read-permission-cache", "misses"),
+                        new Gauge<Long>() {
+                            @Override
+                            public Long getValue() {
+                                return _permissionCheckCache.stats().missCount();
+                            }
+                        });
+            }
+        } else {
+            _permissionCheckCache = null;
+        }
+
+        if (readPermissionCacheSize > 0) {
+            _readPermissionCache = CacheBuilder.newBuilder()
+                    .maximumSize(readPermissionCacheSize)
+                    .build(new CacheLoader<String, Permission>() {
+                        @Override
+                        public Permission load(String table) throws Exception {
+                            return createReadPermission(table);
+                        }
+                    });
+        } else {
+            _readPermissionCache = null;
+        }
+    }
+
+    @Override
+    public DatabusAuthorizerByOwner owner(String ownerId) {
+        // TODO:  To grandfather in subscriptions before API keys were enforced the following code
+        //        permits all operations if there is no owner.  This code should be replaced with the
+        //        commented-out version once enough time has passed for all grandfathered-in
+        //        subscriptions to have been renewed and therefore have an owner attached.
+        //
+        // return new OwnerDatabusAuthorizerForOwner(checkNotNull(ownerId, "ownerId"));
+
+        if (ownerId != null) {
+            return new OwnerDatabusAuthorizerForOwner(ownerId);
+        } else {
+            return ConstantDatabusAuthorizer.ALLOW_ALL.owner(ownerId);
+        }
+    }
+
+    private class OwnerDatabusAuthorizerForOwner implements DatabusAuthorizerByOwner {
+        private final String _ownerId;
+
+        private OwnerDatabusAuthorizerForOwner(String ownerId) {
+            _ownerId = ownerId;
+        }
+
+        /**
+         * A subscription can be accessed if either of the following conditions are met:
+         * <ol>
+         *     <li>The subscription is owned by the provider user.</li>
+         *     <li>The provided user has explicit permission to act as an owner of this subscription (typically reserved
+         *         for administrators).</li>
+         * </ol>
+         */
+        @Override
+        public boolean canAccessSubscription(OwnedSubscription subscription) {
+            return _ownerId.equals(subscription.getOwnerId()) ||
+                    _internalAuthorizer.hasPermissionByInternalId(_ownerId,
+                            Permissions.assumeDatabusSubscriptionOwnership(new NamedResource(subscription.getName())));
+        }
+
+        /**
+         * A table can be polled by a user if that user has read permission on that table.
+         */
+        @Override
+        public boolean canReceiveEventsFromTable(String table) {
+            return _permissionCheckCache != null ?
+                    _permissionCheckCache.getUnchecked(new OwnerTableCacheKey(_ownerId, table)) :
+                    ownerCanReadTable(_ownerId, table);
+        }
+    }
+
+    /**
+     * Determines if an owner has read permission on a table.  This always calls back to the authorizer and will not
+     * return a cached value.
+     */
+    private boolean ownerCanReadTable(String ownerId, String table) {
+        return _internalAuthorizer.hasPermissionByInternalId(ownerId, getReadPermission(table));
+    }
+
+    /**
+     * Gets the Permission instance for read permission on a table.  If caching is enabled the result is either returned
+     * from or added to the cache.
+     */
+    private Permission getReadPermission(String table) {
+        return _readPermissionCache != null ?
+                _readPermissionCache.getUnchecked(table) :
+                createReadPermission(table);
+    }
+
+    /**
+     * Creates a Permission instance for read permission on a table.  This always resolves a new instance and will
+     * not return a cached value.
+     */
+    private Permission createReadPermission(String table) {
+        return _permissionResolver.resolvePermission(Permissions.readSorTable(new NamedResource(table)));
+    }
+
+    /**
+     * Cache key for the permission cache by owner and table.
+     */
+    private static class OwnerTableCacheKey {
+        private final String _ownerId;
+        private final String _table;
+        // Hash code is pre-computed and cached to reduce cache lookup time.
+        private final int _hashCode;
+
+        private OwnerTableCacheKey(String ownerId, String table) {
+            _ownerId = ownerId;
+            _table = table;
+            _hashCode = Objects.hashCode(ownerId, table);
+        }
+
+        @Override
+        public int hashCode() {
+            return _hashCode;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) {
+                return true;
+            }
+            if (!(o instanceof OwnerTableCacheKey)) {
+                return false;
+            }
+            OwnerTableCacheKey that = (OwnerTableCacheKey) o;
+            return _ownerId.equals(that._ownerId) && _table.equals(that._table);
+        }
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/Permissions.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/Permissions.java
@@ -31,6 +31,7 @@ public class Permissions {
     public final static String COMPACT = "compact";
     public final static String POST = "post";
     public final static String POLL = "poll";
+    public final static String ASSUME_OWNERSHIP = "assume_ownership";
     public final static String GET_STATUS = "get_status";
     public final static String SUBSCRIBE = "subscribe";
     public final static String UNSUBSCRIBE = "unsubscribe";
@@ -194,6 +195,10 @@ public class Permissions {
 
     public static String injectDatabus(VerifiableResource subscription) {
         return format("%s|%s|%s", DATABUS, INJECT, escapeSeparators(subscription.toString()));
+    }
+
+    public static String assumeDatabusSubscriptionOwnership(VerifiableResource subscription) {
+        return format("%s|%s|%s", DATABUS, ASSUME_OWNERSHIP, escapeSeparators(subscription.toString()));
     }
 
     public static String unlimitedDatabus(VerifiableResource subscription) {

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
@@ -18,6 +18,7 @@ import com.bazaarvoice.emodb.auth.shiro.GuavaCacheManager;
 import com.bazaarvoice.emodb.auth.shiro.InvalidatableCacheManager;
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
 import com.bazaarvoice.emodb.databus.ReplicationKey;
+import com.bazaarvoice.emodb.databus.SystemInternalId;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -57,6 +58,8 @@ import java.util.Set;
  * <ul>
  * <li> {@link DropwizardAuthConfigurator}
  * <li> @{@link ReplicationKey} String
+ * <li> @{@link SystemInternalId} String
+ * <li> {@link PermissionResolver}
  * <li> {@link InternalAuthorizer}
  * </ul>
  */
@@ -69,6 +72,9 @@ public class SecurityModule extends PrivateModule {
     private final static String ADMIN_INTERNAL_ID = "__admin";
     private final static String REPLICATION_INTERNAL_ID = "__replication";
     private final static String ANONYMOUS_INTERNAL_ID = "__anonymous";
+
+    // Internal identifier for reserved internal processes that do not have a public facing API key
+    private final static String SYSTEM_INTERNAL_ID = "__system";
 
     @Override
     protected void configure() {
@@ -87,8 +93,12 @@ public class SecurityModule extends PrivateModule {
         bind(SecurityManager.class).to(EmoSecurityManager.class);
         bind(InternalAuthorizer.class).to(EmoSecurityManager.class);
 
+        bind(String.class).annotatedWith(SystemInternalId.class).toInstance(SYSTEM_INTERNAL_ID);
+
         expose(DropwizardAuthConfigurator.class);
         expose(Key.get(String.class, ReplicationKey.class));
+        expose(Key.get(String.class, SystemInternalId.class));
+        expose(PermissionResolver.class);
         expose(InternalAuthorizer.class);
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/jersey/ExceptionMappers.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/jersey/ExceptionMappers.java
@@ -24,7 +24,8 @@ public class ExceptionMappers {
                 new JsonStreamProcessingExceptionMapper(),
                 new StashNotAvailableExceptionMapper(),
                 new DeltaSizeLimitExceptionMapper(),
-                new AuditSizeLimitExceptionMapper());
+                new AuditSizeLimitExceptionMapper(),
+                new UnauthorizedSubscriptionExceptionMapper());
     }
 
     public static Iterable<Class> getMapperTypes() {

--- a/web/src/main/java/com/bazaarvoice/emodb/web/jersey/UnauthorizedSubscriptionExceptionMapper.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/jersey/UnauthorizedSubscriptionExceptionMapper.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.web.jersey;
+
+import com.bazaarvoice.emodb.databus.api.UnauthorizedSubscriptionException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class UnauthorizedSubscriptionExceptionMapper implements ExceptionMapper<UnauthorizedSubscriptionException> {
+    @Override
+    public Response toResponse(UnauthorizedSubscriptionException e) {
+        return Response.status(Response.Status.FORBIDDEN)
+                .header("X-BV-Exception", UnauthorizedSubscriptionException.class.getName())
+                .entity(e)
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build();
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusClientSubjectProxy.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusClientSubjectProxy.java
@@ -1,0 +1,15 @@
+package com.bazaarvoice.emodb.web.resources.databus;
+
+import com.bazaarvoice.emodb.auth.jersey.Subject;
+import com.bazaarvoice.emodb.databus.api.Databus;
+
+/**
+ * Provider similar to {@link com.bazaarvoice.emodb.databus.core.DatabusFactory} that is intended for use by the
+ * controller resource to return a Databus owned by the {@link Subject} provided by Jersey.  This is necessary
+ * because requests routed internally are authorized using the internal ID while requests routed to another server
+ * for partitioning reasons are authorized using the API key.
+ */
+public interface DatabusClientSubjectProxy {
+
+    Databus forSubject(Subject subject);
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusClientSubjectProxyServiceFactory.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusClientSubjectProxyServiceFactory.java
@@ -1,0 +1,76 @@
+package com.bazaarvoice.emodb.web.resources.databus;
+
+import com.bazaarvoice.emodb.auth.jersey.Subject;
+import com.bazaarvoice.emodb.databus.api.AuthDatabus;
+import com.bazaarvoice.emodb.databus.api.Databus;
+import com.bazaarvoice.emodb.databus.client.DatabusAuthenticator;
+import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Service factory representation that proxies an {@link AuthDatabus} service factory with a
+ * {@link DatabusClientSubjectProxy} by using the subject's ID as the AuthDatabus credential.
+ */
+public class DatabusClientSubjectProxyServiceFactory implements MultiThreadedServiceFactory<DatabusClientSubjectProxy> {
+
+    private final MultiThreadedServiceFactory<AuthDatabus> _authDatabusServiceFactory;
+
+    public DatabusClientSubjectProxyServiceFactory(MultiThreadedServiceFactory<AuthDatabus> authDatabusServiceFactory) {
+        _authDatabusServiceFactory = checkNotNull(authDatabusServiceFactory);
+    }
+
+    @Override
+    public String getServiceName() {
+        return _authDatabusServiceFactory.getServiceName();
+    }
+
+    @Override
+    public void configure(ServicePoolBuilder<DatabusClientSubjectProxy> servicePoolBuilder) {
+        // No need to configure, this class proxies to a pre-configured AuthDatabus service factory.
+    }
+
+    @Override
+    public DatabusClientSubjectProxy create(ServiceEndPoint endPoint) {
+        AuthDatabus authDatabus = _authDatabusServiceFactory.create(endPoint);
+        return new RemoteDatabusClientSubjectProxy(authDatabus);
+    }
+
+    @Override
+    public void destroy(ServiceEndPoint endPoint, DatabusClientSubjectProxy service) {
+        RemoteDatabusClientSubjectProxy databusFactory = (RemoteDatabusClientSubjectProxy) service;
+        _authDatabusServiceFactory.destroy(endPoint, databusFactory.getAuthDatabus());
+    }
+
+    @Override
+    public boolean isHealthy(ServiceEndPoint endPoint) {
+        return _authDatabusServiceFactory.isHealthy(endPoint);
+    }
+
+    @Override
+    public boolean isRetriableException(Exception exception) {
+        return _authDatabusServiceFactory.isRetriableException(exception);
+    }
+
+    private static class RemoteDatabusClientSubjectProxy implements DatabusClientSubjectProxy {
+        private final AuthDatabus _authDatabus;
+        private final DatabusAuthenticator _databusAuthenticator;
+
+        private RemoteDatabusClientSubjectProxy(AuthDatabus authDatabus) {
+            _authDatabus = authDatabus;
+            _databusAuthenticator = DatabusAuthenticator.proxied(authDatabus);
+        }
+
+        @Override
+        public Databus forSubject(Subject subject) {
+            // Use the database authenticator based on the subject's external ID, which is their API key
+            return _databusAuthenticator.usingCredentials(subject.getId());
+        }
+
+        public AuthDatabus getAuthDatabus() {
+            return _authDatabus;
+        }
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResource1.java
@@ -9,9 +9,9 @@ import com.bazaarvoice.emodb.databus.api.EventViews;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
-import com.bazaarvoice.emodb.databus.client.DatabusAuthenticator;
 import com.bazaarvoice.emodb.databus.core.DatabusChannelConfiguration;
 import com.bazaarvoice.emodb.databus.core.DatabusEventStore;
+import com.bazaarvoice.emodb.databus.core.DatabusFactory;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.web.jersey.params.SecondsParam;
@@ -66,14 +66,14 @@ public class DatabusResource1 {
     private static final PeekOrPollResponseHelper _helperContentOnly = new PeekOrPollResponseHelper(EventViews.ContentOnly.class);
     private static final PeekOrPollResponseHelper _helperWithTags = new PeekOrPollResponseHelper(EventViews.WithTags.class);
 
-    private final Databus _databus;
-    private final DatabusAuthenticator _databusClient;
+    private final DatabusFactory _databusFactory;
+    private final DatabusClientSubjectProxy _databusClient;
     private final DatabusEventStore _eventStore;
     private final DatabusResourcePoller _poller;
 
-    public DatabusResource1(Databus databus, DatabusAuthenticator databusClient, DatabusEventStore eventStore,
+    public DatabusResource1(DatabusFactory databusFactory, DatabusClientSubjectProxy databusClient, DatabusEventStore eventStore,
                             DatabusResourcePoller databusResourcePoller) {
-        _databus = checkNotNull(databus, "databus");
+        _databusFactory = checkNotNull(databusFactory, "databusFactory");
         _databusClient = checkNotNull(databusClient, "databusClient");
         _eventStore = checkNotNull(eventStore, "eventStore");
         _poller = databusResourcePoller;
@@ -91,8 +91,9 @@ public class DatabusResource1 {
             response = Subscription.class
     )
     public Iterator<Subscription> listSubscription(@QueryParam ("from") String fromKeyExclusive,
-                                                   @QueryParam ("limit") @DefaultValue ("10") LongParam limit) {
-        return streamingIterator(_databus.listSubscriptions(Strings.emptyToNull(fromKeyExclusive), limit.get()));
+                                                   @QueryParam ("limit") @DefaultValue ("10") LongParam limit,
+                                                   @Authenticated Subject subject) {
+        return streamingIterator(getService(subject).listSubscriptions(Strings.emptyToNull(fromKeyExclusive), limit.get()));
     }
 
     @PUT
@@ -109,7 +110,9 @@ public class DatabusResource1 {
                                      @QueryParam ("ttl") @DefaultValue ("86400") SecondsParam subscriptionTtl,
                                      @QueryParam ("eventTtl") @DefaultValue ("86400") SecondsParam eventTtl,
                                      @QueryParam ("ignoreSuppressedEvents") BooleanParam ignoreSuppressedEventsParam,
-                                     @QueryParam ("includeDefaultJoinFilter") BooleanParam includeDefaultJoinFilterParam) {
+                                     @QueryParam ("includeDefaultJoinFilter") BooleanParam includeDefaultJoinFilterParam,
+                                     @Authenticated Subject subject) {
+
         // By default, include the default join filter condition
         // Note:  Historically this feature used to be called "ignoreSuppressedEvents".  To provide backwards
         //        compatibility both parameter names are accepted though precedence is given to the newer parameter.
@@ -121,7 +124,8 @@ public class DatabusResource1 {
         if (!conditionString.isEmpty()) {
             tableFilter = new ConditionParam(conditionString).get();
         }
-        _databus.subscribe(subscription, tableFilter, subscriptionTtl.get(), eventTtl.get(), includeDefaultJoinFilter);
+
+        getService(subject).subscribe(subscription, tableFilter, subscriptionTtl.get(), eventTtl.get(), includeDefaultJoinFilter);
         return SuccessResponse.instance();
     }
 
@@ -136,7 +140,7 @@ public class DatabusResource1 {
     public SuccessResponse unsubscribe(@QueryParam ("partitioned") BooleanParam partitioned,
                                        @PathParam ("subscription") String subscription,
                                        @Authenticated Subject subject) {
-        getService(partitioned, subject.getId()).unsubscribe(subscription);
+        getService(partitioned, subject).unsubscribe(subscription);
         return SuccessResponse.instance();
     }
 
@@ -147,8 +151,9 @@ public class DatabusResource1 {
             notes = "Returns a Subscription.",
             response = Subscription.class
     )
-    public Subscription getSubscription(@PathParam ("subscription") String subscription) {
-        return _databus.getSubscription(subscription);
+    public Subscription getSubscription(@PathParam ("subscription") String subscription,
+                                        @Authenticated Subject subject) {
+        return getService(subject).getSubscription(subscription);
     }
 
     @GET
@@ -164,9 +169,9 @@ public class DatabusResource1 {
                               @Authenticated Subject subject) {
         // Call different getEventCount* methods to collect metrics data that distinguish limited vs. unlimited calls.
         if (limit == null || limit.get() == Long.MAX_VALUE) {
-            return getService(partitioned, subject.getId()).getEventCount(subscription);
+            return getService(partitioned, subject).getEventCount(subscription);
         } else {
-            return getService(partitioned, subject.getId()).getEventCountUpTo(subscription, limit.get());
+            return getService(partitioned, subject).getEventCountUpTo(subscription, limit.get());
         }
     }
 
@@ -181,7 +186,7 @@ public class DatabusResource1 {
     public long getClaimCount(@QueryParam ("partitioned") BooleanParam partitioned,
                               @PathParam ("subscription") String subscription,
                               @Authenticated Subject subject) {
-        return getService(partitioned, subject.getId()).getClaimCount(subscription);
+        return getService(partitioned, subject).getClaimCount(subscription);
     }
 
     @GET
@@ -200,7 +205,7 @@ public class DatabusResource1 {
         // For backwards compatibility with older clients only include tags if explicitly requested
         // (default is false).
         PeekOrPollResponseHelper helper = getPeekOrPollResponseHelper(includeTags.get());
-        List<Event> events = getService(partitioned, subject.getId()).peek(subscription, limit.get());
+        List<Event> events = getService(partitioned, subject).peek(subscription, limit.get());
         return Response.ok().entity(helper.asEntity(events)).build();
     }
 
@@ -221,7 +226,7 @@ public class DatabusResource1 {
                          @Authenticated Subject subject) {
         // For backwards compatibility with older clients only include tags if explicitly requested
         // (default is false).
-        Databus databus = getService(partitioned, subject.getId());
+        Databus databus = getService(partitioned, subject);
         PeekOrPollResponseHelper helper = getPeekOrPollResponseHelper(includeTags.get());
         return _poller.poll(databus, subscription, claimTtl.get(), limit.get(), request,
                 ignoreLongPoll.get(), helper);
@@ -245,7 +250,7 @@ public class DatabusResource1 {
                                  @QueryParam ("ttl") @DefaultValue ("30") SecondsParam claimTtl,
                                  List<String> eventKeys,
                                  @Authenticated Subject subject) {
-        getService(partitioned, subject.getId()).renew(subscription, eventKeys, claimTtl.get());
+        getService(partitioned, subject).renew(subscription, eventKeys, claimTtl.get());
         return SuccessResponse.instance();
     }
 
@@ -264,7 +269,7 @@ public class DatabusResource1 {
                                        @Authenticated Subject subject) {
         // Check for null parameters, which will throw a 400, otherwise it throws a 5xx error
         checkArgument(eventKeys != null, "Missing event keys");
-        getService(partitioned, subject.getId()).acknowledge(subscription, eventKeys);
+        getService(partitioned, subject).acknowledge(subscription, eventKeys);
         return SuccessResponse.instance();
     }
 
@@ -277,13 +282,14 @@ public class DatabusResource1 {
             response = Map.class
     )
     public Map<String, Object> replay(@PathParam ("subscription") String subscription,
-                                      @QueryParam ("since") DateTimeParam sinceParam) {
+                                      @QueryParam ("since") DateTimeParam sinceParam,
+                                      @Authenticated Subject subject) {
         checkArgument(!Strings.isNullOrEmpty(subscription), "subscription is required");
         Date since = (sinceParam == null) ? null : sinceParam.get().toDate();
         // Make sure since is within Replay TTL
         checkArgument(since == null || new DateTime(since).plus(DatabusChannelConfiguration.REPLAY_TTL).isAfterNow(),
                 "Since timestamp is outside the replay TTL. Use null 'since' if you want to replay all events.");
-        String id = _databus.replayAsyncSince(subscription, since);
+        String id = getService(subject).replayAsyncSince(subscription, since);
         return ImmutableMap.<String, Object>of("id", id);
     }
 
@@ -294,8 +300,9 @@ public class DatabusResource1 {
             notes = "Returns a ReplaySubsciptionStatus.",
             response = ReplaySubscriptionStatus.class
     )
-    public ReplaySubscriptionStatus getReplayStatus(@PathParam ("replayId") String replayId) {
-        return _databus.getReplayStatus(replayId);
+    public ReplaySubscriptionStatus getReplayStatus(@PathParam ("replayId") String replayId,
+                                                    @Authenticated Subject subject) {
+        return getService(subject).getReplayStatus(replayId);
     }
 
     @POST
@@ -306,12 +313,13 @@ public class DatabusResource1 {
             notes = "Returns a Map.",
             response = Map.class
     )
-    public Map<String, Object> move(@QueryParam ("from") String from, @QueryParam ("to") String to) {
+    public Map<String, Object> move(@QueryParam ("from") String from, @QueryParam ("to") String to,
+                                    @Authenticated Subject subject) {
         checkArgument(!Strings.isNullOrEmpty(from), "from is required");
         checkArgument(!Strings.isNullOrEmpty(to), "to is required");
         checkArgument(!from.equals(to), "cannot move subscription to itself");
 
-        String id = _databus.moveAsync(from, to);
+        String id = getService(subject).moveAsync(from, to);
         return ImmutableMap.<String, Object>of("id", id);
     }
 
@@ -322,8 +330,9 @@ public class DatabusResource1 {
             notes = "Returns a MoveSubscriptionStatus.",
             response = MoveSubscriptionStatus.class
     )
-    public MoveSubscriptionStatus getMoveStatus(@PathParam ("reference") String reference) {
-        return _databus.getMoveStatus(reference);
+    public MoveSubscriptionStatus getMoveStatus(@PathParam ("reference") String reference,
+                                                @Authenticated Subject subject) {
+        return getService(subject).getMoveStatus(reference);
     }
 
     @POST
@@ -336,9 +345,10 @@ public class DatabusResource1 {
     )
     public SuccessResponse injectEvent(@PathParam ("subscription") String subscription,
                                        @QueryParam ("table") String table,
-                                       @QueryParam ("key") String key) {
+                                       @QueryParam ("key") String key,
+                                       @Authenticated Subject subject) {
         // Not partitioned--any server can write events to Cassandra.
-        _databus.injectEvent(subscription, table, key);
+        getService(subject).injectEvent(subscription, table, key);
         return SuccessResponse.instance();
     }
 
@@ -353,7 +363,7 @@ public class DatabusResource1 {
     public SuccessResponse unclaimAll(@QueryParam ("partitioned") BooleanParam partitioned,
                                       @PathParam ("subscription") String subscription,
                                       @Authenticated Subject subject) {
-        getService(partitioned, subject.getId()).unclaimAll(subscription);
+        getService(partitioned, subject).unclaimAll(subscription);
         return SuccessResponse.instance();
     }
 
@@ -368,12 +378,18 @@ public class DatabusResource1 {
     public SuccessResponse purge(@QueryParam ("partitioned") BooleanParam partitioned,
                                  @PathParam ("subscription") String subscription,
                                  @Authenticated Subject subject) {
-        getService(partitioned, subject.getId()).purge(subscription);
+        getService(partitioned, subject).purge(subscription);
         return SuccessResponse.instance();
     }
 
-    private Databus getService(BooleanParam partitioned, String apiKey) {
-        return partitioned != null && partitioned.get() ? _databus : _databusClient.usingCredentials(apiKey);
+    private Databus getService(Subject subject) {
+        return _databusFactory.forOwner(subject.getInternalId());
+    }
+
+    private Databus getService(BooleanParam partitioned, Subject subject) {
+        return partitioned != null && partitioned.get() ?
+                getService(subject) :
+                _databusClient.forSubject(subject);
     }
 
     private static <T> Iterator<T> streamingIterator(Iterator<T> iterator) {

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/LocalDatabusClientSubjectProxy.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/LocalDatabusClientSubjectProxy.java
@@ -1,0 +1,25 @@
+package com.bazaarvoice.emodb.web.resources.databus;
+
+import com.bazaarvoice.emodb.auth.jersey.Subject;
+import com.bazaarvoice.emodb.databus.api.Databus;
+import com.bazaarvoice.emodb.databus.core.DatabusFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * {@link DatabusClientSubjectProxy} implementation that uses the Subject's internal ID to proxy a DatabusFactory.
+ */
+public class LocalDatabusClientSubjectProxy implements DatabusClientSubjectProxy {
+
+    private final DatabusFactory _databusFactory;
+
+    public LocalDatabusClientSubjectProxy(DatabusFactory databusFactory) {
+        _databusFactory = checkNotNull(databusFactory, "databusFactory");
+    }
+
+    @Override
+    public Databus forSubject(Subject subject) {
+        // Get a Databus instance using the subject's internal ID
+        return _databusFactory.forOwner(subject.getInternalId());
+    }
+}


### PR DESCRIPTION
### GitHub Issue

[11](https://github.com/bazaarvoice/emodb/issues/11)

This PR makes the following changes:

* API keys have an immutable internal ID which is not exposed to any public APIs and can therefore be used internally to reference users without the same level of protection.
* Databus subscriptions are now "owned" by their subscriber.  Once a subscription has been created only the owner (or an admin) can perform any further actions on the subscription (peek, poll, renew, delete, and so on).
* Any updates for which the owner does not have read permission are excluded being copied to the subscription on fanout.  For example, if the owner does not have read permission to table "review:test" then any updates to that table will not be included in the subscription, even if the subscription condition is ```alwaysTrue()```.