### PR TITLE
Updated ZkMapStore to encode characters which would create an invalid ZkPath

### DIFF
--- a/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
@@ -382,6 +382,29 @@ public class AdHocThrottleTest extends ResourceTest {
         assertEquals(createClient().getTableApproximateSize("expired-test"), 5L);
     }
 
+    @Test
+    public void testThrottleWithSpecialCharacters() throws Exception {
+        // Throttle requests a path with numerous characters which could cause problems for ZkMapStore.
+        String path = "/sor/1/test:table/chars \t!%$@\u0080.\u0099";
+
+        // Throttle the endpoint to accept no connections
+        _adHocThrottleManager.addThrottle(
+                new AdHocThrottleEndpoint("GET", path),
+                AdHocThrottle.create(0, DateTime.now().plusDays(1)));
+
+
+        // Wait until we've verified that the map store has been updated
+        for (int i=0; i < 100; i++) {
+            if (_mapStore.get("GET_sor~1~test:table~chars \t!%$@\u0080.\u0099") != null) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        assertNotNull(_mapStore.get("GET_sor~1~test:table~chars \t!%$@\u0080.\u0099"));
+
+        verifyThrottled(createClient()).get("test:table", "chars \t!%$@\u0080.\u0099");
+    }
+
     private DataStore createClient() {
         return DataStoreAuthenticator.proxied(new DataStoreClient(URI.create("/sor/1"), new JerseyEmoClient(_resourceTestRule.client())))
                 .usingCredentials(API_KEY);

--- a/web/src/main/java/com/bazaarvoice/emodb/web/throttling/AdHocThrottleEndpoint.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/throttling/AdHocThrottleEndpoint.java
@@ -55,7 +55,7 @@ public class AdHocThrottleEndpoint {
 
     /**
      * The string form of AdHocThrottleEndpoint is used as a key in a {@link com.bazaarvoice.emodb.common.zookeeper.store.MapStore}.
-     * For this reason the string version must not contain spaces and cannot have the '/' character.
+     * For this reason the string version cannot contain the '/' character.
      */
     @Override
     public String toString() {


### PR DESCRIPTION
### GitHub Issue

[12](https://github.com/bazaarvoice/emodb/issues/12)

This PR updates `ZkMapStore` to replace any characters which would be illegal in a ZK path with a hex representation, such converting character 0x99 with "%0099".  The '%' character is also always similarly hex-encoded to avoid ambiguity.