### PR TITLE
Exclude javadoc and sources from binaries. Add web.jar

### DIFF
--- a/yum/dep.xml
+++ b/yum/dep.xml
@@ -24,6 +24,22 @@ http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 ">
             <includes>
                 <include>emodb-web*.jar</include>
             </includes>
+            <excludes>
+                <exclude>*javadoc.jar</exclude>
+                <exclude>*sources.jar</exclude>
+            </excludes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/../web/target</directory>
+            <outputDirectory>/bin</outputDirectory>
+            <fileMode>755</fileMode>
+            <includes>
+                <include>emodb-web*.jar</include>
+            </includes>
+            <excludes>
+                <exclude>*javadoc.jar</exclude>
+                <exclude>*sources.jar</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../web-local</directory>


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

The release gets *javadoc.jar and *sources.jar that breaks our convenience script start-local.sh. Also, we didn't have the main emodb-web*.jar in the binary

## How to Test and Verify

1. Download the tarball from github's latest release
2. Verify `./start-local.sh` works normally. 
3. Verify emodb-web*.jar is also present

## Risk

### Level 

`Low`

### Required Testing

`Smoke`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [X] Pulled down the PR and performed verification of at least being able to
build and run.

- [X] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [X] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [X] PR has a valid summary, and a good description.

