### PR TITLE
Added global settings for configurable suppressed databus events

### DIFF
--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Databus.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Databus.java
@@ -22,7 +22,7 @@ public interface Databus {
      * @param tableFilter - Filter based on table or tags
      * @param subscriptionTtl - Duration for the subscription to be alive
      * @param eventTtl - Duration for the events on the subscription to be alive before expiring
-     * @param ignoreSuppressedEvents - Ignore event marked as "re-etl". By default this is set to true
+     * @param ignoreSuppressedEvents - Ignore events identified as suppress-able by the databus. By default this is set to true
      */
     @Deprecated
     void subscribe(String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl, boolean ignoreSuppressedEvents);

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
@@ -46,6 +46,7 @@ import com.bazaarvoice.emodb.event.api.DedupEventStoreChannels;
 import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
 import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
+import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.ostrich.HostDiscovery;
 import com.codahale.metrics.MetricRegistry;
@@ -87,6 +88,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * <li> DataStore {@link DataProvider}
  * <li> DataStore {@link EventBus}
  * <li> DataStore {@link DataStoreConfiguration}
+ * <li> @{@link SuppressedEventCondition} Supplier&lt;{@link Condition}&gt;
  * </ul>
  * Exports the following:
  * <ul>

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/SuppressedEventCondition.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/SuppressedEventCondition.java
@@ -1,0 +1,22 @@
+package com.bazaarvoice.emodb.databus;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for identifying the condition for suppressing events on the databus when
+ * <code>ignoreSuppressedEvents</code> is enabled for a subscription.
+ *
+ * @see com.bazaarvoice.emodb.databus.api.Databus#subscribe(String, com.bazaarvoice.emodb.sor.condition.Condition, org.joda.time.Duration, org.joda.time.Duration, boolean)
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface SuppressedEventCondition {
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.databus.core;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.databus.ChannelNames;
+import com.bazaarvoice.emodb.databus.SuppressedEventCondition;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
@@ -101,15 +102,17 @@ public class DefaultDatabus implements Databus, Managed {
     private final Meter _discardedMeter;
     private final Meter _consolidatedMeter;
     private final LoadingCache<SizeCacheKey, Map.Entry<Long, Long>> _eventSizeCache;
+    private final Supplier<Condition> _suppressedEventCondition;
     private final Ticker _ticker;
 
     @Inject
     public DefaultDatabus(LifeCycleRegistry lifeCycle, EventBus eventBus, DataProvider dataProvider,
                           SubscriptionDAO subscriptionDao, DatabusEventStore eventStore,
                           SubscriptionEvaluator subscriptionEvaluator, JobService jobService,
-                          JobHandlerRegistry jobHandlerRegistry, MetricRegistry metricRegistry) {
+                          JobHandlerRegistry jobHandlerRegistry, MetricRegistry metricRegistry,
+                          @SuppressedEventCondition Supplier<Condition> suppressedEventCondition) {
         this(lifeCycle, eventBus, dataProvider, subscriptionDao, eventStore, subscriptionEvaluator, jobService,
-                jobHandlerRegistry, metricRegistry, Ticker.systemTicker());
+                jobHandlerRegistry, metricRegistry, suppressedEventCondition, Ticker.systemTicker());
     }
 
     @VisibleForTesting
@@ -117,13 +120,14 @@ public class DefaultDatabus implements Databus, Managed {
                           SubscriptionDAO subscriptionDao, DatabusEventStore eventStore,
                           SubscriptionEvaluator subscriptionEvaluator, JobService jobService,
                           JobHandlerRegistry jobHandlerRegistry, MetricRegistry metricRegistry,
-                          Ticker ticker) {
+                          Supplier<Condition> suppressedEventCondition, Ticker ticker) {
         _eventBus = eventBus;
         _subscriptionDao = subscriptionDao;
         _eventStore = eventStore;
         _dataProvider = dataProvider;
         _subscriptionEvaluator = subscriptionEvaluator;
         _jobService = jobService;
+        _suppressedEventCondition = suppressedEventCondition;
         _ticker = ticker;
         _peekedMeter = newEventMeter("peeked", metricRegistry);
         _polledMeter = newEventMeter("polled", metricRegistry);
@@ -295,9 +299,11 @@ public class DefaultDatabus implements Databus, Managed {
         checkArgument(eventTtl.isLongerThan(Duration.ZERO), "EventTtl must be >0");
         TableFilterValidator.checkAllowed(tableFilter);
         if (ignoreSuppressedEvents) {
-            // Skip databus events tagged with "ignore"
-            Condition skipIgnoreTags = Conditions.not(Conditions.mapBuilder().matches(UpdateRef.TAGS_NAME, Conditions.containsAny("re-etl")).build());
-            tableFilter = Conditions.and(tableFilter, skipIgnoreTags);
+            // If the suppressed event condition is set (that is, isn't "alwaysFalse()") then add it to the filter
+            Condition suppressedEventCondition = _suppressedEventCondition.get();
+            if (!Conditions.alwaysFalse().equals(suppressedEventCondition)) {
+                tableFilter = Conditions.and(tableFilter, Conditions.not(suppressedEventCondition));
+            }
         }
 
         // except for resetting the ttl, recreating a subscription that already exists has no effect.

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
@@ -15,12 +15,16 @@ import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
 import com.bazaarvoice.emodb.job.api.JobService;
+import com.bazaarvoice.emodb.sor.condition.Condition;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.emodb.table.db.ClusterInfo;
 import com.bazaarvoice.emodb.table.db.Placements;
 import com.bazaarvoice.emodb.table.db.consistency.DatabusClusterInfo;
 import com.bazaarvoice.ostrich.HostDiscovery;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.eventbus.EventBus;
@@ -102,6 +106,8 @@ public class DatabusModuleTest {
                         .toInstance(ImmutableList.of(new ClusterInfo("Test Cluster", "Test Metric Cluster")));
                 bind(JobService.class).toInstance(mock(JobService.class));
                 bind(JobHandlerRegistry.class).toInstance(mock(JobHandlerRegistry.class));
+                bind(new TypeLiteral<Supplier<Condition>>(){}).annotatedWith(SuppressedEventCondition.class)
+                        .toInstance(Suppliers.ofInstance(Conditions.alwaysFalse()));
 
                 MetricRegistry metricRegistry = new MetricRegistry();
                 bind(MetricRegistry.class).toInstance(metricRegistry);

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
@@ -11,9 +11,11 @@ import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
 import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.sor.api.Coordinate;
 import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.emodb.sor.core.UpdateRef;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -230,7 +232,8 @@ public class ConsolidationTest {
         JobService jobService = mock(JobService.class);
         JobHandlerRegistry jobHandlerRegistry = mock(JobHandlerRegistry.class);
         return new DefaultDatabus(lifeCycle, eventBus, dataProvider, subscriptionDao, eventStore, subscriptionEvaluator,
-                jobService, jobHandlerRegistry, new MetricRegistry(), ticker);
+                jobService, jobHandlerRegistry, new MetricRegistry(), Suppliers.ofInstance(Conditions.alwaysFalse()),
+                ticker);
     }
 
     private static EventData newEvent(final String id, String table, String key, UUID changeId) {

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusSizeCachingTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusSizeCachingTest.java
@@ -4,8 +4,10 @@ import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
 import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
 import com.bazaarvoice.emodb.job.api.JobService;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Suppliers;
 import com.google.common.base.Ticker;
 import com.google.common.eventbus.EventBus;
 import org.testng.annotations.Test;
@@ -48,7 +50,7 @@ public class DatabusSizeCachingTest {
         DefaultDatabus testDatabus = new DefaultDatabus(
                 mock(LifeCycleRegistry.class), mock(EventBus.class), mock(DataProvider.class), mock(SubscriptionDAO.class),
                 mockEventStore, mock(SubscriptionEvaluator.class), mock(JobService.class), mock(JobHandlerRegistry.class),
-                mock(MetricRegistry.class)) {
+                mock(MetricRegistry.class), Suppliers.ofInstance(Conditions.alwaysFalse())) {
             @Override
             protected Ticker getEventSizeCacheTicker() {
                 return ticker;

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
@@ -9,6 +9,8 @@ import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.emodb.sor.core.UpdateRef;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.eventbus.EventBus;
 import org.joda.time.Duration;
 import org.testng.annotations.Test;
@@ -27,11 +29,13 @@ public class DefaultDatabusTest {
         // This is just an interim setup to be backwards compatible. Soon we will deprecate the
         // ignoreSuppressedEvents flag.
 
+        Supplier<Condition> ignoreReEtl = Suppliers.ofInstance(
+                Conditions.mapBuilder().matches(UpdateRef.TAGS_NAME, Conditions.containsAny("re-etl")).build());
         SubscriptionDAO mockSubscriptionDao = mock(SubscriptionDAO.class);
         DefaultDatabus testDatabus = new DefaultDatabus(
                 mock(LifeCycleRegistry.class), mock(EventBus.class), mock(DataProvider.class), mockSubscriptionDao,
                 mock(DatabusEventStore.class), mock(SubscriptionEvaluator.class), mock(JobService.class),
-                mock(JobHandlerRegistry.class), mock(MetricRegistry.class));
+                mock(JobHandlerRegistry.class), mock(MetricRegistry.class), ignoreReEtl);
         Condition originalCondition = Conditions.alwaysTrue();
         testDatabus.subscribe("test-subscription", originalCondition, Duration.standardDays(7),
                 Duration.standardDays(7));

--- a/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
@@ -18,6 +18,7 @@ import com.bazaarvoice.emodb.databus.DatabusHostDiscovery;
 import com.bazaarvoice.emodb.databus.DatabusModule;
 import com.bazaarvoice.emodb.databus.DatabusZooKeeper;
 import com.bazaarvoice.emodb.databus.ReplicationKey;
+import com.bazaarvoice.emodb.databus.SuppressedEventCondition;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.DataCenterModule;
@@ -28,6 +29,8 @@ import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
 import com.bazaarvoice.emodb.sor.DataStoreModule;
 import com.bazaarvoice.emodb.sor.DataStoreZooKeeper;
 import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.condition.Condition;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.util.ZKNamespaces;
@@ -36,11 +39,14 @@ import com.bazaarvoice.ostrich.ServiceRegistry;
 import com.bazaarvoice.ostrich.discovery.zookeeper.ZooKeeperHostDiscovery;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheck;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import io.dropwizard.server.ServerFactory;
 import io.dropwizard.server.SimpleServerFactory;
@@ -135,6 +141,9 @@ public class CasDatabusTest {
 
                 bind(JobService.class).toInstance(mock(JobService.class));
                 bind(JobHandlerRegistry.class).toInstance(mock(JobHandlerRegistry.class));
+
+                bind(new TypeLiteral<Supplier<Condition>>(){}).annotatedWith(SuppressedEventCondition.class)
+                        .toInstance(Suppliers.ofInstance(Conditions.alwaysFalse()));
 
                 EmoServiceMode serviceMode = EmoServiceMode.STANDARD_ALL;
                 install(new SelfHostAndPortModule());

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <mavenVersion>3.1.1</mavenVersion>
-        <mavenPluginAnnotationsVersion>3.2</mavenPluginAnnotationsVersion>
-        <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
+        <mavenPluginAnnotationsVersion>3.3</mavenPluginAnnotationsVersion>
+        <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
     </properties>
 
     <dependencies>

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResource1.java
@@ -109,7 +109,7 @@ public class DatabusResource1 {
                                      @QueryParam ("ttl") @DefaultValue ("86400") SecondsParam subscriptionTtl,
                                      @QueryParam ("eventTtl") @DefaultValue ("86400") SecondsParam eventTtl,
                                      @QueryParam ("ignoreSuppressedEvents") BooleanParam ignoreSuppressedEventsParam) {
-        // By default, ignore events tagged with "re-etl"
+        // By default, ignore events identified as suppress-able by the databus
         boolean ignoreSuppressedEvents = ignoreSuppressedEventsParam == null ? true : ignoreSuppressedEventsParam.get();
         Condition tableFilter = Conditions.alwaysTrue();
         if (!conditionString.isEmpty()) {

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/DatabusSuppressedEventConditionAdminTask.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/DatabusSuppressedEventConditionAdminTask.java
@@ -1,0 +1,42 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
+import com.bazaarvoice.emodb.databus.SuppressedEventCondition;
+import com.bazaarvoice.emodb.sor.condition.Condition;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
+import com.bazaarvoice.emodb.sor.delta.deser.ParseException;
+import com.google.inject.Inject;
+
+/**
+ * Task for managing the condition used to suppress databus events when a subscription opts to ignore suppressed events.
+ *
+ * Examples:
+ *
+ * View the current condition:
+ * <code>
+ *     $ curl -XPOST "localhost:8081/tasks/databus-suppressed-event-condition"
+ * </code>
+ *
+ * Update the condition condition:
+ * <code>
+ *     $ curl -XPOST 'localhost:8081/tasks/databus-suppressed-event-condition?value=\{..,"~tags":contains("re-etl")\}'
+ * </code>
+ */
+public class DatabusSuppressedEventConditionAdminTask extends SettingAdminTask<Condition> {
+
+    @Inject
+    public DatabusSuppressedEventConditionAdminTask(@SuppressedEventCondition Setting<Condition> setting,
+                                                    TaskRegistry taskRegistry) {
+        super("databus-suppressed-event-condition", setting);
+        taskRegistry.addTask(this);
+    }
+
+    @Override
+    protected Condition toValue(String valueParam) throws InvalidValueException {
+        try {
+            return Conditions.fromString(valueParam);
+        } catch (ParseException e) {
+            throw new InvalidValueException(e.getMessage());
+        }
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/Setting.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/Setting.java
@@ -1,0 +1,47 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.google.common.base.Supplier;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface for a dynamic EmoDB setting.  Unlike system configuration which defines immutable attributes of the
+ * system a setting should affect system behavior but also be adjustable, usually through an administration task.
+ * Settings are system-wide and so affect all EmoDB instances in the cluster across all data centers, although there may
+ * be a propagation delay across data centers due to Cassandra replication and local caching of values.  Therefore,
+ * settings are best used under the following conditions:
+ *
+ * <ul>
+ *     <li>The setting represents a value which should be tunable on a live system without requiring a restart.
+ *     <li>The setting applies universally and is not data center specific.
+ *     <li>Changes to the setting are relatively infrequent and eventual propagation to remote data centers
+ *         is tolerable.
+ * </ul>
+ *
+ * For example, consider the possibility of using settings for a client throttling feature.  With this feature any
+ * client IP making too many requests would be throttled until it backs off to a reasonable request rate.  Storing the
+ * actual client IPs being throttled is a poor fit for a setting since they are typically localized to a data center
+ * and can change frequently based on an uncontrolled variable (client traffic).  Parameters affecting the
+ * <em>behavior</em> of client throttling, such as throttling limits and timeouts, may be good candidates for settings.
+ *
+ * Consumers who only need to read the setting's value should use the {@link Supplier} interface since this gives them
+ * read-only access to the current value.  Tasks responsible for changing a setting's value should use the
+ * {@link Setting} interface.
+ *
+ * @param <T> The setting's value type
+ */
+public interface Setting<T> extends Supplier<T> {
+
+    /**
+     * Returns the name of the setting.
+     * @return the name
+     */
+    String getName();
+
+    /**
+     * Updates the current value for the setting.  This updated value will available immediately in the local data
+     * center after the method returns; remote data centers will eventually see the updated value, typically in less
+     * than one minute.
+     */
+    void set(@Nullable T value);
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingAdminTask.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingAdminTask.java
@@ -1,0 +1,68 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+
+import java.io.PrintWriter;
+import java.util.Collection;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Base task for updating a setting.  Useful for tasks where a single setting should be viewable or mutable.
+ *
+ * By default, calling the task with no parameters displays the current value being used by this instance.
+ * Providing a single "value" parameter updates the setting to the provided value.
+ *
+ * @param <T> The value type for the setting used by this task.
+ */
+abstract public class SettingAdminTask<T> extends Task {
+
+    private final static String VALUE_PARAM = "value";
+
+    private final Setting<T> _setting;
+
+    protected SettingAdminTask(String name, Setting<T> setting) {
+        super(name);
+        _setting = checkNotNull(setting, "setting");
+    }
+
+    /**
+     * Converts a String value from the task parameter to a value.
+     * @param valueParam The String parameter value
+     * @return The setting value
+     * @throws InvalidValueException The parameter could to be converted to the correct type.
+     */
+    abstract protected T toValue(String valueParam) throws InvalidValueException;
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> params, PrintWriter out)
+            throws Exception {
+
+        T currentValue = _setting.get();
+        Collection<String> newValueParam = params.get(VALUE_PARAM);
+
+        if (newValueParam.isEmpty()) {
+            // Display current value
+            out.println(currentValue);
+        } else if (newValueParam.size() != 1) {
+            out.println("Only one \"value\" parameter can be provided");
+        } else {
+            // Update value
+            try {
+                T newValue = toValue(newValueParam.iterator().next());
+                _setting.set(newValue);
+                out.println("Prior value:   " + currentValue);
+                out.println("Updated value: " + newValue);
+            } catch (InvalidValueException e) {
+                out.println(e.getMessage());
+            }
+        }
+    }
+
+    protected static class InvalidValueException extends Exception {
+        public InvalidValueException(String message) {
+            super(message);
+        }
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/Settings.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/Settings.java
@@ -1,0 +1,46 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import java.util.Map;
+
+/**
+ * General interface for reading settings.  In order to create new settings use one of the <code>register</code>
+ * methods from {@link SettingsRegistry}, such as {@link SettingsRegistry#register(String, Class, Object)}.
+ *
+ * Typically the setting returned by the registry can be used throughout the system.  This interface is provided
+ * primarily for debugging purposes, such as dumping the values of all settings.
+ */
+public interface Settings {
+
+    /**
+     * Returns a setting previously registered using {@link SettingsRegistry#register(String, Class, Object)}
+     * with the same name and type.
+     *
+     * @param name The setting name
+     * @param clazz The setting's value type
+     * @param <T> The setting's value type
+     * @return The setting, or null if no matching setting was found
+     */
+    <T> Setting<T> getSetting(String name, Class<T> clazz);
+
+    /**
+     * Returns a setting previously registered using {@link SettingsRegistry#register(String, TypeReference, Object)}
+     * with the same name and type.
+     *
+     * @param name The setting name
+     * @param typeReference The setting's value type
+     * @param <T> The setting's value type
+     * @return The setting, or null if no matching setting was found
+     */
+    <T> Setting<T> getSetting(String name, TypeReference<T> typeReference);
+
+    /**
+     * Gets a copy of all registered settings' current values.  This map is a snapshot and is not backed by the actual
+     * settings.  Updates to the settings will not be reflected in the map and updating the map will not change
+     * any settings.
+     *
+     * @return A copy of the all registered setting's current values.
+     */
+    Map<String, Object> getAll();
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsManager.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsManager.java
@@ -1,0 +1,278 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.bazaarvoice.emodb.common.json.JsonHelper;
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.common.zookeeper.store.ValueStore;
+import com.bazaarvoice.emodb.common.zookeeper.store.ValueStoreListener;
+import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.api.ReadConsistency;
+import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.delta.Delta;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Objects;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.base.Ticker;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import io.dropwizard.lifecycle.Managed;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Implementations of {@link SettingsRegistry} and {@link Settings} that is backed by a system table.  Each
+ * registered setting is stored as a row in the table.  Values are cached for a set time (one minute by default)
+ * so reading the values from the returned settings typically do no incur a round trip to Cassandra.
+ */
+public class SettingsManager implements SettingsRegistry, Settings, Managed {
+
+    private final Logger _log = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Setting records written to the data store only have one attribute, which is a JSON representation of the
+     * setting's value.
+     */
+    private final String VALUE_ATTRIBUTE = "json";
+
+    /**
+     * Changes made in the local data center are propagated immediately using the <code>_lastUpdated</code>
+     * value store.  However, if the settings are changed in a remote data center then we do not receive active
+     * notification.  For this reason the settings are cached in memory for a limited amount of time before they
+     * must be re-fetched from source.
+     */
+    private final static Duration DEFAULT_CACHE_INVALIDATION_TIME = Duration.standardMinutes(1);
+
+    private final ValueStore<Long> _lastUpdated;
+    private final Map<String, SettingImpl> _availableSettings = Maps.newConcurrentMap();
+    private final LoadingCache<SettingImpl<?>, SettingValue<?>> _settingsCache;
+    private final DataStore _dataStore;
+    private final Supplier<String> _settingsTable;
+    private final String _settingsTablePlacement;
+    private final Ticker _ticker;
+    private ValueStoreListener _listener;
+
+    @Inject
+    public SettingsManager(ValueStore<Long> lastUpdated, DataStore dataStore, String settingsTable,
+                           String settingsTablePlacement, LifeCycleRegistry lifeCycleRegistry) {
+        this(lastUpdated, dataStore, settingsTable, settingsTablePlacement, lifeCycleRegistry,
+                DEFAULT_CACHE_INVALIDATION_TIME, Ticker.systemTicker());
+    }
+
+    public SettingsManager(ValueStore<Long> lastUpdated, DataStore dataStore, String settingsTable,
+                           String settingsTablePlacement, LifeCycleRegistry lifeCycleRegistry,
+                           Duration cacheInvalidationTime, Ticker ticker) {
+        _lastUpdated = lastUpdated;
+        _dataStore = dataStore;
+        _settingsTablePlacement = settingsTablePlacement;
+        _ticker = ticker;
+
+        _settingsTable = Suppliers.memoize(() -> {
+            // Create the settings table if it does not exist
+            if (!_dataStore.getTableExists(settingsTable)) {
+                _dataStore.createTable(
+                        settingsTable,
+                        new TableOptionsBuilder().setPlacement(_settingsTablePlacement).build(),
+                        ImmutableMap.<String, Object>of(),
+                        new AuditBuilder().setLocalHost().setComment("create settings table").build());
+            }
+            return settingsTable;
+        });
+
+        _settingsCache = CacheBuilder.newBuilder()
+                .ticker(ticker)
+                .expireAfterWrite(cacheInvalidationTime.getMillis(), TimeUnit.MILLISECONDS)
+                .build(new CacheLoader<SettingImpl<?>, SettingValue<?>>() {
+                    @Override
+                    public SettingValue<?> load(SettingImpl<?> setting) throws Exception {
+                        Map<String, Object> valueMap = _dataStore.get(_settingsTable.get(), setting.getName(), ReadConsistency.STRONG);
+                        if (Intrinsic.isDeleted(valueMap)) {
+                            return SettingValue.absent();
+                        }
+                        String rawValue = (String) valueMap.get(VALUE_ATTRIBUTE);
+                        return SettingValue.present(JsonHelper.fromJson(rawValue, setting.getTypeReference()));
+                    }
+                });
+
+        lifeCycleRegistry.manage(this);
+    }
+
+    @Override
+    public void start() throws Exception {
+        // Register a listener for locally-sourced settings updates to immediately invalidate the settings cache
+        _listener = _settingsCache::invalidateAll;
+        _lastUpdated.addListener(_listener);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        _lastUpdated.removeListener(_listener);
+    }
+
+    @Override
+    public <T> Setting<T> register(String name, Class<T> clazz, @Nullable T defaultValue) {
+        return register(name, asTypeReference(clazz), defaultValue);
+    }
+
+    @Override
+    public <T> Setting<T> register(String name, TypeReference<T> typeReference, @Nullable T defaultValue) {
+        checkNotNull(name, "name");
+        checkNotNull(typeReference, "typeReference");
+        SettingImpl<T> newSetting = new SettingImpl<>(name, typeReference, defaultValue);
+        SettingImpl<?> existingSetting = _availableSettings.putIfAbsent(name, newSetting);
+        if (existingSetting != null) {
+            checkState(existingSetting.metadataEquals(newSetting),
+                    "Setting %s already registered with incompatible parameters", name);
+            //noinspection unchecked
+            return (SettingImpl<T>) existingSetting;
+        }
+        return newSetting;
+    }
+
+    private void set(String setting, Object value) {
+        Delta delta =  Deltas.mapBuilder().put(VALUE_ATTRIBUTE, JsonHelper.asJson(value)).build();
+
+        // Write the delta to the store
+        _dataStore.update(_settingsTable.get(), setting, TimeUUIDs.newUUID(), delta,
+                new AuditBuilder().setLocalHost().setComment("Updated setting").build(), WriteConsistency.STRONG);
+
+        // Notify all nodes in the local cluster to refresh immediately; remote clusters will eventually see the update
+        try {
+            _lastUpdated.set(TimeUnit.NANOSECONDS.toMillis(_ticker.read()));
+        } catch (Exception e) {
+            // This local invalidation was optimistic; log that it failed but otherwise move on.  The local cluster
+            // will read the updated value eventually.
+            _log.warn("Failed to invalidated settings cache", e);
+        }
+    }
+
+    @Override
+    public <T> Setting<T> getSetting(String name, Class<T> clazz) {
+        return getSetting(name, asTypeReference(clazz));
+    }
+
+    @Override
+    public <T> Setting<T> getSetting(String name, TypeReference<T> typeReference) {
+        checkNotNull(name, "name");
+        checkNotNull(typeReference, "typeReference");
+        SettingImpl<?> setting = _availableSettings.get(name);
+        if (setting != null && setting.getTypeReference().getType().equals(typeReference.getType())) {
+            //noinspection unchecked
+            return (Setting<T>) setting;
+        }
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getAll() {
+        Map<String, Object> settings = Maps.newHashMap();
+        for (SettingImpl<?> setting : _availableSettings.values()) {
+            settings.put(setting.getName(), setting.get());
+        }
+        return settings;
+    }
+
+    private <T> TypeReference<T> asTypeReference(Class<T> clazz) {
+        checkNotNull(clazz, "class");
+        return new TypeReference<T>() {
+            @Override
+            public Type getType() {
+                return clazz;
+            }
+        };
+    }
+
+    private final class SettingImpl<T> implements Setting<T> {
+
+        private final String _name;
+        private final TypeReference<T> _typeReference;
+        private final T _defaultValue;
+
+        private SettingImpl(String name, TypeReference<T> typeReference, T defaultValue) {
+            _name = name;
+            _typeReference = typeReference;
+            _defaultValue = defaultValue;
+        }
+
+        @Override
+        public String getName() {
+            return _name;
+        }
+
+        private TypeReference<T> getTypeReference() {
+            return _typeReference;
+        }
+
+        @Override
+        public T get() {
+            //noinspection unchecked
+            SettingValue<T> value = (SettingValue<T>) _settingsCache.getUnchecked(this);
+            if (value.isPresent()) {
+                return value.getValue();
+            }
+            return _defaultValue;
+        }
+
+        @Override
+        public void set(@Nullable T value) {
+            SettingsManager.this.set(_name, value);
+        }
+
+        /**
+         * Returns true if the provided setting instance monitors the same exact setting as this instance.
+         * Practically the same as {@link Object#equals(Object)} but named differently to avoid confusion
+         * since this is comparing the metadata for the setting and not the setting's current value.
+         */
+        public boolean metadataEquals(SettingImpl<?> setting) {
+            return _name.equals(setting._name) &&
+                    _typeReference.getType().equals(setting._typeReference.getType()) &&
+                    Objects.equal(_defaultValue, setting._defaultValue);
+        }
+    }
+
+    /**
+     * Class similar to Optional except supports null values.
+     */
+    private final static class SettingValue<T> {
+        private final boolean _present;
+        private final T _value;
+
+        private static <T> SettingValue<T> absent() {
+            return new SettingValue<>(false, null);
+        }
+
+        private static <T> SettingValue<T> present(@Nullable T value) {
+            return new SettingValue<>(true, value);
+        }
+
+        private SettingValue(boolean present, T value) {
+            _present = present;
+            _value = value;
+        }
+
+        private boolean isPresent() {
+            return _present;
+        }
+
+        private T getValue() {
+            return _value;
+        }
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
@@ -1,0 +1,68 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.bazaarvoice.emodb.common.zookeeper.store.ValueStore;
+import com.bazaarvoice.emodb.common.zookeeper.store.ZkTimestampSerializer;
+import com.bazaarvoice.emodb.common.zookeeper.store.ZkValueStore;
+import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.google.inject.PrivateModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import org.apache.curator.framework.CuratorFramework;
+
+/**
+ * Guice module which configures globally accessible server settings.
+ *  * <p>
+ * Requires the following external references:
+ * <ul>
+ * <li> {@link DataStore}
+ * <li> {@link LifeCycleRegistry}
+ * <li> {@link DataStoreConfiguration}
+ * <li> @SettingsZooKeeper {@link CuratorFramework}
+ * </ul>
+ * Exports the following:
+ * <ul>
+ * <li> {@link SettingsRegistry}
+ * <li> {@link Settings}
+ * </ul>
+ */
+public class SettingsModule extends PrivateModule {
+
+    private final static String SETTINGS_TABLE = "__system:settings";
+
+    @Override
+    protected void configure() {
+        bind(SettingsRegistry.class).to(SettingsManager.class);
+        bind(Settings.class).to(SettingsManager.class);
+
+        expose(SettingsRegistry.class);
+        expose(Settings.class);
+    }
+
+    /**
+     * Returns the binding for the system table placement.  This implementation piggy-backs on the system table
+     * placement from the DataStore configuration.  This isn't optimal since it's violating separation of concerns,
+     * but until there is a globally accessible system table placement available for injection this will
+     * have to suffice.
+     */
+    @Provides @Singleton @SystemTablePlacement
+    String provideSystemTablePlacement(DataStoreConfiguration config) {
+        return config.getSystemTablePlacement();
+    }
+
+    @Provides @Singleton @Named("lastUpdatedStore")
+    ValueStore<Long> provideLastUpdatedValueStore(@SettingsZooKeeper CuratorFramework curator,
+                                                  LifeCycleRegistry lifeCycleRegistry) {
+        return lifeCycleRegistry.manage(new ZkValueStore<>(curator, "settings", new ZkTimestampSerializer()));
+    }
+
+    @Provides @Singleton
+    SettingsManager provideSettings(@Named("lastUpdatedStore") ValueStore<Long> lastUpdated,
+                             DataStore dataStore, @SystemTablePlacement String placement,
+                             LifeCycleRegistry lifeCycleRegistry) {
+        return new SettingsManager(lastUpdated, dataStore, SETTINGS_TABLE, placement, lifeCycleRegistry);
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsRegistry.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsRegistry.java
@@ -1,0 +1,33 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import javax.annotation.Nullable;
+
+/**
+ * Registers new settings for use throughout the system.  The actual behavior of each setting, such as
+ * value caching and propagation delay on update, is up to the implementation.
+ */
+public interface SettingsRegistry {
+
+    /**
+     * Registers a setting.  If the setting is already registered with the same parameters then the existing setting
+     * is returned.  If a setting is already registered with the same name but different type or default value
+     * then an exception is thrown.
+     *
+     * @param name The setting name
+     * @param clazz The setting type
+     * @param defaultValue The default value for the setting, or null if null should be returned if no value is set
+     * @param <T> The setting type
+     * @return The setting
+     */
+    <T> Setting<T> register(String name, Class<T> clazz, @Nullable T defaultValue);
+
+    /**
+     * Identical behavior to {@link #register(String, Class, Object)} with a type parameter that allows for generic
+     * types, such as <code>List&lt;String&gt;</code>.
+     *
+     * @see #register(String, Class, Object)
+     */
+    <T> Setting<T> register(String name, TypeReference<T> type, @Nullable T defaultValue);
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsZooKeeper.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsZooKeeper.java
@@ -1,0 +1,19 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for the ZooKeeper curator namespaced for system settings.
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface SettingsZooKeeper {
+}

--- a/web/src/test/java/com/bazaarvoice/emodb/web/settings/DatabusSuppressedEventConditionAdminTaskTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/settings/DatabusSuppressedEventConditionAdminTaskTest.java
@@ -1,0 +1,98 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
+import com.bazaarvoice.emodb.sor.condition.Condition;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
+import com.google.common.collect.ImmutableMultimap;
+import org.testng.annotations.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@SuppressWarnings("unchecked")
+public class DatabusSuppressedEventConditionAdminTaskTest {
+
+    @Test
+    public void testGetCurrentValue() throws Exception {
+        Setting<Condition> setting = mock(Setting.class);
+        when(setting.get()).thenReturn(Conditions.alwaysFalse());
+        TaskRegistry taskRegistry = mock(TaskRegistry.class);
+
+        DatabusSuppressedEventConditionAdminTask task = new DatabusSuppressedEventConditionAdminTask(setting, taskRegistry);
+
+        StringWriter out = new StringWriter();
+        ImmutableMultimap<String, String> params = ImmutableMultimap.of();
+        task.execute(params, new PrintWriter(out));
+
+        verify(taskRegistry).addTask(task);
+        verify(setting, never()).set(any(Condition.class));
+        assertEquals(out.toString(), "alwaysFalse()\n");
+    }
+
+    @Test
+    public void testUpdateValue() throws Exception {
+        Setting<Condition> setting = mock(Setting.class);
+        when(setting.get()).thenReturn(Conditions.alwaysFalse());
+        TaskRegistry taskRegistry = mock(TaskRegistry.class);
+
+        DatabusSuppressedEventConditionAdminTask task = new DatabusSuppressedEventConditionAdminTask(setting, taskRegistry);
+
+        StringWriter out = new StringWriter();
+        ImmutableMultimap<String, String> params = ImmutableMultimap.of("value", "{..,\"~tags\":contains(\"re-etl\")}");
+        task.execute(params, new PrintWriter(out));
+
+        verify(taskRegistry).addTask(task);
+        verify(setting).set(Conditions.mapBuilder().matches("~tags", Conditions.contains("re-etl")).build());
+
+        // Simplify result by collapsing whitespace
+        String actual = out.toString().replaceAll("\\s", " ").replaceAll("\\s{1,}", " ");
+        String expected = "Prior value: alwaysFalse() Updated value: {..,\"~tags\":contains(\"re-etl\")} ";
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testSetMultipleValuesFails() throws Exception {
+        Setting<Condition> setting = mock(Setting.class);
+        when(setting.get()).thenReturn(Conditions.alwaysFalse());
+        TaskRegistry taskRegistry = mock(TaskRegistry.class);
+
+        DatabusSuppressedEventConditionAdminTask task = new DatabusSuppressedEventConditionAdminTask(setting, taskRegistry);
+
+        StringWriter out = new StringWriter();
+        ImmutableMultimap<String, String> params = ImmutableMultimap.of(
+                "value", "{..,\"~tags\":contains(\"tag1\")}", "value", "{..,\"~tags\":contains(\"tag1\")}");
+
+        task.execute(params, new PrintWriter(out));
+
+        verify(taskRegistry).addTask(task);
+        // Setting should be un-changed
+        verify(setting, never()).set(any(Condition.class));
+        assertEquals(out.toString(), "Only one \"value\" parameter can be provided\n");
+    }
+
+    @Test
+    public void testInvalidConditionFails() throws Exception {
+        Setting<Condition> setting = mock(Setting.class);
+        when(setting.get()).thenReturn(Conditions.alwaysFalse());
+        TaskRegistry taskRegistry = mock(TaskRegistry.class);
+
+        DatabusSuppressedEventConditionAdminTask task = new DatabusSuppressedEventConditionAdminTask(setting, taskRegistry);
+
+        StringWriter out = new StringWriter();
+        ImmutableMultimap<String, String> params = ImmutableMultimap.of("value", "{..,\"typo\":here}");
+        task.execute(params, new PrintWriter(out));
+
+        verify(taskRegistry).addTask(task);
+        verify(setting, never()).set(any(Condition.class));
+        // Actual text of Condition parse error may vary in the future; make a minimal check for the expected error text
+        assertTrue(out.toString().startsWith("Expected a valid value"));
+    }
+}

--- a/web/src/test/java/com/bazaarvoice/emodb/web/settings/SettingsManagerTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/settings/SettingsManagerTest.java
@@ -1,0 +1,137 @@
+package com.bazaarvoice.emodb.web.settings;
+
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.common.zookeeper.store.ValueStore;
+import com.bazaarvoice.emodb.common.zookeeper.store.ValueStoreListener;
+import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Ticker;
+import org.joda.time.Duration;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
+
+public class SettingsManagerTest {
+
+    private final static long START_TIME_NS = 1472766259192000000L;
+
+    private DataStore _dataStore;
+    private ValueStore<Long> _lastUpdated;
+    private Ticker _ticker;
+    private SettingsManager _settingsManager;
+
+    @BeforeMethod
+    public void setUp() {
+        _dataStore = new InMemoryDataStore(new MetricRegistry());
+        _lastUpdated = mock(ValueStore.class);
+        _ticker = mock(Ticker.class);
+        when(_ticker.read()).thenReturn(START_TIME_NS);
+
+        _settingsManager = new SettingsManager(_lastUpdated, _dataStore, "__system:settings",
+                "app_global:sys", mock(LifeCycleRegistry.class), Duration.standardMinutes(1), _ticker);
+    }
+
+    @Test
+    public void testSetting() {
+        Setting<String> setting = _settingsManager.register("test1", String.class, "def");
+        assertEquals(setting.getName(), "test1");
+        assertEquals(setting.get(), "def");
+        // Default is not being read from data store
+        assertTrue(Intrinsic.isDeleted(_dataStore.get("__system:settings", "test1")));
+
+        // Update value
+        setting.set("newvalue");
+        // Need to advance time by 1 minute to enforce value returned is not cached
+        when(_ticker.read()).thenReturn(START_TIME_NS + TimeUnit.MINUTES.toNanos(1));
+        assertEquals(setting.get(), "newvalue");
+        assertEquals(_dataStore.get("__system:settings", "test1").get("json"), "\"newvalue\"");
+
+        // Verify setting exists in manager
+        assertSame(_settingsManager.getSetting("test1", String.class), setting);
+    }
+
+    @Test
+    public void testDoubleRegistration() {
+        Setting<String> setting = _settingsManager.register("test2", String.class, null);
+
+        // Re-register with same parameters
+        assertSame(_settingsManager.register("test2", String.class, null), setting);
+
+        // Re-register with different parameters
+        try {
+            _settingsManager.register("test2", Boolean.class, null);
+            fail("type changed");
+        } catch (IllegalStateException e) {
+            // Ok
+        }
+        try {
+            _settingsManager.register("test2", String.class, "uh-oh");
+            fail("Default changed");
+        } catch (IllegalStateException e) {
+            // OK
+        }
+    }
+
+    @Test
+    public void testCaching() {
+        Setting<String> setting = _settingsManager.register("test3", String.class, null);
+        assertNull(setting.get());
+
+        // Update the value in the backend without going through the settings API
+        _dataStore.update("__system:settings", "test3", TimeUUIDs.newUUID(),
+                Deltas.mapBuilder().put("json", "\"newvalue\"").build(),
+                new AuditBuilder().setComment("test").build());
+
+        for (int sec : new Integer[] {0, 1, 59, 60, 120}) {
+            when(_ticker.read()).thenReturn(START_TIME_NS + TimeUnit.SECONDS.toNanos(sec));
+            if (sec < 60) {
+                assertNull(setting.get());
+            } else {
+                assertEquals(setting.get(), "newvalue");
+            }
+        }
+    }
+
+    @Test
+    public void testUpdateNotification() throws Exception {
+        Setting<String> setting = _settingsManager.register("test4", String.class, null);
+        setting.set("foo");
+        verify(_lastUpdated).set(TimeUnit.NANOSECONDS.toMillis(START_TIME_NS));
+    }
+
+    @Test
+    public void testCacheInvalidation() throws Exception {
+        _settingsManager.start();
+        ArgumentCaptor<ValueStoreListener> captor = ArgumentCaptor.forClass(ValueStoreListener.class);
+        verify(_lastUpdated).addListener(captor.capture());
+
+        Setting<String> setting = _settingsManager.register("test5", String.class, null);
+        assertNull(setting.get());
+        // Change the value
+        setting.set("foo");
+        // Time hasn't advanced, so should still be null
+        assertNull(setting.get());
+
+        // Don't advance time, but call the value store listener
+        captor.getValue().valueChanged();
+
+        // Cache should have been invalidated, so new value is now returned
+        assertEquals(setting.get(), "foo");
+    }
+}


### PR DESCRIPTION
## Github Issue #

[26](https://github.com/bazaarvoice/emodb/issues/26)

## What Are We Doing Here?

Three changes:

* The condition for ignorable suppressed databus events is now configurable rather than hard-coded to `not({..,"~tags",contains("re-etl")})`.
* A new DW task was created for updating the condition.
* A re-usable settings-management system was created for storing and propagating the condition through the system.

## How to Test and Verify

1. Create a databus subscription:

   ```
   $ curl -s -XPUT -H "Content-Type: application/x.json-condition" 'http://localhost:8080/bus/1/test-sub?ignoreSuppressedEvents=true' --data-binary 'alwaysTrue()'
   {"success":true}
   ```
2. Assuming a clean system there should be not suppressable events configured:

   ```
   $ curl -s 'http://localhost:8080/bus/1/test-sub'
   {"name":"test-sub","tableFilter":"alwaysTrue()","expiresAt":"2016-09-03T15:47:51.146Z","eventTtl":86400000}
   ```
3. Change the global condition:

   ```
   $ curl -XPOST 'localhost:8081/tasks/databus-suppressed-event-condition?value=\{..,"~tags":containsAny("ignore")\}'
   Prior value:   alwaysFalse()
   Updated value: {..,"~tags":contains("ignore")}
   ```
4. Renew the subscription; it should now contain the suppressed condition:

   ```
   $ curl -s -XPUT -H "Content-Type: application/x.json-condition" 'http://localhost:8080/bus/1/test-sub?ignoreSuppressedEvents=true' --data-binary 'alwaysTrue()'
   {"success":true}
   $curl -s 'http://localhost:8080/bus/1/test-sub'
   {"name":"test-sub","tableFilter":"and(alwaysTrue(),not({..,\"~tags\":contains(\"ignore\")}))","expiresAt":"2016-09-03T15:53:38.180Z","eventTtl":86400000}
    ```

## Risk

Fairly low; the area of the system affected is very localized, and the more complicated code around inserting the suppressed event condition was already in place.

### Level 

Medium

### Required Testing

Manual

### Risk Summary

This change doesn't really add many new risks.  The largest is the uncertainty due to natural delays.  Cross-data-center replication of the setting may take up to a minute, longer if there is a break in the
Cassandra replication.  Additionally, the ignored events are only updated per-subscription at renew time.  So, for example, if a subscription only renews once every four hours then updating the suppressed event condition immediately may take up to four hours to go into effect for that subscription.  Not really a bug, just something to keep in mind when changing the condition; the administrator probably wants to make the update with ample lead time before anyone floods the system with events that should be suppressed.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.

