### PR TITLE
ability to run start-local.sh from any dir

### DIFF
--- a/yum/start-local.sh
+++ b/yum/start-local.sh
@@ -21,4 +21,15 @@
 # java -jar bin/emodb-web.jar server conf/config-local.yaml conf/config-ddl-local.yaml
 #
 
+#traverse all links to arrive at the real directory of the script.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+pushd $DIR
 java -jar bin/emodb-web-local-*.jar server conf/config-local.yaml conf/config-ddl-local.yaml conf/cassandra.yaml -z
+popd


### PR DESCRIPTION
## Github Issue #

[29](https://github.com/bazaarvoice/emodb/issues/29)

## What Are We Doing Here?

Just a quick fix to let you run the start-local.sh script from any directory, even through symlinks.

## How to Test and Verify

1. check out my PR
2. run start-local.sh from any other directory (it should start Emo)
3. create a symlink to start-local.sh and run it via the symlink (this should also work)
4. might as well also run it from the actual repo directory just to make sure that there's no regression

## Risk

### Level 

Low 

### Required Testing

Your call. I'd say manual is enough.

### Risk Summary

Well, if we break the script, no one will be able to run emo locally. On the other hand, it'll be really easy to test. I have used this recipe before on both Linux and Mac.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [X] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [X] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [X] PR has a valid summary, and a good description.

