### PR TITLE
Added "~lastMutateAt" intrinsic

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ See [Security Management] (https://github.com/bazaarvoice/emodb/blob/master/mark
           "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
           "~id": "demo1",
           "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+          "~lastMutateAt": "2012-06-22T20:12:09.679Z",
           "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1",
           "~table": "review:testcustomer",
           "~version": 2,
@@ -193,6 +194,7 @@ See [Security Management] (https://github.com/bazaarvoice/emodb/blob/master/mark
             "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
             "~id": "demo1",
             "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+            "~lastMutateAt": "2012-06-22T20:12:09.679Z",
             "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1",
             "~table": "review:testcustomer",
             "~version": 2,
@@ -214,8 +216,9 @@ See [Security Management] (https://github.com/bazaarvoice/emodb/blob/master/mark
           {
             "eventKey":"e9f5b640-caf8-11e1-96fe-0013e8cdbb13#review:testcustomer#demo1",
             "content":{
-              "~deleted":false,"~lastUpdateAt":"2012-07-11T01:37:02.372Z","~id":"demo1",
-              "~lastUpdateAt":"2012-07-11T01:37:13.351Z","~table":"review:testcustomer",
+              "~deleted":false,"~firstUpdateAt":"2012-07-11T01:37:02.372Z","~id":"demo1",
+              "~lastUpdateAt":"2012-07-11T01:37:13.351Z","~lastMutateAt":"2012-07-11T01:37:13.351Z",
+              "~table":"review:testcustomer",
               "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1","~version":2,
               "author":"Bob","client":"TestCustomer","rating":5,
               "status":"APPROVED", "title":"Best Ever!","type":"review"

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/TableFilterIntrinsics.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/TableFilterIntrinsics.java
@@ -42,6 +42,11 @@ class TableFilterIntrinsics implements Intrinsics {
     }
 
     @Override
+    public String getLastMutateAt() {
+        throw new UnsupportedOperationException(Intrinsic.LAST_MUTATE_AT);
+    }
+
+    @Override
     public String getTablePlacement() {
         return _table.getOptions().getPlacement();
     }

--- a/docs/_posts/2014-08-07-quickstart.md
+++ b/docs/_posts/2014-08-07-quickstart.md
@@ -107,6 +107,7 @@ The following examples assume you have [jq](https://stedolan.github.io/jq/) or a
           "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
           "~id": "demo1",
           "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+          "~lastMutateAt": "2012-06-22T20:12:09.679Z",
           "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1",
           "~table": "review:testcustomer",
           "~version": 2,
@@ -127,6 +128,7 @@ The following examples assume you have [jq](https://stedolan.github.io/jq/) or a
             "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
             "~id": "demo1",
             "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+            "~lastMutateAt": "2012-06-22T20:12:09.679Z",
             "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1",
             "~table": "review:testcustomer",
             "~version": 2,
@@ -148,8 +150,9 @@ The following examples assume you have [jq](https://stedolan.github.io/jq/) or a
           {
             "eventKey":"e9f5b640-caf8-11e1-96fe-0013e8cdbb13#review:testcustomer#demo1",
             "content":{
-              "~deleted":false,"~lastUpdateAt":"2012-07-11T01:37:02.372Z","~id":"demo1",
-              "~lastUpdateAt":"2012-07-11T01:37:13.351Z","~table":"review:testcustomer",
+              "~deleted":false,"~firstUpdateAt":"2012-07-11T01:37:02.372Z","~id":"demo1",
+              "~lastUpdateAt":"2012-07-11T01:37:13.351Z","~lastMutateAt":"2012-07-11T01:37:13.351Z",
+              "~table":"review:testcustomer",
               "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1","~version":2,
               "author":"Bob","client":"TestCustomer","rating":5,
               "status":"APPROVED", "title":"Best Ever!","type":"review"

--- a/docs/_posts/2014-08-31-sor.markdown
+++ b/docs/_posts/2014-08-31-sor.markdown
@@ -477,6 +477,7 @@ Example:
       "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
       "~id": "demo1",
       "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+      "~lastMutateAt": "2012-06-22T20:12:09.679Z",
       "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1",
       "~table": "review:testcustomer",
       "~version": 2,
@@ -522,6 +523,7 @@ Example:
       "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
       "~id": "demo1",
       "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+      "~lastMutateAt": "2012-06-22T20:12:09.679Z",
       "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1",
       "~table": "review:testcustomer",
       "~version": 2,
@@ -537,6 +539,7 @@ Example:
       "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
       "~id": "demo2",
       "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+      "~lastMutateAt": "2012-06-22T20:12:09.679Z",
       "~signature": "96976f792cc1a52ebf39e8962f6a24d0",
       "~table": "review:testcustomer",
       "~version": 2,
@@ -646,6 +649,7 @@ Example:
         "~deleted": false,
         "~firstUpdateAt": "2012-07-30T21:33:28.908Z",
         "~lastUpdateAt": "2012-07-30T21:33:33.194Z"
+        "~lastMutateAt": "2012-07-30T21:33:33.194Z"
       }
     ]
 

--- a/docs/_posts/2016-08-29-deltas.md
+++ b/docs/_posts/2016-08-29-deltas.md
@@ -128,6 +128,13 @@ fields to every object:
     and `t3` and data center B writes update `t2`, a reader in data center A may read one version of the object
     consisting of `[t1, t3]` then later read a second version of the object consisting of `[t1, t2, t3]`.  Both
     versions will have the same `~lastUpdateAt`, but they will have different values of `~version` and `~signature`.
+*   `~lastMutateAt` - An ISO 8601-format timestamp string extracted from the time UUID of the last delta written to the
+    object which changed the document content (excluding intrinsics).  For example, if the latest delta is
+    `{..,"available":true}` and the prior state of the document already contained the value "available" set to `true`
+    then the `~lastUpdateAt` would be updated but the `~lastMutateAt` would retain the timestamp from the previous
+    delta.  For the same reasons as `~lastUpdateAt` `~lastMutateAt` is also unreliable for comparing object
+    versions.  In fact, under the right circumstances replication delays between data centers can actually cause
+    the `~lastMutateAt` value to move backwards if the same updates are applied in each data center.
 *   Plus all map entries specified in the table template when the System of Record table was created.
 
 The Java System of Record API accepts the following as JSON objects:

--- a/docs/_posts/2016-08-31-mapreduce.md
+++ b/docs/_posts/2016-08-31-mapreduce.md
@@ -211,6 +211,7 @@ CREATE FUNCTION emo_table AS 'com.bazaarvoice.emodb.hive.udf.EmoTable';
 CREATE FUNCTION emo_coordinate AS 'com.bazaarvoice.emodb.hive.udf.EmoCoordinate';
 CREATE FUNCTION emo_first_update_at AS 'com.bazaarvoice.emodb.hive.udf.EmoFirstUpdateAt';
 CREATE FUNCTION emo_last_update_at AS 'com.bazaarvoice.emodb.hive.udf.EmoLastUpdateAt';
+CREATE FUNCTION emo_last_mutate_at AS 'com.bazaarvoice.emodb.hive.udf.EmoLastMutateAt';
 CREATE FUNCTION emo_text AS 'com.bazaarvoice.emodb.hive.udf.EmoText';
 CREATE FUNCTION emo_boolean AS 'com.bazaarvoice.emodb.hive.udf.EmoBoolean';
 CREATE FUNCTION emo_int AS 'com.bazaarvoice.emodb.hive.udf.EmoInt';

--- a/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/json/IntrinsicsOnly.java
+++ b/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/json/IntrinsicsOnly.java
@@ -24,4 +24,6 @@ public class IntrinsicsOnly {
     public Date firstUpdateAt;
     @JsonProperty (Intrinsic.LAST_UPDATE_AT)
     public Date lastUpdateAt;
+    @JsonProperty (Intrinsic.LAST_MUTATE_AT)
+    public Date lastMutateAt;
 }

--- a/mapreduce/sor-hive/src/main/java/com/bazaarvoice/emodb/hive/udf/EmoFunctions.java
+++ b/mapreduce/sor-hive/src/main/java/com/bazaarvoice/emodb/hive/udf/EmoFunctions.java
@@ -16,6 +16,7 @@ public class EmoFunctions {
                     .put("emo_coordinate", EmoCoordinate.class)
                     .put("emo_first_update_at", EmoFirstUpdateAt.class)
                     .put("emo_last_update_at", EmoLastUpdateAt.class)
+                    .put("emo_last_mutate_at", EmoLastMutateAt.class)
                     .put("emo_text", EmoText.class)
                     .put("emo_boolean", EmoBoolean.class)
                     .put("emo_int", EmoInt.class)

--- a/mapreduce/sor-hive/src/main/java/com/bazaarvoice/emodb/hive/udf/EmoLastMutateAt.java
+++ b/mapreduce/sor-hive/src/main/java/com/bazaarvoice/emodb/hive/udf/EmoLastMutateAt.java
@@ -1,0 +1,26 @@
+package com.bazaarvoice.emodb.hive.udf;
+
+
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.fasterxml.jackson.core.JsonParser;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.udf.UDFType;
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import org.apache.hadoop.io.Text;
+
+import java.io.IOException;
+
+@UDFType (deterministic = true)
+@Description (name = "emo_last_mutate_at", value = "Gets the last mutate at timestamp from an EmoDB entry JSON")
+public class EmoLastMutateAt extends AbstractEmoFieldUDF<TimestampWritable> {
+
+    public TimestampWritable evaluate(final Text json) {
+        return evaluateAndNarrow(json, Intrinsic.LAST_MUTATE_AT);
+    }
+
+    @Override
+    protected TimestampWritable narrow(JsonParser parser)
+            throws IOException {
+        return narrowToTimestamp(parser);
+    }
+}

--- a/markdowns/Deltas.md
+++ b/markdowns/Deltas.md
@@ -119,6 +119,13 @@ fields to every object:
     and `t3` and data center B writes update `t2`, a reader in data center A may read one version of the object
     consisting of `[t1, t3]` then later read a second version of the object consisting of `[t1, t2, t3]`.  Both
     versions will have the same `~lastUpdateAt`, but they will have different values of `~version` and `~signature`.
+*   `~lastMutateAt` - An ISO 8601-format timestamp string extracted from the time UUID of the last delta written to the
+    object which changed the document content (excluding intrinsics).  For example, if the latest delta is
+    `{..,"available":true}` and the prior state of the document already contained the value "available" set to `true`
+    then the `~lastUpdateAt` would be updated but the `~lastMutateAt` would retain the timestamp from the previous
+    delta.  For the same reasons as `~lastUpdateAt` `~lastMutateAt` is also unreliable for comparing object
+    versions.  In fact, under the right circumstances replication delays between data centers can actually cause
+    the `~lastMutateAt` value to move backwards if the same updates are applied in each data center.
 *   Plus all map entries specified in the table template when the System of Record table was created.
 
 The Java System of Record API accepts the following as JSON objects:

--- a/markdowns/MapReduce.md
+++ b/markdowns/MapReduce.md
@@ -202,6 +202,7 @@ CREATE FUNCTION emo_table AS 'com.bazaarvoice.emodb.hive.udf.EmoTable';
 CREATE FUNCTION emo_coordinate AS 'com.bazaarvoice.emodb.hive.udf.EmoCoordinate';
 CREATE FUNCTION emo_first_update_at AS 'com.bazaarvoice.emodb.hive.udf.EmoFirstUpdateAt';
 CREATE FUNCTION emo_last_update_at AS 'com.bazaarvoice.emodb.hive.udf.EmoLastUpdateAt';
+CREATE FUNCTION emo_last_mutate_at AS 'com.bazaarvoice.emodb.hive.udf.EmoLastMutateAt';
 CREATE FUNCTION emo_text AS 'com.bazaarvoice.emodb.hive.udf.EmoText';
 CREATE FUNCTION emo_boolean AS 'com.bazaarvoice.emodb.hive.udf.EmoBoolean';
 CREATE FUNCTION emo_int AS 'com.bazaarvoice.emodb.hive.udf.EmoInt';

--- a/markdowns/SystemOfRecordApi.md
+++ b/markdowns/SystemOfRecordApi.md
@@ -448,6 +448,7 @@ Example:
       "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
       "~id": "demo1",
       "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+      "~lastMutateAt": "2012-06-22T20:12:09.679Z",
       "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1",
       "~table": "review:testcustomer",
       "~version": 2,
@@ -489,6 +490,7 @@ Example:
       "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
       "~id": "demo1",
       "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+      "~lastMutateAt": "2012-06-22T20:12:09.679Z",
       "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1",
       "~table": "review:testcustomer",
       "~version": 2,
@@ -504,6 +506,7 @@ Example:
       "~firstUpdateAt": "2012-06-22T20:11:53.473Z",
       "~id": "demo1",
       "~lastUpdateAt": "2012-06-22T20:12:09.679Z",
+      "~lastMutateAt": "2012-06-22T20:12:09.679Z",
       "~signature": "7db2ef78f7830acaaa53f242a5e5ffa1",
       "~table": "review:testcustomer",
       "~version": 2,
@@ -608,6 +611,7 @@ Example:
         "~deleted": false,
         "~firstUpdateAt": "2012-07-30T21:33:28.908Z",
         "~lastUpdateAt": "2012-07-30T21:33:33.194Z"
+        "~lastMutateAt": "2012-07-30T21:33:33.194Z"
       }
     ]
 

--- a/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
@@ -229,6 +229,7 @@ public class CasDataStoreTest {
                 put("~signature", Intrinsic.getSignature(content1)).
                 put("~firstUpdateAt", content1.get(Intrinsic.FIRST_UPDATE_AT)).
                 put("~lastUpdateAt", content1.get(Intrinsic.LAST_UPDATE_AT)).
+                put("~lastMutateAt", content1.get(Intrinsic.LAST_MUTATE_AT)).
                 put("name", "Bob").
                 put("state", "APPROVED").
                 build();
@@ -247,6 +248,7 @@ public class CasDataStoreTest {
                 put("~signature", Intrinsic.getSignature(content2)).
                 put("~firstUpdateAt", content2.get(Intrinsic.FIRST_UPDATE_AT)).
                 put("~lastUpdateAt", content2.get(Intrinsic.LAST_UPDATE_AT)).
+                put("~lastMutateAt", content2.get(Intrinsic.LAST_MUTATE_AT)).
                 put("name", "Joe").
                 build());
 
@@ -270,6 +272,7 @@ public class CasDataStoreTest {
                 put("~signature", Intrinsic.getSignature(content4)).
                 put("~firstUpdateAt", content4.get(Intrinsic.FIRST_UPDATE_AT)).
                 put("~lastUpdateAt", content4.get(Intrinsic.LAST_UPDATE_AT)).
+                put("~lastMutateAt", content4.get(Intrinsic.LAST_MUTATE_AT)).
                 put("name", "Alice").
                 put("state", "APPROVED").
                 put("delta1", "value1").
@@ -310,6 +313,7 @@ public class CasDataStoreTest {
                 put("~signature", Intrinsic.getSignature(content2Deleted)).
                 put("~firstUpdateAt", content2.get(Intrinsic.FIRST_UPDATE_AT)).
                 put("~lastUpdateAt", content2Deleted.get(Intrinsic.LAST_UPDATE_AT)).
+                put("~lastMutateAt", content2Deleted.get(Intrinsic.LAST_MUTATE_AT)).
                 build();
         assertEquals(content2Deleted, content2DeletedExpected);
         assertTrue((Intrinsic.getLastUpdateAt(content2Deleted)).compareTo(Intrinsic.getLastUpdateAt(content2)) >= 0);

--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -861,7 +861,7 @@ public class DataStoreJerseyTest extends ResourceTest {
         List<Change> expected = ImmutableList.of(
                 new ChangeBuilder(TimeUUIDs.newUUID())
                         .with(Deltas.literal("hello world"))
-                        .with(new Compaction(5, TimeUUIDs.newUUID(), TimeUUIDs.newUUID(), "1234567890abcdef", null))
+                        .with(new Compaction(5, TimeUUIDs.newUUID(), TimeUUIDs.newUUID(), "1234567890abcdef", null, null))
                         .build());
         when(_server.getTimeline("table-name", "row-key", true, false, null, null, true, 10, ReadConsistency.STRONG))
                 .thenReturn(expected.iterator());

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Compaction.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Compaction.java
@@ -46,7 +46,11 @@ public final class Compaction {
     /**
      * Like {@link #_lastContentMutation} except this is the UUID of the most consistent delta which changed the
      * resolved object or its metadata (namely, the event tags).  Any delta between this and the cutoff do not need to
-     * be posted to the databus because they are redundant to the subscriber.
+     * be posted to the databus because they are redundant to the subscriber.  For example, assume an update is made
+     * at time t1 with tags ["alpha"].  Later, at time t2 a no-op update <code>..</code> is made with tags ["beta"].
+     * This second update would change <code>_lastMutation</code> but not <code>_lastContentMutation</code>.  Finally,
+     * a third no-op delta at time t3 with the same tags as the previous update, ["beta"], would change neither
+     * <code>_lastMutation</code> nor <code>_lastContentMutation</code>.
      */
     private final UUID _lastMutation;
 

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Compaction.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Compaction.java
@@ -38,8 +38,15 @@ public final class Compaction {
     private Set<String> _lastTags;
 
     /**
-     * UUID of the most recent consistent delta which changed the resolved object deleted by compaction.
-     * Any delta between this and the cutoff are redundant.
+     * UUID of the most recent consistent delta which changed the resolved object deleted by compaction.  Any delta
+     * between this and the cutoff resolve to the same content, excluding intrinsics such as version and signature.
+     */
+     private final UUID _lastContentMutation;
+
+    /**
+     * Like {@link #_lastContentMutation} except this is the UUID of the most consistent delta which changed the
+     * resolved object or its metadata (namely, the event tags).  Any delta between this and the cutoff do not need to
+     * be posted to the databus because they are redundant to the subscriber.
      */
     private final UUID _lastMutation;
 
@@ -47,16 +54,19 @@ public final class Compaction {
                       @Nullable UUID first,
                       @Nullable UUID cutoff,
                       @Nullable String cutoffSignature,
+                      @Nullable UUID lastContentMutation,
                       @Nullable UUID lastMutation) {
-        this(count, first, cutoff, cutoffSignature, lastMutation, null, null);
+        this(count, first, cutoff, cutoffSignature, lastContentMutation, lastMutation, null, null);
     }
 
     public Compaction(long count,
                       @Nullable UUID first,
                       @Nullable UUID cutoff,
                       @Nullable String cutoffSignature,
-                      @Nullable UUID lastMutation, Delta compactedDelta) {
-        this(count, first, cutoff, cutoffSignature, lastMutation, compactedDelta, null);
+                      @Nullable UUID lastContentMutation,
+                      @Nullable UUID lastMutation,
+                      Delta compactedDelta) {
+        this(count, first, cutoff, cutoffSignature, lastContentMutation, lastMutation, compactedDelta, null);
     }
 
     @JsonCreator
@@ -64,6 +74,7 @@ public final class Compaction {
                       @JsonProperty("first") @Nullable UUID first,
                       @JsonProperty("cutoff") @Nullable UUID cutoff,
                       @JsonProperty("cutoffSignature") @Nullable String cutoffSignature,
+                      @JsonProperty("lastContentMutation") @Nullable UUID lastContentMutation,
                       @JsonProperty("lastMutation") @Nullable UUID lastMutation,
                       @JsonProperty("compactedDelta") @Nullable Delta compactedDelta,
                       @JsonProperty("lastTags") @Nullable Set<String> lastTags) {
@@ -74,6 +85,9 @@ public final class Compaction {
         _first = first;
         _cutoff = cutoff;
         _cutoffSignature = cutoffSignature;
+        // For historical reasons there may exist grandfathered-in compactions where the last mutation was recorded
+        // but not the last content mutation.  In these cases substitute the last mutation if available
+        _lastContentMutation = lastContentMutation != null ? lastContentMutation : lastMutation;
         _lastMutation = lastMutation;
         _compactedDelta = compactedDelta;
         _lastTags = lastTags == null ? ImmutableSet.<String>of() : lastTags;
@@ -86,6 +100,10 @@ public final class Compaction {
 
     public UUID getFirst() {
         return _first;
+    }
+
+    public UUID getLastContentMutation() {
+        return _lastContentMutation;
     }
 
     public UUID getLastMutation() {
@@ -129,11 +147,12 @@ public final class Compaction {
                 Objects.equal(_first, that.getFirst()) &&
                 Objects.equal(_cutoff, that.getCutoff()) &&
                 Objects.equal(_cutoffSignature, that.getCutoffSignature()) &&
-                Objects.equal(_lastMutation, that.getLastMutation());
+                Objects.equal(_lastMutation, that.getLastMutation()) &&
+                Objects.equal(_lastContentMutation, that.getLastContentMutation());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_count, _first, _cutoff, _cutoffSignature, _lastMutation);
+        return Objects.hashCode(_count, _first, _cutoff, _cutoffSignature, _lastMutation, _lastContentMutation);
     }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Intrinsic.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Intrinsic.java
@@ -19,10 +19,12 @@ public abstract class Intrinsic {
     public static final String DELETED = "~deleted";
     public static final String FIRST_UPDATE_AT = "~firstUpdateAt";
     public static final String LAST_UPDATE_AT = "~lastUpdateAt";
+    public static final String LAST_MUTATE_AT = "~lastMutateAt";
     public static final String PLACEMENT = "~placement";
 
     public static final Set<String> DATA_FIELDS =
-            ImmutableSet.of(ID, TABLE, VERSION, SIGNATURE, DELETED, FIRST_UPDATE_AT, LAST_UPDATE_AT, PLACEMENT);
+            ImmutableSet.of(ID, TABLE, VERSION, SIGNATURE, DELETED, FIRST_UPDATE_AT, LAST_UPDATE_AT,
+                    LAST_MUTATE_AT, PLACEMENT);
 
     // Audit Fields
 
@@ -61,4 +63,9 @@ public abstract class Intrinsic {
     public static Date getLastUpdateAt(Map<String, ?> content) {
         return JsonHelper.parseTimestamp((String) content.get(LAST_UPDATE_AT));
     }
+
+    public static Date getLastMutateAt(Map<String, ?> content) {
+        return JsonHelper.parseTimestamp((String) content.get(LAST_MUTATE_AT));
+    }
+
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluator.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluator.java
@@ -82,6 +82,8 @@ public class ConditionEvaluator implements ConditionVisitor<Object, Boolean> {
             return intrinsics.getFirstUpdateAt();
         } else if (Intrinsic.LAST_UPDATE_AT.equals(name)) {
             return intrinsics.getLastUpdateAt();
+        } else if (Intrinsic.LAST_MUTATE_AT.equals(name)) {
+            return intrinsics.getLastMutateAt();
         } else if (Intrinsic.PLACEMENT.equals(name)) {
             return intrinsics.getTablePlacement();
         } else {

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/eval/Intrinsics.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/eval/Intrinsics.java
@@ -14,5 +14,7 @@ public interface Intrinsics {
 
     String getLastUpdateAt();
 
+    String getLastMutateAt();
+
     String getTablePlacement();
 }

--- a/sor-api/src/test/java/com/bazaarvoice/emodb/sor/api/ChangeJsonTest.java
+++ b/sor-api/src/test/java/com/bazaarvoice/emodb/sor/api/ChangeJsonTest.java
@@ -53,7 +53,7 @@ public class ChangeJsonTest {
         UUID first = TimeUUIDs.newUUID();
         UUID cutoff = TimeUUIDs.newUUID();
         String cutoffSignature = "00000000000000000000000000000000";
-        Compaction compaction = new Compaction(3, first, cutoff, cutoffSignature, cutoff);
+        Compaction compaction = new Compaction(3, first, cutoff, cutoffSignature, cutoff, cutoff);
         Change expected = new ChangeBuilder(changeId).with(delta).with(compaction).build();
 
         SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZZ");
@@ -64,7 +64,7 @@ public class ChangeJsonTest {
                 "\"timestamp\":\"" + dateFmt.format(TimeUUIDs.getDate(changeId)) + "\"," +
                 "\"id\":\"" + changeId + "\"," +
                 "\"delta\":\"{\\\"name\\\":\\\"Bob\\\",\\\"state\\\":\\\"SUBMITTED\\\"}\"," +
-                "\"compaction\":{\"count\":3,\"first\":\"" + first + "\",\"cutoff\":\"" + cutoff + "\",\"cutoffSignature\":\"00000000000000000000000000000000\",\"lastMutation\":\"" + cutoff + "\",\"lastTags\":[]}," +
+                "\"compaction\":{\"count\":3,\"first\":\"" + first + "\",\"cutoff\":\"" + cutoff + "\",\"cutoffSignature\":\"00000000000000000000000000000000\",\"lastContentMutation\":\"" + cutoff + "\",\"lastMutation\":\"" + cutoff + "\",\"lastTags\":[]}," +
                 "\"tags\":[]}");
 
         Change actual = JsonHelper.fromJson(string, Change.class);
@@ -79,7 +79,7 @@ public class ChangeJsonTest {
         UUID first = TimeUUIDs.newUUID();
         UUID cutoff = TimeUUIDs.newUUID();
         String cutoffSignature = "00000000000000000000000000000000";
-        Compaction compaction = new Compaction(3, first, cutoff, cutoffSignature, cutoff, delta);
+        Compaction compaction = new Compaction(3, first, cutoff, cutoffSignature, cutoff, cutoff, delta);
         Change expected = new ChangeBuilder(changeId).with(delta).with(compaction).build();
 
         SimpleDateFormat dateFmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZZ");
@@ -90,7 +90,7 @@ public class ChangeJsonTest {
                 "\"timestamp\":\"" + dateFmt.format(TimeUUIDs.getDate(changeId)) + "\"," +
                 "\"id\":\"" + changeId + "\"," +
                 "\"delta\":\"{\\\"name\\\":\\\"Bob\\\",\\\"state\\\":\\\"SUBMITTED\\\"}\"," +
-                "\"compaction\":{\"count\":3,\"first\":\"" + first + "\",\"cutoff\":\"" + cutoff + "\",\"cutoffSignature\":\"00000000000000000000000000000000\",\"lastMutation\":\"" + cutoff + "\",\"compactedDelta\":\"{\\\"name\\\":\\\"Bob\\\",\\\"state\\\":\\\"SUBMITTED\\\"}\",\"lastTags\":[]}," +
+                "\"compaction\":{\"count\":3,\"first\":\"" + first + "\",\"cutoff\":\"" + cutoff + "\",\"cutoffSignature\":\"00000000000000000000000000000000\",\"lastContentMutation\":\"" + cutoff + "\",\"lastMutation\":\"" + cutoff + "\",\"compactedDelta\":\"{\\\"name\\\":\\\"Bob\\\",\\\"state\\\":\\\"SUBMITTED\\\"}\",\"lastTags\":[]}," +
                 "\"tags\":[]}");
 
         Change actual = JsonHelper.fromJson(string, Change.class);

--- a/sor-api/src/test/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluatorTest.java
+++ b/sor-api/src/test/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluatorTest.java
@@ -143,11 +143,28 @@ public class ConditionEvaluatorTest {
     }
 
     @Test
+    public void testIntrinsicLastMutateAtNull() {
+        Intrinsics intrinsics = mock(Intrinsics.class);
+        when(intrinsics.getLastMutateAt()).thenReturn(null);
+        assertTrue(eval(Conditions.intrinsic(Intrinsic.LAST_MUTATE_AT, (Object) null), null, intrinsics));
+        assertFalse(eval(Conditions.intrinsic(Intrinsic.LAST_MUTATE_AT, "2012-07-08T22:21:36.866Z"), null, intrinsics));
+    }
+
+    @Test
     public void testIntrinsicLastUpdateAtNull() {
         Intrinsics intrinsics = mock(Intrinsics.class);
         when(intrinsics.getLastUpdateAt()).thenReturn(null);
         assertTrue(eval(Conditions.intrinsic(Intrinsic.LAST_UPDATE_AT, (Object) null), null, intrinsics));
         assertFalse(eval(Conditions.intrinsic(Intrinsic.LAST_UPDATE_AT, "2012-07-08T22:21:36.866Z"), null, intrinsics));
+    }
+
+    @Test
+    public void testIntrinsicLastMutateAt() {
+        Intrinsics intrinsics = mock(Intrinsics.class);
+        when(intrinsics.getLastMutateAt()).thenReturn("2012-07-08T22:21:36.866Z");
+        assertTrue(eval(Conditions.intrinsic(Intrinsic.LAST_MUTATE_AT, "2012-07-08T22:21:36.866Z"), null, intrinsics));
+        assertFalse(eval(Conditions.intrinsic(Intrinsic.LAST_MUTATE_AT, "2012-07-08T22:29:31.588Z"), null, intrinsics));
+        assertFalse(eval(Conditions.intrinsic(Intrinsic.LAST_MUTATE_AT, (Object) null), null, intrinsics));
     }
 
     @Test

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/AbstractCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/AbstractCompactor.java
@@ -91,6 +91,7 @@ public abstract class AbstractCompactor {
                     compaction.getFirst(),
                     compaction.getCutoff(),
                     compaction.getCutoffSignature(),
+                    compaction.getLastContentMutation(),
                     compaction.getLastMutation(),
                     pendingCompaction.getStartingDelta(), compaction.getLastTags());
             resolver = new DefaultResolver(intrinsics, compactionInfo);

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultCompactor.java
@@ -103,6 +103,7 @@ public class DefaultCompactor extends AbstractCompactor {
                     resolved.getIntrinsics().getFirstUpdateAtUuid(),
                     resolved.getIntrinsics().getLastUpdateAtUuid(),
                     resolved.getIntrinsics().getSignature(),
+                    resolved.getIntrinsics().getLastMutateAtUuid(),
                     resolved.getLastMutation(),
                     // Compacted Delta
                     resolved.getConstant(), resolved.getLastTags());

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
@@ -402,6 +402,10 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
         if (lastUpdateAt != null) {
             result.put(Intrinsic.LAST_UPDATE_AT, lastUpdateAt);
         }
+        String lastMutateAt = intrinsics.getLastMutateAt();
+        if (lastMutateAt != null) {
+            result.put(Intrinsic.LAST_MUTATE_AT, lastMutateAt);
+        }
         return result;
     }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
@@ -148,6 +148,7 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
                     resolved.getIntrinsics().getFirstUpdateAtUuid(),
                     resolved.getIntrinsics().getLastUpdateAtUuid(),
                     resolved.getIntrinsics().getSignature(),
+                    resolved.getIntrinsics().getLastMutateAtUuid(),
                     resolved.getLastMutation(),
                     // Compacted Delta
                     resolved.getConstant(), resolved.getLastTags());

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MutableIntrinsics.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MutableIntrinsics.java
@@ -18,6 +18,7 @@ class MutableIntrinsics implements Intrinsics {
     private boolean _deleted;
     private UUID _firstUpdateAt;
     private UUID _lastUpdateAt;
+    private UUID _lastMutateAt;
 
     static MutableIntrinsics create(Key key) {
         return new MutableIntrinsics(key);
@@ -96,6 +97,19 @@ class MutableIntrinsics implements Intrinsics {
     @Override
     public String getLastUpdateAt() {
         return asISOTimestamp(_lastUpdateAt);
+    }
+
+    UUID getLastMutateAtUuid() {
+        return _lastMutateAt;
+    }
+
+    void setLastMutateAt(UUID lastMutateAt) {
+        _lastMutateAt = lastMutateAt;
+    }
+
+    @Override
+    public String getLastMutateAt() {
+        return asISOTimestamp(_lastMutateAt);
     }
 
     @Override

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/CompactorTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/CompactorTest.java
@@ -74,7 +74,7 @@ public class CompactorTest {
         Delta delta2 = Deltas.literal(ImmutableMap.of("key", "value"));
         Delta delta3 = Deltas.mapBuilder().put("key2", "change").build();
         // Old style compaction
-        Compaction compaction2 = new Compaction(2, t1, t3, "abcdef0123456789", t3);
+        Compaction compaction2 = new Compaction(2, t1, t3, "abcdef0123456789", t3, t3);
         final List<Map.Entry<UUID, Compaction>> compactions2 = ImmutableList.of(
                 Maps.immutableEntry(t5, compaction2));
         final List<Map.Entry<UUID,Change>> deltas2 = ImmutableList.of(
@@ -178,14 +178,14 @@ public class CompactorTest {
         SystemClock.tick();
 
         // Compaction records after the first compaction
-        Compaction compaction1 = new Compaction(2, t1, t2, "0123456789abcdef", t2);
+        Compaction compaction1 = new Compaction(2, t1, t2, "0123456789abcdef", t2, t2);
         final List<Map.Entry<UUID, Compaction>> compactions1 = ImmutableList.of(
                 Maps.immutableEntry(t4, compaction1));
 
         // Compaction and delta records after the second compaction
         Delta delta2 = Deltas.literal(ImmutableMap.of("key", "value"));
         Delta delta3 = Deltas.mapBuilder().put("key2", "change").build();
-        Compaction compaction2 = new Compaction(2, t1, t3, "abcdef0123456789", t3);
+        Compaction compaction2 = new Compaction(2, t1, t3, "abcdef0123456789", t3, t3);
         final List<Map.Entry<UUID, Compaction>> compactions2 = ImmutableList.of(
                 Maps.immutableEntry(t5, compaction2));
         final List<Map.Entry<UUID,Change>> deltas2 = ImmutableList.of(

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/DataStoreTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/DataStoreTest.java
@@ -210,7 +210,7 @@ public class DataStoreTest {
         // Make a non-mutative change
         now = new Date(now.getTime() + 1000);
         changeId = com.bazaarvoice.emodb.common.uuid.TimeUUIDs.uuidForTimestamp(now);
-        store.update(TABLE, KEY1, changeId, Deltas.mapBuilder().put("key", "value0").build(), audit, WriteConsistency.STRONG);
+        store.update(TABLE, KEY1, changeId, Deltas.noop(), audit, WriteConsistency.STRONG);
         record = store.get(TABLE, KEY1);
         // Only the last update date should have changed
         lastUpdateDate = now;
@@ -240,7 +240,7 @@ public class DataStoreTest {
         // Repeat the compaction process, but this time the most recent delta is non-mutative
         now = new Date(now.getTime() + 1000);
         changeId = com.bazaarvoice.emodb.common.uuid.TimeUUIDs.uuidForTimestamp(now);
-        store.update(TABLE, KEY1, changeId, Deltas.mapBuilder().put("key", "value1").build(), audit, WriteConsistency.STRONG);
+        store.update(TABLE, KEY1, changeId, Deltas.noop(), audit, WriteConsistency.STRONG);
         store.compact(TABLE, KEY1, Duration.millis(0), ReadConsistency.STRONG, WriteConsistency.STRONG);
         SystemClock.tick();
         store.compact(TABLE, KEY1, Duration.millis(0), ReadConsistency.STRONG, WriteConsistency.STRONG);
@@ -255,7 +255,7 @@ public class DataStoreTest {
         // Make a non-mutative change
         now = new Date(now.getTime() + 1000);
         changeId = com.bazaarvoice.emodb.common.uuid.TimeUUIDs.uuidForTimestamp(now);
-        store.update(TABLE, KEY1, changeId, Deltas.mapBuilder().put("key", "value1").build(), audit, WriteConsistency.STRONG);
+        store.update(TABLE, KEY1, changeId, Deltas.noop(), audit, WriteConsistency.STRONG);
         record = store.get(TABLE, KEY1);
         // Only the last update date should have changed
         lastUpdateDate = now;
@@ -297,25 +297,27 @@ public class DataStoreTest {
         Date firstUpdateDate = now;
         // Perform a mutative update
         now = new Date(now.getTime() + 1000);
+        // This will be the last time the content is mutated in this test; save the date
+        Date lastContentMutateDate = now;
         changeId = com.bazaarvoice.emodb.common.uuid.TimeUUIDs.uuidForTimestamp(now);
         store.update(TABLE, KEY1, changeId, Deltas.mapBuilder().put("key", "value1").build(), audit, WriteConsistency.STRONG);
-        Date lastContentMutateDate = now;
         // Perform a non-mutative update
         now = new Date(now.getTime() + 1000);
         changeId = com.bazaarvoice.emodb.common.uuid.TimeUUIDs.uuidForTimestamp(now);
-        store.update(TABLE, KEY1, changeId, Deltas.mapBuilder().put("key", "value1").build(), audit, WriteConsistency.STRONG);
+        store.update(TABLE, KEY1, changeId, Deltas.noop(), audit, WriteConsistency.STRONG);
         // Perform another non-mutative update, this time with different event tags
         now = new Date(now.getTime() + 1000);
+        // This will be the last time the content or tags are mutated in this test; save the date
+        Date lastMutateDate = now;
         changeId = com.bazaarvoice.emodb.common.uuid.TimeUUIDs.uuidForTimestamp(now);
         store.updateAll(
-                ImmutableList.of(new Update(TABLE, KEY1, changeId, Deltas.mapBuilder().put("key", "value1").build(), audit, WriteConsistency.STRONG)),
+                ImmutableList.of(new Update(TABLE, KEY1, changeId, Deltas.noop(), audit, WriteConsistency.STRONG)),
                 ImmutableSet.of("tag1"));
-        Date lastMutateDate = now;
         // Perform a final non-mutative update with the same event tags
         now = new Date(now.getTime() + 1000);
         changeId = com.bazaarvoice.emodb.common.uuid.TimeUUIDs.uuidForTimestamp(now);
         store.updateAll(
-                ImmutableList.of(new Update(TABLE, KEY1, changeId, Deltas.mapBuilder().put("key", "value1").build(), audit, WriteConsistency.STRONG)),
+                ImmutableList.of(new Update(TABLE, KEY1, changeId, Deltas.noop(), audit, WriteConsistency.STRONG)),
                 ImmutableSet.of("tag1"));
         Date lastUpdateDate = now;
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/matching/AuthorizationIntrinsics.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/matching/AuthorizationIntrinsics.java
@@ -50,4 +50,9 @@ public class AuthorizationIntrinsics implements Intrinsics {
     public String getLastUpdateAt() {
         throw new UnsupportedOperationException("Cannot evaluate last update time in table authorization context");
     }
+
+    @Override
+    public String getLastMutateAt() {
+        throw new UnsupportedOperationException("Cannot evaluate last mutate time in table authorization context");
+    }
 }


### PR DESCRIPTION
## Github Issue #

[31](https://github.com/bazaarvoice/emodb/issues/31)

## What Are We Doing Here?

This PR adds the `~lastMutateAt` intrinsic as described in the GitHub issue.  No additional features are included, although there is a slight modification to compactions.  The existing "lastMutationId" calculation in resolution and compaction is databus-centric and considers a change to the document content or tags as a mutation.  This works well to optimistically keep redundant deltas off of the databus while ensuring any potentially mutative delta is posted.  However, it interferes with the intrinsic since the `~lastMutateAt` timestamp should not be incremented if only the metadata (event tags) are changed in a delta.  The compaction record has a new field, `lastContentMutation` to track the UUID of the last delta which changed the content independently of the existing `lastMutation` field which includes tags in this calculation.  Existing compactions are grandfathered-in by substituting the `lastMutation` for the `lastContentMutation` if the former exists but the latter does not.

## How to Test and Verify

1. Check out this PR
2. Create a table called "mutation:demo"
3. Repeat this sequence:

   ```
$ curl -s -XPUT -H "Content-Type: application/json" "http://localhost:8080/sor/1/mutation:demo/demo1?audit=comment:'initial+submission'" --data-binary '{"value": true}'
{"success":true}
$ curl localhost:8080/sor/1/mutation:demo/demo1 | jq .
{
  "~lastMutateAt": "2016-09-12T22:07:21.438Z",
  "value": true,
  "~id": "demo1",
  "~table": "mutation:demo",
  "~version": 1,
  "~signature": "2cd08e5eaf149e03240259407df57c9d",
  "~deleted": false,
  "~firstUpdateAt": "2016-09-12T22:07:21.438Z",
  "~lastUpdateAt": "2016-09-12T22:07:21.438Z"
}
$ curl -s -H "Content-Type: application/x.json-delta" "http://localhost:8080/sor/1/mutation:demo/demo1?audit=comment:'unchanged'" --data-binary '{..,"value":true}'
{"success":true}
$ curl localhost:8080/sor/1/mutation:demo/demo1 | jq .
{
  "~lastMutateAt": "2016-09-12T22:07:21.438Z",
  "value": true,
  "~id": "demo1",
  "~table": "mutation:demo",
  "~version": 2,
  "~signature": "b7a9efc0bf9c8f3c07eb1b0c1518bc2a",
  "~deleted": false,
  "~firstUpdateAt": "2016-09-12T22:07:21.438Z",
  "~lastUpdateAt": "2016-09-12T22:07:41.113Z"
}
$ curl -s -H "Content-Type: application/x.json-delta" "http://localhost:8080/sor/1/mutation:demo/demo1?audit=comment:'changed'" --data-binary '{..,"value":false}'
{"success":true}
$ curl localhost:8080/sor/1/mutation:demo/demo1 | jq .
{
  "~lastMutateAt": "2016-09-12T22:08:23.446Z",
  "value": false,
  "~id": "demo1",
  "~table": "mutation:demo",
  "~version": 4,
  "~signature": "6eeb0406adfd7ba5f764bdf9529d458d",
  "~deleted": false,
  "~firstUpdateAt": "2016-09-12T22:07:21.438Z",
  "~lastUpdateAt": "2016-09-12T22:08:23.446Z"
}
$ curl -s -H "Content-Type: application/x.json-delta" "http://localhost:8080/sor/1/mutation:demo/demo1?audit=comment:'unchanged'" --data-binary '{..,"value":false}'
{"success":true}
$ curl localhost:8080/sor/1/mutation:demo/demo1 | jq .
{
  "~lastMutateAt": "2016-09-12T22:08:23.446Z",
  "value": false,
  "~id": "demo1",
  "~table": "mutation:demo",
  "~version": 5,
  "~signature": "4c8d7853afae28285cf7bba5fece5dbd",
  "~deleted": false,
  "~firstUpdateAt": "2016-09-12T22:07:21.438Z",
  "~lastUpdateAt": "2016-09-12T22:08:33.204Z"
}
   ```

## Risk

Medium.  In addition to the risk outlined in the issue, the added attribute to compaction adds some risk, particularly with regards to handling of existing compaction records.

### Level 

Medium

### Required Testing

Manual.

### Risk Summary

No additional risks not previously discussed.

## Code Review Checklist

- [x] Tests are included. If not, make sure you leave us a line or two for the reason.

- [x] Pulled down the PR and performed verification of at least being able to
build and run.

- [x] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [x] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [x] PR has a valid summary, and a good description.

