### PR TITLE
Defer deleting base compaction until the owner is behind FCT

### DIFF
--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -17,8 +17,8 @@
 
     <properties>
         <mavenVersion>3.1.1</mavenVersion>
-        <mavenPluginAnnotationsVersion>3.2</mavenPluginAnnotationsVersion>
-        <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
+        <mavenPluginAnnotationsVersion>3.3</mavenPluginAnnotationsVersion>
+        <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
     </properties>
 
     <dependencies>

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
@@ -137,8 +137,7 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
             Resolved resolved = resolver.resolved();
 
             // Note: We should *not* delete the compaction that the new compaction is based upon, and defer
-            // its deletes upon a later compaction. The deletes of all compactions are taken care of simultaneously
-            // while looking for most effective compaction in {@link AbstractCompactor#findEffectiveCompaction}.
+            // its delete once the new compaction is also behind FCT.
 
             // Write a new compaction record and re-write the preceding delta with the content resolved to this point.
             compactionKey = TimeUUIDs.newUUID();

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
@@ -41,8 +41,8 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
 
     /**
      * This method creates pending compactions if there are deltas behind the Full Consistency Timestamp (FCT).
-     * To avoid corruption in a distributed system, we defer the deletes of "compaction-owned" deltas until the said
-     * compaction is behind FCT.
+     * To avoid corruption in a distributed system, we defer the deletes of "compaction-owned" deltas or compactions
+     * until the owning compaction is behind FCT.
      * Also, we try to avoid any further compactions, if there is already an outstanding compaction, which is not behind FCT yet.
      * This is because if we keep compacting and not delete deltas, then we can get in a situation when compactions will kept
      * getting "eaten" by newer compactions and their owned deltas will never get deleted.
@@ -55,7 +55,8 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
         DeltasArchive deltasArchive = new DeltasArchive();
 
         // Loop through the compaction records and find the one that is most up-to-date.  Obsolete ones may be deleted.
-        Map.Entry<UUID, Compaction> compactionEntry = findEffectiveCompaction(record.passOneIterator(), keysToDelete);
+        Map.Entry<UUID, Compaction> compactionEntry = findEffectiveCompaction(record.passOneIterator(), keysToDelete, compactionConsistencyTimeStamp);
+
         // Check to see if this is a legacy compaction
         if (compactionEntry != null && compactionEntry.getValue().getCompactedDelta() == null) {
             // Legacy compaction found. Can't use this compactor.
@@ -135,11 +136,9 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
             // Merge the N oldest deltas and write the result into the new compaction.
             Resolved resolved = resolver.resolved();
 
-            // Delete old compaction record.
-            if (compaction != null) {
-                keysToDelete.add(compactionKey);
-                compactionKeysToDelete.add(compactionKey);
-            }
+            // Note: We should *not* delete the compaction that the new compaction is based upon, and defer
+            // its deletes upon a later compaction. The deletes of all compactions are taken care of simultaneously
+            // while looking for most effective compaction in {@link AbstractCompactor#findEffectiveCompaction}.
 
             // Write a new compaction record and re-write the preceding delta with the content resolved to this point.
             compactionKey = TimeUUIDs.newUUID();

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiDCCompactionTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiDCCompactionTest.java
@@ -1,0 +1,187 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.common.uuid.UUIDs;
+import com.bazaarvoice.emodb.sor.api.Audit;
+import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.Compaction;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.ReadConsistency;
+import com.bazaarvoice.emodb.sor.api.TableOptions;
+import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.db.Key;
+import com.bazaarvoice.emodb.sor.db.Record;
+import com.bazaarvoice.emodb.sor.db.test.InMemoryDataDAO;
+import com.bazaarvoice.emodb.sor.delta.Delta;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.bazaarvoice.emodb.sor.test.MultiDCDataStores;
+import com.bazaarvoice.emodb.sor.test.SystemClock;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import org.joda.time.Duration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Tests that compactions in multiple data centers do not result in data loss.
+ * New compactions should not delete the base compaction unless the new "owner" compaction is also behind the FCT.
+ */
+public class MultiDCCompactionTest {
+
+    private static final String TABLE = "item";
+    private static final String KEY = "key1";
+
+    @Test
+    public void testMultiDcCompactionWithDelayBetweenDeletesAndCompaction() throws Exception {
+        // setup a pair of DataStores that replicate to each other, simulating two data centers
+        MultiDCDataStores allDCs = new MultiDCDataStores(2, new MetricRegistry());
+        DataStore dc1 = allDCs.dc(0);
+        DataStore dc2 = allDCs.dc(1);
+        InMemoryDataDAO dao1 = allDCs.dao(0);
+        InMemoryDataDAO dao2 = allDCs.dao(1);
+
+        TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
+        dc1.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
+
+        UUID changeId1, changeId2, changeId3, changeId4, changeId5;
+
+        // write initial updates that's visible to both data centers
+        dc1.update(TABLE, KEY, changeId1 = TimeUUIDs.newUUID(), Deltas.fromString("{\"first_name\":\"Bob\"}"), newAudit("submit"), WriteConsistency.STRONG);
+        dc1.update(TABLE, KEY, changeId2 = TimeUUIDs.newUUID(), Deltas.fromString("{..,\"last_name\":\"Smith\"}"), newAudit("update"), WriteConsistency.STRONG);
+
+        SystemClock.tick();
+
+        // This should add a new compaction record while deferring the deletes upon a subsequent compaction
+        dc1.compact(TABLE, KEY, Duration.millis(0), ReadConsistency.STRONG, WriteConsistency.STRONG);
+
+        SystemClock.tick();
+        // write 3 more deltas that are replicated everywhere
+        dc1.update(TABLE, KEY, changeId3 = TimeUUIDs.newUUID(), Deltas.fromString("{..,\"third\":\"555-5555\"}"), newAudit("update"), WriteConsistency.STRONG);
+        SystemClock.tick();
+        UUID cutoffchangeId = TimeUUIDs.getNext(changeId3);
+        dc1.update(TABLE, KEY, changeId4 = TimeUUIDs.newUUID(), Deltas.fromString("{..,\"fourth\":\"more\"}"), newAudit("update"), WriteConsistency.STRONG);
+        SystemClock.tick();
+        dc1.update(TABLE, KEY, changeId5 = TimeUUIDs.newUUID(), Deltas.fromString("{..,\"fifth\":\"more\"}"), newAudit("update"), WriteConsistency.STRONG);
+
+        // Simulate an out of order replication, where the deletes associated with the compaction will replicate,
+        // but the corresponding compaction record itself won't replicate until later
+        allDCs.onlyReplicateDeletesUponCompactions();
+
+        SystemClock.tick();
+        // This will *only* replicate the deletes associated with the compaction
+        dc1.compact(TABLE, KEY, Duration.millis(System.currentTimeMillis() - TimeUUIDs.getTimeMillis(cutoffchangeId)), ReadConsistency.STRONG, WriteConsistency.STRONG);
+
+        // DC2 has replicated the deletes for first two deltas, and the first compaction, but didn't get the second compaction delta.
+        // Now, DC2 undergoes a compaction on its own
+        // This will cause data loss if the second compaction deleted the first compaction too.
+        dc2.compact(TABLE, KEY, Duration.millis(0), ReadConsistency.STRONG, WriteConsistency.STRONG);
+
+        // Let's replicate the compaction records
+        allDCs.replicateCompactionDeltas();
+
+        Map<String, Object> actualRow = dc1.get(TABLE, KEY, ReadConsistency.STRONG);
+        Map<String, Object> actualRowdc2 = dc2.get(TABLE, KEY, ReadConsistency.STRONG);
+
+        // Verify that the record in both data centers has converged
+        assertEquals(actualRow, actualRowdc2, "Both rows should converge at this point");
+
+        // Verify that the first two deltas are now gone !!
+        assertTrue(actualRow.containsKey("first_name"));
+        assertTrue(actualRow.containsKey("last_name"));
+        assertTrue(actualRow.containsKey("third"));
+        assertTrue(actualRow.containsKey("fourth"));
+        assertTrue(actualRow.containsKey("fifth"));
+    }
+
+    /** Test that compactions are only deleted when the chosen compaction is behind FCT. **/
+    @Test
+    public void testCorrectCompactionsAreDeleted() {
+        // Test that compactions are only deleted when the chosen compaction is behind FCT.
+        // As it is, a new compaction is not started if a compaction exists outside of FCT.
+        // So, when the most effective compaction is found to be behind FCT, only then every other compaction is deleted.
+        // If the winning compaction happens to be outside of FCT, we defer the deletes of *all* other compactions.
+
+        // Create a compactor
+        long now = System.currentTimeMillis();
+        MetricRegistry metricRegistry = new MetricRegistry();
+        Counter archiveDeltaSize = metricRegistry.counter(MetricRegistry.name("bv.emodb.sor", "DistributedCompactor", "testArchivedDeltaSize"));
+        Compactor compactor = new DistributedCompactor(archiveDeltaSize, false, metricRegistry);
+
+        final Key key = mock(Key.class);
+        UUID t1 = TimeUUIDs.newUUID(); // First compaction
+        SystemClock.tick();
+        long fctBeforeT2 = System.currentTimeMillis();
+        SystemClock.tick();
+        UUID t2 = TimeUUIDs.newUUID(); // Second compaction (winning)
+        SystemClock.tick();
+        long fctAfterT2 = System.currentTimeMillis();
+        SystemClock.tick();
+        UUID t3 = TimeUUIDs.newUUID(); // Third compaction
+
+        // Sample content
+        Delta delta = Deltas.literal(ImmutableMap.of("key", "value"));
+
+        // Mock compaction signature
+        Hasher hasher = Hashing.md5().newHasher();
+        hasher.putBytes(UUIDs.asByteArray(t1));
+        String signature = hasher.hash().toString();
+
+        // c2 is the winning compaction
+        Compaction c1 = new Compaction(4, t1, t1, signature, null, null, delta);
+        Compaction c2 = new Compaction(4, t1, t1, signature, null, null, delta);
+        Compaction c3 = new Compaction(3, t1, t1, signature, null, null, delta);
+
+        final List<Map.Entry<UUID, Compaction>> compactions = Lists.newArrayList(
+                Maps.immutableEntry(t1, c1),
+                Maps.immutableEntry(t2, c2),
+                Maps.immutableEntry(t3, c3)
+                );
+
+        Record record = mock(Record.class);
+        when(record.getKey()).thenReturn(key);
+        when(record.passOneIterator()).thenReturn(compactions.iterator()).thenReturn(compactions.iterator());
+        when(record.passTwoIterator()).thenReturn(Iterators.emptyIterator()).thenReturn(Iterators.emptyIterator());
+
+        //noinspection unchecked
+        Supplier<Record> requeryFn = mock(Supplier.class);
+
+        Expanded expand = compactor.expand(record, fctBeforeT2, fctBeforeT2, MutableIntrinsics.create(key), false, requeryFn);
+
+        // Verify that no pending compaction is produced since the winning compaction is outside of FCT
+        assertNull(expand.getPendingCompaction());
+
+        // Change the FCT such that the winning compaction (c2) is before FCT
+        expand = compactor.expand(record, fctAfterT2, fctAfterT2, MutableIntrinsics.create(key), false, requeryFn);
+        List<UUID> deletedCompactions = expand.getPendingCompaction().getCompactionKeysToDelete();
+        // Verify that compactions other than c2, are deleted
+        Assert.assertTrue(deletedCompactions.contains(t1));
+        Assert.assertTrue(deletedCompactions.contains(t3));
+    }
+
+    private Audit newAudit(String comment) {
+        return new AuditBuilder().
+                setProgram("test").
+                setLocalHost().
+                setComment(comment).
+                build();
+    }
+}

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
@@ -96,6 +96,18 @@ public class MultiDCDataStores {
         }
     }
 
+    public void onlyReplicateDeletesUponCompactions() {
+        for (ReplicatingDataWriterDAO dao : _replDaos) {
+            dao.onlyReplicateDeletesUponCompaction();
+        }
+    }
+
+    public void replicateCompactionDeltas() {
+        for (ReplicatingDataWriterDAO dao : _replDaos) {
+            dao.replicateCompactionDeltas();
+        }
+    }
+
     public MultiDCDataStores setFullConsistencyDelayMillis(int fullConsistencyDelayMillis) {
         for (InMemoryDataDAO dao : _inMemoryDaos) {
             dao.setFullConsistencyDelayMillis(fullConsistencyDelayMillis);

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/test/ReplicatingDataWriterDAO.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/test/ReplicatingDataWriterDAO.java
@@ -21,6 +21,10 @@ import java.util.UUID;
  * <p>
  * Replication can be stopped and started to simulate replication lag in
  * unit tests.
+ * </p>
+ * <p>
+ *     Replication can be replayed out of order too ...
+ * </p>
  */
 public class ReplicatingDataWriterDAO implements DataWriterDAO {
 
@@ -100,11 +104,20 @@ public class ReplicatingDataWriterDAO implements DataWriterDAO {
         }
     }
 
+    public void onlyReplicateDeletesUponCompaction() {
+        for (PausableDataWriterDAO remote : _remotes) {
+            remote.onlyReplicateDeletesUponCompaction();
+        }
+    }
+
+    public void replicateCompactionDeltas() {
+        for (PausableDataWriterDAO remote : _remotes) {
+            remote.replicateCompactionDeltas();
+        }
+    }
+
     private UpdateListener noop() {
-        return new UpdateListener() {
-            @Override
-            public void beforeWrite(Collection<RecordUpdate> updates) {
-            }
+        return updates -> {
         };
     }
 }


### PR DESCRIPTION
## Github Issue #

[37](https://github.com/bazaarvoice/emodb/issues/37)

## What Are We Doing Here?

Currently, there is a rare bug that can present itself when a high update row is being compacted simultaneously in two data centers. Consider the following scenario:


| Sequence | DC-1 | DC-2 | Remarks |
| -----------  | ------ | ------ | ---------- |
|1|D1, D2, FCT, D3, D4, C1(D1,D2) |D1, D2, FCT, D3, D4|DC-1 compacts, but C1 isn't replicated to DC-2|
|2|D1, D2, D3, D4, C1(D1,D2), FCT |D1, D2, D3,  D4, C1(D1,D2), FCT,|Compaction C1 and D3 are behind FCT in both data-centers|
|3| D3, D4, FCT C2(C1,D3)|D3, D4, FCT, C3(D3, D4)|D1,D2 and C1 gets deleted, while creating a new compaction, C2. This is where the problem is. Deletes got replicated to DC-2, and before C2 could make it to DC-2, DC-2 created another compaction C3, based on only D3 and D4. And thus, C3 becomes the last effective compaction which does not include C2 owned deltas|
|4| D3, D4, FCT, C2(C1,D3), C3(D3, D4)|D3, FCT, C3(D3, D4)|DC-1 replicated the corrupted compaction C3, and uses it as the best compaction|

To resolve the above, this PR defers the delete of the base compaction until the owner compaction itself is behind FCT. In the above scenario, C1 would not be deleted in Step 3.

## How to Test and Verify

1. Check out this PR
2. Make sure it compiles and run. The unit tests do test the above scenario
3. Profit

## Risk
Medium. Although there is nothing destructive about this PR, it does deal with compactions that is a core functionality. Running it in QA and stress testing is recommended.

### Level 

Medium

### Required Testing

Regression and Manual testing.

### Risk Summary

Although there is nothing destructive about this PR, it does deal with compactions that is a core functionality. Running it in QA and stress testing is recommended.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
