### PR TITLE
Fixed dependency injection issue with SettingsManager and DataStore

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
@@ -8,6 +8,7 @@ import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
 import com.google.inject.PrivateModule;
+import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.name.Named;
@@ -61,8 +62,11 @@ public class SettingsModule extends PrivateModule {
 
     @Provides @Singleton
     SettingsManager provideSettings(@Named("lastUpdatedStore") ValueStore<Long> lastUpdated,
-                             DataStore dataStore, @SystemTablePlacement String placement,
-                             LifeCycleRegistry lifeCycleRegistry) {
+                                    Provider<DataStore> dataStore, @SystemTablePlacement String placement,
+                                    LifeCycleRegistry lifeCycleRegistry) {
+        // Note:  To prevent potential circular dependencies while constructing SettingsManager a Provider for the
+        //        DataStore must be injected, deferring resolution of the DataStore until after all related
+        //        objects are constructed.
         return new SettingsManager(lastUpdated, dataStore, SETTINGS_TABLE, placement, lifeCycleRegistry);
     }
 }

--- a/web/src/test/java/com/bazaarvoice/emodb/web/settings/SettingsManagerTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/settings/SettingsManagerTest.java
@@ -11,6 +11,7 @@ import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Ticker;
+import com.google.inject.util.Providers;
 import org.joda.time.Duration;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
@@ -42,7 +43,7 @@ public class SettingsManagerTest {
         _ticker = mock(Ticker.class);
         when(_ticker.read()).thenReturn(START_TIME_NS);
 
-        _settingsManager = new SettingsManager(_lastUpdated, _dataStore, "__system:settings",
+        _settingsManager = new SettingsManager(_lastUpdated, Providers.of(_dataStore), "__system:settings",
                 "app_global:sys", mock(LifeCycleRegistry.class), Duration.standardMinutes(1), _ticker);
     }
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Upon deployment of EmoDB 5.4.6 EmoDB would fail to come up in all but the system data center.  The root cause is a circular dependency injection issue.

## How to Test and Verify

1. Check out this PR
2. Run two EmoDBs on different ports with different data centers.
3. Verify both start up successfully.

## Risk

Low, although the existing of the unfixed version prevents deploying to non-system data centers.

### Level 

Low

### Required Testing

Regression

### Risk Summary

No additional risk

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.

