### PR TITLE
Fixed use of Ticker for getting current time

### DIFF
--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/time/ClockTicker.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/time/ClockTicker.java
@@ -1,0 +1,71 @@
+package com.bazaarvoice.emodb.common.dropwizard.time;
+
+import com.google.common.base.Ticker;
+
+import java.time.Clock;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Implementation of {@link Ticker} using the current time as returned by {@link Clock#millis()}
+ * as the return value for {@link Ticker#read()}.  Because of this the returned value will be in nanoseconds per the
+ * Ticker spec but will only have millisecond resolution.
+ *
+ * On its own there is no real benefit of ClockTicker over {@link Ticker#systemTicker()}; both implementations
+ * provide elapsed time from a fixed point and ClockTicker only provides millisecond precision while system ticker
+ * may provide nanosecond precision.  The benefit comes from using ClockTicker in conjunction with Clock
+ * for classes and processes that require both.  For example, consider the following class:
+ *
+ * <code>
+ * public class SampleClass {
+ *
+ *     private LoadingCache<String, Integer> _lastMinuteCountCache;
+ *
+ *     public SampleClass(Clock clock) {
+ *         _lastMinuteCountCache = CacheBuilder.newBuilder()
+ *                 .ticker(ClockTicker.getTicker(clock))
+ *                 .expireAfterAccess(1, TimeUnit.MINUTES)
+ *                 .build(new CacheLoader<String, Integer>() {
+ *                     public Integer load(String key) throws Exception {
+ *                         return getCountSince(key, clock.millis());
+ *                     }
+ *                 });
+ *     }
+ *  ...
+ * }
+ * </code>
+ *
+ * This class requires the current time for its business logic and a ticker for cache expiration.  By providing a
+ * Clock instance and using a ClockTicker tests can be built which consistently use the time provided
+ * by <code>clock</code> to maintain a consistent timeline.
+ */
+public final class ClockTicker {
+
+    private static final ClockTickerImpl DEFAULT = new ClockTickerImpl(Clock.systemUTC());
+
+    public static Ticker getDefault() {
+        return DEFAULT;
+    }
+
+    public static Ticker getTicker(Clock clock) {
+        // Return the singleton instance for the default UTC clock
+        if (Clock.systemUTC().equals(clock)) {
+            return DEFAULT;
+        }
+        return new ClockTickerImpl(clock);
+    }
+
+    private static class ClockTickerImpl extends Ticker {
+        private final Clock _clock;
+
+        private ClockTickerImpl(Clock clock) {
+            _clock = checkNotNull(clock, "clock");
+        }
+
+        @Override
+        public long read() {
+            return TimeUnit.MILLISECONDS.toNanos(_clock.millis());
+        }
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
@@ -62,6 +62,7 @@ import com.sun.jersey.api.client.Client;
 import org.apache.curator.framework.CuratorFramework;
 
 import java.nio.ByteBuffer;
+import java.time.Clock;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -89,6 +90,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * <li> DataStore {@link EventBus}
  * <li> DataStore {@link DataStoreConfiguration}
  * <li> @{@link DefaultJoinFilter} Supplier&lt;{@link Condition}&gt;
+ * <li> {@link Clock}
  * </ul>
  * Exports the following:
  * <ul>

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
@@ -40,6 +40,7 @@ import org.apache.curator.utils.EnsurePath;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
+import java.time.Clock;
 import java.util.Collection;
 
 import static org.mockito.Matchers.eq;
@@ -111,6 +112,7 @@ public class DatabusModuleTest {
 
                 MetricRegistry metricRegistry = new MetricRegistry();
                 bind(MetricRegistry.class).toInstance(metricRegistry);
+                bind(Clock.class).toInstance(mock(Clock.class));
 
                 install(new DatabusModule(serviceMode, metricRegistry));
             }

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
@@ -15,6 +15,8 @@ import com.google.common.eventbus.EventBus;
 import org.joda.time.Duration;
 import org.testng.annotations.Test;
 
+import java.time.Clock;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -35,7 +37,7 @@ public class DefaultDatabusTest {
         DefaultDatabus testDatabus = new DefaultDatabus(
                 mock(LifeCycleRegistry.class), mock(EventBus.class), mock(DataProvider.class), mockSubscriptionDao,
                 mock(DatabusEventStore.class), mock(SubscriptionEvaluator.class), mock(JobService.class),
-                mock(JobHandlerRegistry.class), mock(MetricRegistry.class), ignoreReEtl);
+                mock(JobHandlerRegistry.class), mock(MetricRegistry.class), ignoreReEtl, Clock.systemUTC());
         Condition originalCondition = Conditions.mapBuilder().contains("foo", "bar").build();
         testDatabus.subscribe("test-subscription", originalCondition, Duration.standardDays(7),
                 Duration.standardDays(7));

--- a/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
@@ -13,11 +13,11 @@ import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.SimpleLifeCycleRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
-import com.bazaarvoice.emodb.databus.DefaultJoinFilter;
 import com.bazaarvoice.emodb.databus.DatabusConfiguration;
 import com.bazaarvoice.emodb.databus.DatabusHostDiscovery;
 import com.bazaarvoice.emodb.databus.DatabusModule;
 import com.bazaarvoice.emodb.databus.DatabusZooKeeper;
+import com.bazaarvoice.emodb.databus.DefaultJoinFilter;
 import com.bazaarvoice.emodb.databus.ReplicationKey;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
@@ -62,6 +62,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.time.Clock;
 import java.util.List;
 
 import static org.mockito.Mockito.atLeastOnce;
@@ -144,6 +145,8 @@ public class CasDatabusTest {
 
                 bind(new TypeLiteral<Supplier<Condition>>(){}).annotatedWith(DefaultJoinFilter.class)
                         .toInstance(Suppliers.ofInstance(Conditions.alwaysFalse()));
+
+                bind(Clock.class).toInstance(Clock.systemDefaultZone());
 
                 EmoServiceMode serviceMode = EmoServiceMode.STANDARD_ALL;
                 install(new SelfHostAndPortModule());

--- a/queue/src/main/java/com/bazaarvoice/emodb/queue/QueueModule.java
+++ b/queue/src/main/java/com/bazaarvoice/emodb/queue/QueueModule.java
@@ -36,6 +36,7 @@ import com.google.inject.TypeLiteral;
 import org.apache.curator.framework.CuratorFramework;
 
 import java.nio.ByteBuffer;
+import java.time.Clock;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -56,6 +57,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * <li> @{@link DedupQueueHostDiscovery} {@link HostDiscovery}
  * <li> @{@link QueueZooKeeper} {@link CuratorFramework}
  * <li> @{@link Global} {@link CuratorFramework}
+ * <li> {@link Clock}
  * </ul>
  * Exports the following:
  * <ul>

--- a/queue/src/main/java/com/bazaarvoice/emodb/queue/core/DefaultDedupQueueService.java
+++ b/queue/src/main/java/com/bazaarvoice/emodb/queue/core/DefaultDedupQueueService.java
@@ -6,9 +6,12 @@ import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.queue.api.DedupQueueService;
 import com.google.inject.Inject;
 
+import java.time.Clock;
+
 public class DefaultDedupQueueService extends AbstractQueueService implements DedupQueueService {
     @Inject
-    public DefaultDedupQueueService(DedupEventStore eventStore, JobService jobService, JobHandlerRegistry jobHandlerRegistry) {
-        super(eventStore, jobService, jobHandlerRegistry, MoveDedupQueueJob.INSTANCE);
+    public DefaultDedupQueueService(DedupEventStore eventStore, JobService jobService, JobHandlerRegistry jobHandlerRegistry,
+                                    Clock clock) {
+        super(eventStore, jobService, jobHandlerRegistry, MoveDedupQueueJob.INSTANCE, clock);
     }
 }

--- a/queue/src/main/java/com/bazaarvoice/emodb/queue/core/DefaultQueueService.java
+++ b/queue/src/main/java/com/bazaarvoice/emodb/queue/core/DefaultQueueService.java
@@ -6,9 +6,12 @@ import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.queue.api.QueueService;
 import com.google.inject.Inject;
 
+import java.time.Clock;
+
 public class DefaultQueueService extends AbstractQueueService implements QueueService {
     @Inject
-    public DefaultQueueService(EventStore eventStore, JobService jobService, JobHandlerRegistry jobHandlerRegistry) {
-        super(eventStore, jobService, jobHandlerRegistry, MoveQueueJob.INSTANCE);
+    public DefaultQueueService(EventStore eventStore, JobService jobService, JobHandlerRegistry jobHandlerRegistry,
+                               Clock clock) {
+        super(eventStore, jobService, jobHandlerRegistry, MoveQueueJob.INSTANCE, clock);
     }
 }

--- a/queue/src/test/java/com/bazaarvoice/emodb/queue/QueueModuleTest.java
+++ b/queue/src/test/java/com/bazaarvoice/emodb/queue/QueueModuleTest.java
@@ -23,6 +23,8 @@ import com.google.inject.Injector;
 import org.apache.curator.framework.CuratorFramework;
 import org.testng.annotations.Test;
 
+import java.time.Clock;
+
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertNotNull;
 
@@ -57,6 +59,7 @@ public class QueueModuleTest {
 
                 MetricRegistry metricRegistry = new MetricRegistry();
                 bind(MetricRegistry.class).toInstance(metricRegistry);
+                bind(Clock.class).toInstance(mock(Clock.class));
 
                 install(new QueueModule(metricRegistry));
             }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -29,11 +29,11 @@ import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
 import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
 import com.bazaarvoice.emodb.common.zookeeper.store.ZkMapStore;
 import com.bazaarvoice.emodb.common.zookeeper.store.ZkTimestampSerializer;
-import com.bazaarvoice.emodb.databus.DefaultJoinFilter;
 import com.bazaarvoice.emodb.databus.DatabusConfiguration;
 import com.bazaarvoice.emodb.databus.DatabusHostDiscovery;
 import com.bazaarvoice.emodb.databus.DatabusModule;
 import com.bazaarvoice.emodb.databus.DatabusZooKeeper;
+import com.bazaarvoice.emodb.databus.DefaultJoinFilter;
 import com.bazaarvoice.emodb.databus.api.AuthDatabus;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.client.DatabusAuthenticator;
@@ -130,6 +130,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URI;
+import java.time.Clock;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -202,6 +203,7 @@ public class EmoModule extends AbstractModule {
             bind(MetricRegistry.class).toInstance(_environment.metrics());
             bind(ServerFactory.class).toInstance(_configuration.getServerFactory());
             bind(DataCenterConfiguration.class).toInstance(_configuration.getDataCenterConfiguration());
+            bind(Clock.class).toInstance(Clock.systemUTC());
         }
 
         /** Connect to ZooKeeper. */

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
@@ -14,6 +14,8 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import org.apache.curator.framework.CuratorFramework;
 
+import java.time.Clock;
+
 /**
  * Guice module which configures globally accessible server settings.
  *  * <p>
@@ -23,6 +25,7 @@ import org.apache.curator.framework.CuratorFramework;
  * <li> {@link LifeCycleRegistry}
  * <li> {@link DataStoreConfiguration}
  * <li> @SettingsZooKeeper {@link CuratorFramework}
+ * <li> {@link Clock}
  * </ul>
  * Exports the following:
  * <ul>
@@ -63,10 +66,11 @@ public class SettingsModule extends PrivateModule {
     @Provides @Singleton
     SettingsManager provideSettings(@Named("lastUpdatedStore") ValueStore<Long> lastUpdated,
                                     Provider<DataStore> dataStore, @SystemTablePlacement String placement,
-                                    LifeCycleRegistry lifeCycleRegistry) {
+                                    LifeCycleRegistry lifeCycleRegistry, Clock clock) {
         // Note:  To prevent potential circular dependencies while constructing SettingsManager a Provider for the
         //        DataStore must be injected, deferring resolution of the DataStore until after all related
         //        objects are constructed.
-        return new SettingsManager(lastUpdated, dataStore, SETTINGS_TABLE, placement, lifeCycleRegistry);
+        return new SettingsManager(
+                lastUpdated, dataStore, SETTINGS_TABLE, placement, lifeCycleRegistry, clock);
     }
 }


### PR DESCRIPTION
## Github Issue #

[39](https://github.com/bazaarvoice/emodb/issues/39)

## What Are We Doing Here?

There are several changes in this PR:

1. Replaced locations where `Ticker` was being used to get the current time with a `Clock`.
2. Changed `Clock` and `Ticker` instances to be formally injected by Guava.

## How to Test and Verify

1. Check out the project
2. Run EmoDB
3. Configure a Stash server with a scheduled scan and start Stash. The startup logs will show the first scan scheduled for the next expected time (within 24 hours).

## Risk

Low.  The new classes introduced are thin and mostly self explanatory; otherwise, most of the changes are around injection of the new time providers.

### Level 

`Medium`

### Required Testing

`Regression`

### Risk Summary

Low; associated risks are already outlined in the corresponding issue.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.

…time