### PR TITLE
Make Stash queue names configurable

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScannerConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScannerConfiguration.java
@@ -68,6 +68,16 @@ public class ScannerConfiguration {
     @JsonProperty ("scheduledScan")
     private ScheduledScanConfiguration _scheduledScan = new ScheduledScanConfiguration();
 
+    @Valid
+    @NotNull
+    @JsonProperty ("pendingScanRangeQueueName")
+    private Optional<String> _pendingScanRangeQueueName = Optional.absent();
+
+    @Valid
+    @NotNull
+    @JsonProperty ("completeScanRangeQueueName")
+    private Optional<String> _completeScanRangeQueueName = Optional.absent();
+
     public boolean isUseSQSQueues() {
         return _useSQSQueues;
     }
@@ -143,6 +153,24 @@ public class ScannerConfiguration {
 
     public ScannerConfiguration setScheduledScan(ScheduledScanConfiguration scheduledScan) {
         _scheduledScan = scheduledScan;
+        return this;
+    }
+
+    public Optional<String> getPendingScanRangeQueueName() {
+        return _pendingScanRangeQueueName;
+    }
+
+    public ScannerConfiguration setPendingScanRangeQueueName(Optional<String> pendingScanRangeQueueName) {
+        _pendingScanRangeQueueName = pendingScanRangeQueueName;
+        return this;
+    }
+
+    public Optional<String> getCompleteScanRangeQueueName() {
+        return _completeScanRangeQueueName;
+    }
+
+    public ScannerConfiguration setCompleteScanRangeQueueName(Optional<String> completeScanRangeQueueName) {
+        _completeScanRangeQueueName = completeScanRangeQueueName;
         return this;
     }
 }


### PR DESCRIPTION
## Github Issue #

None at this time

## What Are We Doing Here?

We'd like to test multiple Stash runs with different configurations in the same environment to validate changes which effect Stash.  Unfortunately the Stash queue names are hard-coded such that the only variable in the name, EmoDB cluster, must be the same for each Stash service.  This pull request makes the Stash queue names configurable, with the defaults staying as they are if no explicit action is taken.

## How to Test and Verify

1. Check out this PR
2. Run Stash locally, setting the queue names to different values and leaving them unchanged
3. Verify the correct queues are being written to and polled.

## Risk

Low.  This change only affects how the queue names are generated.  None of the actual Stash logic is changed.

### Level 

`Low`
### Required Testing

`Regression`

### Risk Summary

No additional concerns.  The only risk is if a new version of Stash is deployed with different queue names while an existing Stash run is still active.  In this case the new Stash will not query the old Stash's queues, causing it to be hung indefinitely.  However, this is an extremely unlikely scenario which can be easily worked around.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.

