### PR TITLE
Fixed performance for describing splits

### DIFF
--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/astyanax/KeyspaceUtil.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/astyanax/KeyspaceUtil.java
@@ -1,0 +1,66 @@
+package com.bazaarvoice.emodb.common.cassandra.astyanax;
+
+import com.netflix.astyanax.Keyspace;
+import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.astyanax.connectionpool.HostConnectionPool;
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.netflix.astyanax.shallows.EmptyKeyspaceTracerFactory;
+import com.netflix.astyanax.thrift.ThriftKeyspaceImpl;
+import org.apache.cassandra.thrift.Cassandra;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Helper utility for Keyspace operations
+ */
+public final class KeyspaceUtil {
+
+    // Static utility
+    private KeyspaceUtil() {
+        // empty
+    }
+
+    /**
+     * Starts the process of pinning calls to a Keyspace to a specific host.
+     */
+    public static PinnedKeyspaceBuilder pin(Keyspace keyspace) {
+        return new PinnedKeyspaceBuilder(keyspace);
+    }
+
+    public static class PinnedKeyspaceBuilder {
+        private final Keyspace _keyspace;
+
+        private PinnedKeyspaceBuilder(Keyspace keyspace) {
+            _keyspace = checkNotNull(keyspace, "keyspace");
+        }
+
+        public Keyspace toHost(String hostName) throws ConnectionException {
+            Host host = _keyspace.getConnectionPool().getPools().stream()
+                    .map(HostConnectionPool::getHost)
+                    .filter(poolHost -> hostName.equals(poolHost.getHostName()))
+                    .findFirst().orElseThrow(() -> new IllegalArgumentException("No hosts pools found"));
+
+            return pinToVerifiedHost(host);
+        }
+
+        /**
+         * Returns a view of the provided Keyspace that pins all operations to the provided host.
+         */
+        public Keyspace toHost(Host host) throws ConnectionException {
+            checkArgument(_keyspace.getConnectionPool().getPools().stream()
+                            .map(HostConnectionPool::getHost)
+                            .anyMatch(poolHost -> poolHost.equals(host)),
+                    "Host not found in pool");
+
+            return pinToVerifiedHost(host);
+        }
+
+        private Keyspace pinToVerifiedHost(Host host) throws ConnectionException {
+            //noinspection unchecked
+            PinnedConnectionPool<Cassandra.Client> pinnedPool = new PinnedConnectionPool(_keyspace.getConnectionPool(), host);
+            return new ThriftKeyspaceImpl(
+                    _keyspace.getKeyspaceName(), pinnedPool, _keyspace.getConfig(), EmptyKeyspaceTracerFactory.getInstance());
+        }
+    }
+}

--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/astyanax/PinnedConnectionPool.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/astyanax/PinnedConnectionPool.java
@@ -1,0 +1,109 @@
+package com.bazaarvoice.emodb.common.cassandra.astyanax;
+
+import com.netflix.astyanax.connectionpool.ConnectionPool;
+import com.netflix.astyanax.connectionpool.Host;
+import com.netflix.astyanax.connectionpool.HostConnectionPool;
+import com.netflix.astyanax.connectionpool.Operation;
+import com.netflix.astyanax.connectionpool.OperationResult;
+import com.netflix.astyanax.connectionpool.exceptions.ConnectionException;
+import com.netflix.astyanax.connectionpool.exceptions.OperationException;
+import com.netflix.astyanax.connectionpool.impl.AbstractOperationFilter;
+import com.netflix.astyanax.connectionpool.impl.Topology;
+import com.netflix.astyanax.partitioner.Partitioner;
+import com.netflix.astyanax.retry.RetryPolicy;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * ConnectionPool implementation which delegates all operations to a specific host.
+ * @param <T>
+ */
+public class PinnedConnectionPool<T> implements ConnectionPool<T> {
+
+    private final ConnectionPool<T> _delegate;
+    private final Host _host;
+
+    public PinnedConnectionPool(ConnectionPool<T> delegate, Host host) {
+        checkArgument(delegate.hasHost(host), "Cannot pin to host not in pool");
+        _delegate = delegate;
+        _host = host;
+    }
+
+    @Override
+    public <R> OperationResult<R> executeWithFailover(Operation<T, R> operation, RetryPolicy retryPolicy)
+            throws ConnectionException, OperationException {
+        Operation<T, R> pinnedOperation = new AbstractOperationFilter<T, R>(operation) {
+            @Override
+            public Host getPinnedHost() {
+                return _host;
+            }
+        };
+
+        return _delegate.executeWithFailover(pinnedOperation, retryPolicy);
+    }
+
+    // All remaining operations delegate to the original pool.
+
+    @Override
+    public boolean addHost(Host host, boolean b) {
+        return _delegate.addHost(host, b);
+    }
+
+    @Override
+    public boolean removeHost(Host host, boolean b) {
+        return _delegate.removeHost(host, b);
+    }
+
+    @Override
+    public boolean isHostUp(Host host) {
+        return _delegate.isHostUp(host);
+    }
+
+    @Override
+    public boolean hasHost(Host host) {
+        return _delegate.hasHost(host);
+    }
+
+    @Override
+    public List<HostConnectionPool<T>> getActivePools() {
+        return _delegate.getActivePools();
+    }
+
+    @Override
+    public List<HostConnectionPool<T>> getPools() {
+        return _delegate.getPools();
+    }
+
+    @Override
+    public void setHosts(Collection<Host> collection) {
+        _delegate.setHosts(collection);
+    }
+
+    @Override
+    public HostConnectionPool<T> getHostPool(Host host) {
+        return _delegate.getHostPool(host);
+    }
+
+    @Override
+    public void shutdown() {
+        _delegate.shutdown();
+    }
+
+    @Override
+    public void start() {
+        _delegate.start();
+    }
+
+    @Override
+    public Topology<T> getTopology() {
+        return _delegate.getTopology();
+    }
+
+    @Override
+    public Partitioner getPartitioner() {
+        return _delegate.getPartitioner();
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
@@ -406,7 +406,7 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO {
     private List<CfSplit> getCfSplits(Keyspace keyspace, ColumnFamily<ByteBuffer, UUID> cf, String start,
                                     String end, int desiredRecordsPerSplit, Iterable<TokenRange> allTokenRanges) {
         // There is a hole in the describeSplitsEx() call where if the call is routed to a Cassandra node which does
-        // have a replica of the requested token range then it will return a single split equivalent to the requested
+        // not have a replica of the requested token range then it will return a single split equivalent to the requested
         // range.  To accommodate this each query is routed to a host that is verified to have a replica of the range.
 
         ScanRange splitRange = ScanRange.create(parseTokenString(start), parseTokenString(end));
@@ -436,10 +436,10 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO {
                             throw Throwables.propagate(e);
                         }
                     }
-
-                    assert intersectionSplits != null : "Exception would have been thrown if no splits had returned successfully";
-                    cfSplits.addAll(intersectionSplits);
                 }
+
+                assert intersectionSplits != null : "Exception would have been thrown if no host had responded successfully";
+                cfSplits.addAll(intersectionSplits);
             }
         }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.sor.db.astyanax;
 
 import com.bazaarvoice.emodb.common.api.impl.LimitCounter;
 import com.bazaarvoice.emodb.common.cassandra.CassandraKeyspace;
+import com.bazaarvoice.emodb.common.cassandra.astyanax.KeyspaceUtil;
 import com.bazaarvoice.emodb.common.cassandra.nio.BufferUtils;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.sor.api.Change;
@@ -38,7 +39,6 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -78,6 +78,7 @@ import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.EndpointDetails;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.thrift.transport.TTransportException;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -396,18 +397,52 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO {
             String start = toTokenString(keyRange.getStart());
             String end = toTokenString(keyRange.getEnd());
 
-            splits.addAll(getCfSplits(keyspace, cf, start, end, desiredRecordsPerSplit, keyRange.getStart()));
+            splits.addAll(getCfSplits(keyspace, cf, start, end, desiredRecordsPerSplit));
         }
         return splits;
     }
 
     private List<CfSplit> getCfSplits(Keyspace keyspace, ColumnFamily<ByteBuffer, UUID> cf, String start,
-                                    String end, int desiredRecordsPerSplit, ByteBuffer startKey) {
-        try {
-            return keyspace.describeSplitsEx(cf.getName(), start, end, desiredRecordsPerSplit, startKey);
-        } catch (ConnectionException e) {
-            throw Throwables.propagate(e);
+                                    String end, int desiredRecordsPerSplit) {
+        // There is a hole in the describeSplitsEx() call where if the call is routed to a Cassandra node which does
+        // have a replica of the requested token range then it will return a single split equivalent to the requested
+        // range.  To accommodate this each query is routed to a host that is verified to have a replica of the range.
+
+        ScanRange splitRange = ScanRange.create(parseTokenString(start), parseTokenString(end));
+        List<CfSplit> cfSplits = Lists.newArrayList();
+
+        // Iterate over the entire ring to find the token ranges which overlap with the provided range
+        for (TokenRange hostTokenRange : describeCassandraTopology(keyspace).values()) {
+            ScanRange hostSplitRange = ScanRange.create(
+                    parseTokenString(hostTokenRange.getStartToken()),
+                    parseTokenString(hostTokenRange.getEndToken()));
+
+            // Use the intersection to determine if there is overlap
+            for (ScanRange intersection : splitRange.intersection(hostSplitRange)) {
+                // Try once on each host until splits are returned
+
+                List<CfSplit> intersectionSplits = null;
+                for (Iterator<String> hosts = hostTokenRange.getEndpoints().iterator(); hosts.hasNext() && intersectionSplits == null; ) {
+                    String host = hosts.next();
+                    try {
+                        intersectionSplits = KeyspaceUtil.pin(keyspace).toHost(host)
+                                .describeSplitsEx(cf.getName(), toTokenString(intersection.getFrom()),
+                                        toTokenString(intersection.getTo()),
+                                        desiredRecordsPerSplit, intersection.getFrom());
+                    } catch (ConnectionException e) {
+                        // If there is another host to try then do so, otherwise raise the exception
+                        if (!hosts.hasNext()) {
+                            throw Throwables.propagate(e);
+                        }
+                    }
+
+                    assert intersectionSplits != null : "Exception would have been thrown if no splits had returned successfully";
+                    cfSplits.addAll(intersectionSplits);
+                }
+            }
         }
+
+        return cfSplits;
     }
 
     @Timed(name = "bv.emodb.sor.AstyanaxDataReaderDAO.getSplit", absolute = true)
@@ -456,14 +491,13 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO {
      * ring of 12 hosts and a replication factor of 3 this method would return a Multimap with 3 keys and each key would
      * contain 4 token ranges.
      */
-    private Multimap<String, TokenRange> describeCassandraTopology(final CassandraKeyspace keyspace){
+    private Multimap<String, TokenRange> describeCassandraTopology(final Keyspace keyspace){
         try {
-            Keyspace astyanaxKeyspace = keyspace.getAstyanaxKeyspace();
             @SuppressWarnings ("unchecked")
-            ConnectionPool<Cassandra.Client> connectionPool = (ConnectionPool<Cassandra.Client>) astyanaxKeyspace.getConnectionPool();
+            ConnectionPool<Cassandra.Client> connectionPool = (ConnectionPool<Cassandra.Client>) keyspace.getConnectionPool();
 
             return connectionPool.executeWithFailover(
-                    new AbstractKeyspaceOperationImpl<Multimap<String, TokenRange>>(EmptyKeyspaceTracerFactory.getInstance().newTracer(CassandraOperationType.DESCRIBE_RING), keyspace.getName()) {
+                    new AbstractKeyspaceOperationImpl<Multimap<String, TokenRange>>(EmptyKeyspaceTracerFactory.getInstance().newTracer(CassandraOperationType.DESCRIBE_RING), keyspace.getKeyspaceName()) {
                         @Override
                         protected Multimap<String, TokenRange> internalExecute(Cassandra.Client client, ConnectionContext state)
                                 throws Exception {
@@ -472,12 +506,12 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO {
                                 // The final local endpoint "owns" the token range, the rest are for replication
                                 EndpointDetails endpointDetails = Iterables.getLast(tokenRange.getEndpoint_details());
                                 racks.put(endpointDetails.getRack(),
-                                        new TokenRangeImpl(tokenRange.getStart_token(), tokenRange.getEnd_token(), ImmutableList.<String>of()));
+                                        new TokenRangeImpl(tokenRange.getStart_token(), tokenRange.getEnd_token(), tokenRange.getEndpoints()));
                             }
                             return Multimaps.unmodifiableMultimap(racks);
                         }
                     },
-                    astyanaxKeyspace.getConfig().getRetryPolicy().duplicate()).getResult();
+                    keyspace.getConfig().getRetryPolicy().duplicate()).getResult();
         } catch (ConnectionException e) {
             throw Throwables.propagate(e);
         }
@@ -493,7 +527,7 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO {
         ColumnFamily<ByteBuffer, UUID> cf = placement.getDeltaColumnFamily();
 
         // Get the topology so the splits can be grouped by rack
-        Multimap<String, TokenRange> racks = describeCassandraTopology(keyspace);
+        Multimap<String, TokenRange> racks = describeCassandraTopology(keyspace.getAstyanaxKeyspace());
         ScanRangeSplits.Builder builder = ScanRangeSplits.builder();
 
         for (Map.Entry<String, Collection<TokenRange>> entry : racks.asMap().entrySet()) {
@@ -527,45 +561,17 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO {
                                                  TokenRange tokenRange, int desiredRecordsPerSplit, ScanRangeSplits.Builder builder) {
         // Split the token range into sub-ranges with approximately the desired number of records per split
         String rangeStart = tokenRange.getStartToken();
-        ByteBuffer rangeStartToken = parseTokenString(rangeStart);
 
-        List<CfSplit> unvalidatedSplits = getCfSplits(
+        List<CfSplit> splits = getCfSplits(
                 keyspace.getAstyanaxKeyspace(), cf, tokenRange.getStartToken(), tokenRange.getEndToken(),
-                desiredRecordsPerSplit, rangeStartToken);
+                desiredRecordsPerSplit);
 
-        // When getting splits of this size Cassandra sometimes does a poor job of estimating the size of a
-        // single split.  Continually re-split until all sizes are validated
-        List<CfSplit> resplits;
-        // To sanity check for an infinite loop from Cassandra, only allow a finite number of refinements.
-        int infiniteResplitCheck = 0;
+        for (CfSplit split : splits) {
+            ByteBuffer begin = parseTokenString(split.getStartToken());
+            ByteBuffer finish = parseTokenString(split.getEndToken());
 
-        while (!unvalidatedSplits.isEmpty()) {
-            if (infiniteResplitCheck++ == 500) {
-                throw new RuntimeException("Potential infinite scan range splits detected");
-            }
-
-            resplits = Lists.newArrayList();
-
-            for (CfSplit unvalidatedSplit : unvalidatedSplits) {
-                List<CfSplit> subSplits = getCfSplits(
-                        keyspace.getAstyanaxKeyspace(), cf, unvalidatedSplit.getStartToken(), unvalidatedSplit.getEndToken(),
-                        desiredRecordsPerSplit, parseTokenString(unvalidatedSplit.getStartToken()));
-
-                if (subSplits.size() == 1) {
-                    // Split is right-sized
-                    ByteBuffer begin = parseTokenString(unvalidatedSplit.getStartToken());
-                    ByteBuffer finish = parseTokenString(unvalidatedSplit.getEndToken());
-
-                    builder.addScanRange(rack, rangeStart, ScanRange.create(begin, finish));
-                } else {
-                    // Retry with each of the returned sub-splits
-                    resplits.addAll(subSplits);
-                }
-            }
-
-            unvalidatedSplits = resplits;
+            builder.addScanRange(rack, rangeStart, ScanRange.create(begin, finish));
         }
-
     }
 
     @Override


### PR DESCRIPTION
## Github Issue #

[44](https://github.com/bazaarvoice/emodb/issues/44)

## What Are We Doing Here?

This pull request updates the `describe_splits_ex` call to always route to a Cassandra node which has a replica of the requested token range.  When the call is routed to a node which does not the splits returned is always a single split equivalent to the full range requested.

## How to Test and Verify

1. Check out this PR
2. Create a table with many records
3. Get splits for the table with varying sizes and verify that each returned split is reasonably close to the requested size.
4. Perform a Stash run and verify the results.

Note that although the above will verify no regression issues locally to truly test the fix requires use of a Cassandra ring with at least 4 nodes.

## Risk

Medium.  Any regression would affect splits and Stash.

### Level 

`Medium`

### Required Testing

`Regression`

### Risk Summary

No additional risks not already addressed in above or in related issue.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.