### PR TITLE
Updated Cassandra health check to include CQL connection

### DIFF
--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/guava/MoreSuppliers.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/guava/MoreSuppliers.java
@@ -1,0 +1,90 @@
+package com.bazaarvoice.emodb.common.dropwizard.guava;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+import java.util.PrimitiveIterator;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Extension of {@link Suppliers}.
+ */
+public final class MoreSuppliers {
+
+    private MoreSuppliers() {
+        // empty
+    }
+
+    /**
+     * Memoization similar to {@link Suppliers#memoizeWithExpiration(Supplier, long, TimeUnit)} except the expiration
+     * is randomly selected to be a value within provided bounds.  For example:
+     *
+     * <code>
+     *     Supplier&lt;Object&t; supplier = MoreSuppliers.memoizeWithRandomExpiration(delegate, 5, 10, TimeUnit.SECONDS);
+     * </code>
+     *
+     * returns a Supplier that will memoize the delegate's response for a random number of nanoseconds between 5
+     * (inclusive) to 10 (exclusive) seconds.
+     *
+     * This is useful when numerous memoized values are typically computed independently but used within the same operation.
+     * If all values were computed and memoized together then each call that refreshes from delegate could take longer
+     * than desirable.  Similarly, if each value were memomized independently using the same expiration then herding
+     * behavior would result in the same long calls at expiration time.  A random expiration allows each value to be
+     * cached but spread out the refresh cycle so that it is unlikely that any single call will refresh the entire value
+     * set, so long as the call frequency is significantly below <code>minDuration</code>.
+     */
+    public static <T> Supplier<T> memoizeWithRandomExpiration(Supplier<T> delegate, long minDuration, long maxDuration, TimeUnit units) {
+        if (minDuration == maxDuration) {
+            // This case resolves to standard expiration
+            return Suppliers.memoizeWithExpiration(delegate, minDuration, units);
+        }
+        return new RandomExpirationSupplier<T>(delegate, minDuration, maxDuration, units);
+    }
+
+    /**
+     * Class modeled off of {@link Suppliers.ExpiringMemoizingSupplier} except the expiration time is randomly
+     * selected within the provided bounds for each iteration.
+     */
+    private final static class RandomExpirationSupplier<T> implements Supplier<T> {
+
+        private final Supplier<T> _delegate;
+        private final PrimitiveIterator.OfLong _nanosDurations;
+        private transient volatile T _value;
+        private transient volatile long _expirationNanos = 0;
+
+        RandomExpirationSupplier(Supplier<T> delegate, long minDuration, long maxDuration, TimeUnit timeUnit) {
+            checkArgument(minDuration >= 0, "minDuration cannot be negative");
+            checkArgument(maxDuration > minDuration, "maxDuration must be greater than minDuration");
+            checkNotNull(delegate, "delegate");
+            checkNotNull(timeUnit, "timeUnit");
+
+            long minDurationNanos = timeUnit.toNanos(minDuration);
+            long maxDurationNanos = timeUnit.toNanos(maxDuration);
+
+            _delegate = delegate;
+            _nanosDurations = new Random().longs(minDurationNanos, maxDurationNanos).iterator();
+        }
+
+        @Override
+        public T get() {
+            long expirationNanos = _expirationNanos;
+            long now = System.nanoTime();
+
+            if (expirationNanos == 0 || now - expirationNanos >= 0) {
+                synchronized(this) {
+                    if (expirationNanos == _expirationNanos) {
+                        _value = _delegate.get();
+                        expirationNanos = now + _nanosDurations.nextLong();
+                    }
+                    _expirationNanos = expirationNanos == 0 ? 1 : expirationNanos;
+                }
+            }
+
+            return _value;
+        }
+    }
+}


### PR DESCRIPTION
## Github Issue #

[46](https://github.com/bazaarvoice/emodb/issues/46)

## What Are We Doing Here?

This pull request has two changes:

1. As described in the corresponding issue, the Cassandra health check now performs a quick query to validate both the Astyanax and CQL drivers are connected as expected.
2. Added an element of randomization to the health check result cache to help avoid query herding on frequent health check calls.

## How to Test and Verify

1. Check out this PR
2. Build and start EmoDB
3. Call `localhost:8081/healthcheck`
4. Verify each Cassandra health check includes results from Astyanax and CQL.  For example:

```
{
  "databus-cassandra": {
    "message": "Astyanax: 127.0.0.1(127.0.0.1):9160 545us | CQL: /127.0.0.1:9164 -> /127.0.0.1 471us",
    "healthy": true
  }
}
```

## Risk

Low.  The updates are localized to the Cassandra health check.

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

No additional risks not already mentioned in the issue.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
