### PR TITLE
Fixed errors grandfathering-in pre-existing API keys to internal IDs

### DIFF
--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKey.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKey.java
@@ -4,7 +4,6 @@ import com.bazaarvoice.emodb.auth.identity.AuthIdentity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.hash.Hashing;
 
 import java.util.List;
 import java.util.Set;
@@ -23,20 +22,6 @@ public class ApiKey extends AuthIdentity {
                   @JsonProperty("internalId") String internalId,
                   @JsonProperty("roles") List<String> roles) {
 
-        // API keys have been in use since before internal IDs were introduced.  To grandfather in those keys we'll
-        // use a hash of the API key as the internal ID.
-        this(key, resolveInternalId(key, internalId), ImmutableSet.copyOf(roles));
-    }
-
-    private static String resolveInternalId(String key, String internalId) {
-        if (internalId != null) {
-            return internalId;
-        }
-        // SHA-256 is a little heavy but it has two advantages:
-        // 1.  It is the same algorithm currently used to store API keys by the permission manager so there isn't a
-        //     potential conflict between keys.
-        // 2.  The API keys are cached by Shiro so this conversion will only take place when the key needs to
-        //     be (re)loaded.
-        return Hashing.sha256().hashUnencodedChars(key).toString();
+        this(key, internalId, ImmutableSet.copyOf(roles));
     }
 }

--- a/quality/integration/src/test/java/test/integration/auth/TableAuthIdentityManagerTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/TableAuthIdentityManagerTest.java
@@ -1,0 +1,117 @@
+package test.integration.auth;
+
+import com.bazaarvoice.emodb.auth.apikey.ApiKey;
+import com.bazaarvoice.emodb.auth.identity.TableAuthIdentityManager;
+import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.bazaarvoice.emodb.sor.uuid.TimeUUIDs;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.hash.Hashing;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+
+public class TableAuthIdentityManagerTest {
+
+    /**
+     * There are two tables which store identities in TableAuthIdentityManager: One table keyed by a hash of the
+     * API key, and an index table ID'd by the internal ID which contains the API key hash.  This second table is used
+     * to look up API keys by internal ID.  It should be rare, but it is possible for an API key record to exist
+     * without a corresponding internal ID.  One possible way for this to happen is grandfathered in API keys
+     * created before the introduction of internal IDs.  TableAuthIdentityManager should rebuild the index
+     * when there is a missing or incorrect index record.  This test verifies that works as expected.
+     */
+    @Test
+    public void testRebuildInternalIdIndex() {
+        DataStore dataStore = new InMemoryDataStore(new MetricRegistry());
+        TableAuthIdentityManager<ApiKey> tableAuthIdentityManager = new TableAuthIdentityManager<>(
+                ApiKey.class, dataStore, "__auth:keys", "__auth:internal_ids", "app_global:sys", Hashing.sha256());
+
+        ApiKey apiKey = new ApiKey("testkey", "id0", ImmutableSet.of("role1", "role2"));
+        apiKey.setOwner("testowner");
+        tableAuthIdentityManager.updateIdentity(apiKey);
+
+        // Verify both tables have been written
+
+        String keyTableId = Hashing.sha256().hashUnencodedChars("testkey").toString();
+
+        Map<String, Object> keyMap = dataStore.get("__auth:keys", keyTableId);
+        assertFalse(Intrinsic.isDeleted(keyMap));
+        assertEquals(keyMap.get("owner"), "testowner");
+
+        Map<String, Object> indexMap = dataStore.get("__auth:internal_ids", "id0");
+        assertFalse(Intrinsic.isDeleted(indexMap));
+        assertEquals(indexMap.get("hashedId"), keyTableId);
+
+        // Deliberately delete the index map record
+        dataStore.update("__auth:internal_ids", "id0", TimeUUIDs.newUUID(), Deltas.delete(),
+                new AuditBuilder().setComment("test delete").build());
+
+        // Verify that a lookup by internal ID works
+        Set<String> roles = tableAuthIdentityManager.getRolesByInternalId("id0");
+        assertEquals(roles, ImmutableSet.of("role1", "role2"));
+
+        // Verify that the index record is re-created
+        indexMap = dataStore.get("__auth:internal_ids", "id0");
+        assertFalse(Intrinsic.isDeleted(indexMap));
+        assertEquals(indexMap.get("hashedId"), keyTableId);
+    }
+
+    @Test
+    public void testGrandfatheredInInternalId() {
+        DataStore dataStore = new InMemoryDataStore(new MetricRegistry());
+        TableAuthIdentityManager<ApiKey> tableAuthIdentityManager = new TableAuthIdentityManager<>(
+                ApiKey.class, dataStore, "__auth:keys", "__auth:internal_ids", "app_global:sys", Hashing.sha256());
+
+        // Perform an operation on tableAuthIdentityManager to force it to create API key tables; the actual
+        // operation doesn't matter.
+        tableAuthIdentityManager.getIdentity("ignore");
+
+        String id = "aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllll";
+        String hash = Hashing.sha256().hashUnencodedChars(id).toString();
+
+        // Write out a record which mimics the pre-internal-id format.  Notably missing is the "internalId" attribute.
+        Map<String, Object> oldIdentityMap = ImmutableMap.<String, Object>builder()
+                .put("maskedId", "aaaa****************************************llll")
+                .put("owner", "someone")
+                .put("description", "something")
+                .put("roles", ImmutableList.of("role1", "role2"))
+                .build();
+
+        dataStore.update("__auth:keys", hash, TimeUUIDs.newUUID(), Deltas.literal(oldIdentityMap),
+                new AuditBuilder().setComment("test grandfathering").build());
+
+        // Verify the record can be read by ID.  The key's internal ID will be the hashed ID.
+        ApiKey apiKey = tableAuthIdentityManager.getIdentity(id);
+        assertNotNull(apiKey);
+        assertEquals(apiKey.getId(), id);
+        assertEquals(apiKey.getInternalId(), hash);
+        assertEquals(apiKey.getOwner(), "someone");
+        assertEquals(apiKey.getDescription(), "something");
+        assertEquals(apiKey.getRoles(), ImmutableList.of("role1", "role2"));
+
+        // Verify that a lookup by internal ID works
+        Set<String> roles = tableAuthIdentityManager.getRolesByInternalId(hash);
+        assertEquals(roles, ImmutableSet.of("role1", "role2"));
+
+        // Verify that the index record was created with the hashed ID as the internal ID
+        Map<String, Object> indexMap = dataStore.get("__auth:internal_ids", hash);
+        assertFalse(Intrinsic.isDeleted(indexMap));
+        assertEquals(indexMap.get("hashedId"), hash);
+
+        // Verify lookup by internal ID still works with the index record in place
+        roles = tableAuthIdentityManager.getRolesByInternalId(hash);
+        assertEquals(roles, ImmutableSet.of("role1", "role2"));
+    }
+}


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

In https://github.com/bazaarvoice/emodb/pull/19 API keys were updated to also have an internal ID.  Several bugs were found when grandfathering in pre-existing API keys:

1. Lookup by internal ID isn't working
2. A null pointer exception is thrown updating the internal ID index for pre-existing API keys

The root cause for the first issue is that grandfathered-in API keys were using a hash of the API key as the internal ID.  However, since at the point in the code where the index is being rebuilt the API key is unknown it is using a stubbed value "ignore".  As a result the internal ID always matched the SHA-256 hash of "ignore" which was always a mismatch for the actual API key's hash.  The solution was to use the precomputed hash from the API key table, which is the key's intrinsic ID.  The result is the same, the hash of the API key is its internal ID, but now it is recovered correctly without needing to know the API key.

The root cause of the second issue is a side-effect of modifying the JSON map representation of the key in a method call.  The solution was to create a copy of the map to avoid such side effects.

## How to Test and Verify

It's difficult to test without manually changing some data on the backend.  To truly reproduce:

1. Check out the latest version of Emo without this fix
2. Run and create an API key with full permissions
3. Create a databus subscription with condition "alwaysTrue()"
4. Create a table and write a document to that table.
5. Fanout will fail due to the null pointer exception above.

With the fix in place fanout will succeed.  Polling on the subscription should return the created document.

## Risk

High.  Without this fix databus fanout will fail on any pre-existing API keys.

### Level 

`Medium`

### Required Testing

`Regression`

### Risk Summary

As previously stated, this is a must-fix bug for any EmoDB environment which contains API keys created prior to the introduction of internal IDs.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.

