### PR TITLE
Changed API deletion to instead set key as inactive

### DIFF
--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKey.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKey.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.auth.apikey;
 
 import com.bazaarvoice.emodb.auth.identity.AuthIdentity;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
@@ -13,15 +14,15 @@ import java.util.Set;
  */
 public class ApiKey extends AuthIdentity {
 
-    public ApiKey(String key, String internalId, Set<String> roles) {
-        super(key, internalId, roles);
+    public ApiKey(String key, String internalId, IdentityState state, Set<String> roles) {
+        super(key, internalId, state, roles);
     }
 
     @JsonCreator
     public ApiKey(@JsonProperty("id") String key,
                   @JsonProperty("internalId") String internalId,
+                  @JsonProperty("state") IdentityState state,
                   @JsonProperty("roles") List<String> roles) {
-
-        this(key, internalId, ImmutableSet.copyOf(roles));
+        this(key, internalId, state, ImmutableSet.copyOf(roles));
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentity.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentity.java
@@ -12,7 +12,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Base unit of identity for a client which can be authenticated in the application.
  */
-abstract public class AuthIdentity {
+abstract public class AuthIdentity implements InternalIdentity {
 
     /**
      * Each identity is associated with an internal ID which is never exposed outside the system.  This is done
@@ -49,13 +49,15 @@ abstract public class AuthIdentity {
     private String _description;
     // Date this identity was issued
     private Date _issued;
+    // State for this identity
+    private IdentityState _state;
 
-
-    protected AuthIdentity(String id, String internalId, Set<String> roles) {
+    protected AuthIdentity(String id, String internalId, IdentityState state, Set<String> roles) {
         checkArgument(!Strings.isNullOrEmpty(id), "id");
         checkArgument(!Strings.isNullOrEmpty(internalId), "internalId");
         _id = id;
         _internalId = internalId;
+        _state = state;
         _roles = ImmutableSet.copyOf(checkNotNull(roles, "roles"));
     }
 
@@ -63,14 +65,17 @@ abstract public class AuthIdentity {
         return _id;
     }
 
+    @Override
     public String getInternalId() {
         return _internalId;
     }
 
+    @Override
     public Set<String> getRoles() {
         return _roles;
     }
 
+    @Override
     public String getOwner() {
         return _owner;
     }
@@ -79,6 +84,7 @@ abstract public class AuthIdentity {
         _owner = owner;
     }
 
+    @Override
     public String getDescription() {
         return _description;
     }
@@ -87,11 +93,21 @@ abstract public class AuthIdentity {
         _description = description;
     }
 
+    @Override
     public Date getIssued() {
         return _issued;
     }
 
     public void setIssued(Date issued) {
         _issued = issued;
+    }
+
+    @Override
+    public IdentityState getState() {
+        return _state;
+    }
+
+    public void setState(IdentityState state) {
+        _state = state;
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentityManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentityManager.java
@@ -1,7 +1,5 @@
 package com.bazaarvoice.emodb.auth.identity;
 
-import java.util.Set;
-
 /**
  * Manager for identities.
  */
@@ -18,12 +16,34 @@ public interface AuthIdentityManager<T extends AuthIdentity> {
     void updateIdentity(T identity);
 
     /**
-     * Deletes an identity.
+     * Migrates an existing identity to a new identity.  The internal ID for the identity remains unchanged.
+     * This is useful if an identity has been compromised and the secret ID needs to be changed while keeping all other
+     * attributes of the identity unmodified.
      */
-    void deleteIdentity(String id);
+    void migrateIdentity(String existingId, String newId);
 
     /**
-     * Gets the roles associated with an identity by its internal ID.
+     * Deletes an identity.  This should NOT be called under normal circumstances and is in place to support internal
+     * testing.  This method deletes any record that the identity exists, leaving open the following possible vectors:
+     *
+     * <ol>
+     *     <li>The ID can be recreated, allowing the previous user to access using the ID.</li>
+     *     <li>A typical implementation stores the identity using a hash of the ID.  If another identity is created
+     *         whose ID hashes the same value then the previous users's ID would authenticate as the new ID.</li>
+     *     <li>As more of the system associates first order objects with owners there is an increased risk for
+     *         dangling identity references if they are deleted.</li>
+     * </ol>
+     *
+     * Under normal circumstances the correct approach is to set an identity's state to INACTIVE using
+     * {@link #updateIdentity(AuthIdentity)} rather than to delete the identity.
      */
-    Set<String> getRolesByInternalId(String internalId);
+    void deleteIdentityUnsafe(String id);
+
+    /**
+     * Returns an {@link InternalIdentity} view of the identity identified by internal ID, or null if no
+     * such entity exists.  This method is useful when internal operations are required for a user, such as
+     * verifying whether she has specific permissions, without actually logging the user in or exposing sufficient
+     * information for the caller to log the user in or spoof that user's identity.
+     */
+    InternalIdentity getInternalIdentity(String internalId);
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/IdentityState.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/IdentityState.java
@@ -1,0 +1,27 @@
+package com.bazaarvoice.emodb.auth.identity;
+
+/**
+ * State for an {@link AuthIdentity}.  Currently there are 3 possible values:
+ *
+ * <ol>
+ *     <li>ACTIVE.  This is the normal state for an identity.</li>
+ *     <li>INACTIVE.  The identity exists but cannot be authenticated or authorized for any operations.</li>
+ *     <li>MIGRATED.  The identity's ID has been migrated and the current identity is a historical record from the
+ *                    old ID.  Like INACTIVE, a MIGRATED identity cannot be authenticated or authorized.</li>
+ * </ol>
+ */
+public enum IdentityState {
+    ACTIVE,
+    INACTIVE,
+    MIGRATED;
+
+    /**
+     * Returns true if an identity is in a state where it can be authorized or authenticated.  The current
+     * implementation redundantly returns true only for ACTIVE.  Even so, use of this method is preferred to
+     * verify if an identity can be authorized or authenticated since that tautology may change if other states
+     * are introduced.
+     */
+    public boolean isActive() {
+        return this == ACTIVE;
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/InternalIdentity.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/InternalIdentity.java
@@ -1,0 +1,25 @@
+package com.bazaarvoice.emodb.auth.identity;
+
+import java.util.Date;
+import java.util.Set;
+
+/**
+ * Interface for getting information about an identity for internal purposes.  Notably it this interface does not
+ * expose the secret ID of the identity, such as its API key.  This allows use of the identity for validating
+ * permissions and other common metadata without exposing the ID necessary for logging in, spoofing, or otherwise
+ * leaking the identity.
+ */
+public interface InternalIdentity {
+
+    String getInternalId();
+
+    Set<String> getRoles();
+
+    String getOwner();
+
+    String getDescription();
+
+    Date getIssued();
+
+    IdentityState getState();
+}

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/CacheManagingAuthIdentityManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/CacheManagingAuthIdentityManager.java
@@ -2,8 +2,6 @@ package com.bazaarvoice.emodb.auth.identity;
 
 import com.bazaarvoice.emodb.auth.shiro.InvalidatableCacheManager;
 
-import java.util.Set;
-
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -33,15 +31,23 @@ public class CacheManagingAuthIdentityManager<T extends AuthIdentity> implements
     }
 
     @Override
-    public void deleteIdentity(String id) {
-        checkNotNull(id);
-        _manager.deleteIdentity(id);
+    public void migrateIdentity(String existingId, String newId) {
+        checkNotNull(existingId);
+        checkNotNull(newId);
+        _manager.migrateIdentity(existingId, newId);
         _cacheManager.invalidateAll();
     }
 
     @Override
-    public Set<String> getRolesByInternalId(String internalId) {
+    public void deleteIdentityUnsafe(String id) {
+        checkNotNull(id, "id");
+        _manager.deleteIdentityUnsafe(id);
+        _cacheManager.invalidateAll();
+    }
+
+    @Override
+    public InternalIdentity getInternalIdentity(String internalId) {
         checkNotNull(internalId, "internalId");
-        return _manager.getRolesByInternalId(internalId);
+        return _manager.getInternalIdentity(internalId);
     }
 }

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/DeferringAuthIdentityManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/DeferringAuthIdentityManager.java
@@ -1,14 +1,10 @@
 package com.bazaarvoice.emodb.auth.identity;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -64,20 +60,29 @@ public class DeferringAuthIdentityManager<T extends AuthIdentity> implements Aut
     }
 
     @Override
-    public void deleteIdentity(String id) {
-        checkNotNull(id);
-        checkArgument(!_identityMap.containsKey(id), "Cannot delete static identity: %s", id);
-        _manager.deleteIdentity(id);
+    public void migrateIdentity(String existingId, String newId) {
+        checkNotNull(existingId);
+        checkNotNull(newId);
+        checkArgument(!_identityMap.containsKey(existingId), "Cannot migrate from static identity: %s", existingId);
+        checkArgument(!_identityMap.containsKey(newId), "Cannot migrate to static identity: %s", newId);
+        _manager.migrateIdentity(existingId, newId);
     }
 
     @Override
-    public Set<String> getRolesByInternalId(String internalId) {
+    public void deleteIdentityUnsafe(String id) {
+        checkNotNull(id, "id");
+        checkArgument(!_identityMap.containsKey(id), "Cannot delete static identity: %s", id);
+        _manager.deleteIdentityUnsafe(id);
+    }
+
+    @Override
+    public InternalIdentity getInternalIdentity(String internalId) {
         checkNotNull(internalId, "internalId");
 
         T identity = _internalIdMap.get(internalId);
         if (identity != null) {
-            return identity.getRoles();
+            return identity;
         }
-        return _manager.getRolesByInternalId(internalId);
+        return _manager.getInternalIdentity(internalId);
     }
 }

--- a/auth/auth-test/src/test/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyRealmTest.java
+++ b/auth/auth-test/src/test/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyRealmTest.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.auth.apikey;
 
 import com.bazaarvoice.emodb.auth.identity.AuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.CacheManagingAuthIdentityManager;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.MatchingPermissionResolver;
 import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
@@ -33,7 +34,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -51,7 +51,7 @@ public class ApiKeyRealmTest {
         CacheRegistry cacheRegistry = new DefaultCacheRegistry(new SimpleLifeCycleRegistry(), new MetricRegistry());
         InvalidatableCacheManager _cacheManager = new GuavaCacheManager(cacheRegistry);
 
-        InMemoryAuthIdentityManager<ApiKey> authIdentityDAO = new InMemoryAuthIdentityManager<>();
+        InMemoryAuthIdentityManager<ApiKey> authIdentityDAO = new InMemoryAuthIdentityManager<>(ApiKey.class);
         _authIdentityManager = new CacheManagingAuthIdentityManager<>(authIdentityDAO, _cacheManager);
 
         _permissionManager = mock(PermissionManager.class);
@@ -216,7 +216,7 @@ public class ApiKeyRealmTest {
 
     @Test
     public void testPermissionCheckByInternalId() {
-        ApiKey apiKey = new ApiKey("apikey0", "id0", ImmutableList.of("role0"));
+        ApiKey apiKey = new ApiKey("apikey0", "id0", IdentityState.ACTIVE, ImmutableList.of("role0"));
         _authIdentityManager.updateIdentity(apiKey);
         Permission rolePermission = mock(Permission.class);
         Permission positivePermission = mock(Permission.class);
@@ -243,7 +243,7 @@ public class ApiKeyRealmTest {
 
     @Test
     public void testCachedPermissionCheckByInternalId() {
-        ApiKey apiKey = new ApiKey("apikey0", "id0", ImmutableList.of("role0"));
+        ApiKey apiKey = new ApiKey("apikey0", "id0", IdentityState.ACTIVE, ImmutableList.of("role0"));
         _authIdentityManager.updateIdentity(apiKey);
         Permission rolePermission = mock(Permission.class);
         Permission positivePermission = mock(Permission.class);

--- a/docs/_posts/2016-08-31-securityadmin.md
+++ b/docs/_posts/2016-08-31-securityadmin.md
@@ -131,13 +131,15 @@ roles: record_update, databus_standard
 issued: 11/13/14 12:01 PM
 ```
 
-### Delete API key
+### Inactivate API key
 
-You can delete an API key with the _delete_ action as in the following example:
+An inactive key can no longer be authenticated for access or authorized for any permissions.  Effectively it is
+deleted, although internally a record of the key exists to prevent re-use.  You can inactivate an API key with the
+_inactivate_ action as in the following example:
 
 ```
-$ curl -XPOST 'localhost:8081/tasks/api-key?action=delete&APIKey=pebbles&key=kp7w6odzin5zki7riqhduadisi7a6wa7cobbfbb379e3z6q5'
-API key deleted
+$ curl -XPOST 'localhost:8081/tasks/api-key?action=inactivate&APIKey=pebbles&key=kp7w6odzin5zki7riqhduadisi7a6wa7cobbfbb379e3z6q5'
+API key inactivated
 ```
 
 Permissions

--- a/quality/integration/src/test/java/com/bazaarvoice/emodb/test/ResourceTest.java
+++ b/quality/integration/src/test/java/com/bazaarvoice/emodb/test/ResourceTest.java
@@ -38,7 +38,7 @@ public abstract class ResourceTest {
     }
 
     protected static ResourceTestRule setupResourceTestRule(List<Object> resourceList, List<Object> filters, ApiKey apiKey, ApiKey unauthorizedKey, String typeName) {
-        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
+        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>(ApiKey.class);
         authIdentityManager.updateIdentity(apiKey);
         authIdentityManager.updateIdentity(unauthorizedKey);
 

--- a/quality/integration/src/test/java/test/integration/auth/RoleAdminTaskTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/RoleAdminTaskTest.java
@@ -4,6 +4,7 @@ import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeyRealm;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeySecurityManager;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
@@ -46,7 +47,7 @@ public class RoleAdminTaskTest {
 
     @BeforeMethod
     public void setUp() {
-        _authIdentityManager = new InMemoryAuthIdentityManager<>();
+        _authIdentityManager = new InMemoryAuthIdentityManager<>(ApiKey.class);
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(mock(DataStore.class), mock(BlobStore.class));
         _permissionManager = new InMemoryPermissionManager(permissionResolver);
 
@@ -56,7 +57,7 @@ public class RoleAdminTaskTest {
                         null));
 
         _task = new RoleAdminTask(securityManager, _permissionManager, mock(TaskRegistry.class));
-        _authIdentityManager.updateIdentity(new ApiKey("test-admin", "id_admin", ImmutableSet.of(DefaultRoles.admin.toString())));
+        _authIdentityManager.updateIdentity(new ApiKey("test-admin", "id_admin", IdentityState.ACTIVE, ImmutableSet.of(DefaultRoles.admin.toString())));
     }
 
     @AfterMethod

--- a/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
@@ -1,6 +1,7 @@
 package test.integration.blob;
 
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
@@ -102,11 +103,11 @@ public class BlobStoreJerseyTest extends ResourceTest {
     public ResourceTestRule _resourceTestRule = setupResourceTestRule();
 
     private ResourceTestRule setupResourceTestRule() {
-        final InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB, "id0", ImmutableSet.of("blob-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_UNAUTHORIZED, "id1", ImmutableSet.of("unauthorized-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB_A, "id2", ImmutableSet.of("blob-role-a")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB_B, "id3", ImmutableSet.of("blob-role-b")));
+        final InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>(ApiKey.class);
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB, "id0", IdentityState.ACTIVE, ImmutableSet.of("blob-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_UNAUTHORIZED, "id1", IdentityState.ACTIVE, ImmutableSet.of("unauthorized-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB_A, "id2", IdentityState.ACTIVE, ImmutableSet.of("blob-role-a")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_BLOB_B, "id3", IdentityState.ACTIVE, ImmutableSet.of("blob-role-b")));
 
         final EmoPermissionResolver permissionResolver = new EmoPermissionResolver(mock(DataStore.class), _server);
         final InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);

--- a/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
@@ -2,6 +2,7 @@ package test.integration.databus;
 
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.auth.jersey.Subject;
 import com.bazaarvoice.emodb.common.api.ServiceUnavailableException;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
@@ -111,8 +112,8 @@ public class DatabusJerseyTest extends ResourceTest {
     @Rule
     public ResourceTestRule _resourceTestRule = setupResourceTestRule(
             Collections.<Object>singletonList(new DatabusResource1(_local, _client, mock(DatabusEventStore.class), new DatabusResourcePoller(new MetricRegistry()))),
-                    new ApiKey(APIKEY_DATABUS, INTERNAL_ID_DATABUS, ImmutableSet.of("databus-role")),
-                    new ApiKey(APIKEY_UNAUTHORIZED, INTERNAL_ID_UNAUTHORIZED, ImmutableSet.of("unauthorized-role")),
+                    new ApiKey(APIKEY_DATABUS, INTERNAL_ID_DATABUS, IdentityState.ACTIVE, ImmutableSet.of("databus-role")),
+                    new ApiKey(APIKEY_UNAUTHORIZED, INTERNAL_ID_UNAUTHORIZED, IdentityState.ACTIVE, ImmutableSet.of("unauthorized-role")),
                     "databus");
 
     @After

--- a/quality/integration/src/test/java/test/integration/databus/ReplicationJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/ReplicationJerseyTest.java
@@ -1,6 +1,7 @@
 package test.integration.databus;
 
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
@@ -38,11 +39,11 @@ public class ReplicationJerseyTest extends ResourceTest {
 
     @Rule
     public ResourceTestRule _resourceTestRule = setupReplicationResourceTestRule(ImmutableList.<Object>of(new ReplicationResource1(_server)),
-            new ApiKey(APIKEY_REPLICATION, "repl", ImmutableSet.of("replication-role")),
-            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", ImmutableSet.of("unauthorized-role")));
+            new ApiKey(APIKEY_REPLICATION, "repl", IdentityState.ACTIVE, ImmutableSet.of("replication-role")),
+            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", IdentityState.ACTIVE, ImmutableSet.of("unauthorized-role")));
 
     protected static ResourceTestRule setupReplicationResourceTestRule(List<Object> resourceList, ApiKey apiKey, ApiKey unauthorizedKey) {
-        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
+        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>(ApiKey.class);
         authIdentityManager.updateIdentity(apiKey);
         authIdentityManager.updateIdentity(unauthorizedKey);
 

--- a/quality/integration/src/test/java/test/integration/exceptions/ExceptionMapperJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/exceptions/ExceptionMapperJerseyTest.java
@@ -1,6 +1,7 @@
 package test.integration.exceptions;
 
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.blob.api.BlobNotFoundException;
 import com.bazaarvoice.emodb.blob.api.RangeNotSatisfiableException;
 import com.bazaarvoice.emodb.common.json.JsonStreamProcessingException;
@@ -39,8 +40,8 @@ public class ExceptionMapperJerseyTest extends ResourceTest {
 
     @Rule
     public ResourceTestRule _resourceTestRule = setupResourceTestRule(Collections.<Object>singletonList(new ExceptionResource()),
-            new ApiKey("unused", "id0", ImmutableSet.<String>of()),
-            new ApiKey("also-unused", "id1", ImmutableSet.<String>of()),
+            new ApiKey("unused", "id0", IdentityState.ACTIVE, ImmutableSet.<String>of()),
+            new ApiKey("also-unused", "id1", IdentityState.ACTIVE, ImmutableSet.<String>of()),
             "exception");
 
     @Test

--- a/quality/integration/src/test/java/test/integration/queue/DedupQueueJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/queue/DedupQueueJerseyTest.java
@@ -1,6 +1,7 @@
 package test.integration.queue;
 
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.common.api.ServiceUnavailableException;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
 import com.bazaarvoice.emodb.common.jersey.dropwizard.JerseyEmoClient;
@@ -56,8 +57,8 @@ public class DedupQueueJerseyTest extends ResourceTest {
 
     @Rule
     public ResourceTestRule _resourceTestRule = setupResourceTestRule(Collections.<Object>singletonList(new DedupQueueResource1(_server, DedupQueueServiceAuthenticator.proxied(_proxy))),
-            new ApiKey(APIKEY_QUEUE, "queue", ImmutableSet.of("queue-role")),
-            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", ImmutableSet.of("unauthorized-role")),
+            new ApiKey(APIKEY_QUEUE, "queue", IdentityState.ACTIVE, ImmutableSet.of("queue-role")),
+            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", IdentityState.ACTIVE, ImmutableSet.of("unauthorized-role")),
             "queue");
 
     @After

--- a/quality/integration/src/test/java/test/integration/queue/QueueJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/queue/QueueJerseyTest.java
@@ -1,6 +1,7 @@
 package test.integration.queue;
 
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.client.EmoClientException;
 import com.bazaarvoice.emodb.common.api.ServiceUnavailableException;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
@@ -57,8 +58,8 @@ public class QueueJerseyTest extends ResourceTest {
 
     @Rule
     public ResourceTestRule _resourceTestRule = setupResourceTestRule(Collections.<Object>singletonList(new QueueResource1(_server, QueueServiceAuthenticator.proxied(_proxy))),
-            new ApiKey(APIKEY_QUEUE, "queue", ImmutableSet.of("queue-role")),
-            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", ImmutableSet.of("unauthorized-role")),
+            new ApiKey(APIKEY_QUEUE, "queue", IdentityState.ACTIVE, ImmutableSet.of("queue-role")),
+            new ApiKey(APIKEY_UNAUTHORIZED, "unauth", IdentityState.ACTIVE, ImmutableSet.of("unauthorized-role")),
             "queue");
 
     @After

--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -3,6 +3,7 @@ package test.integration.sor;
 import com.bazaarvoice.emodb.auth.InvalidCredentialException;
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
@@ -109,6 +110,7 @@ public class DataStoreJerseyTest extends ResourceTest {
     private static final String APIKEY_REVIEWS_ONLY = "reviews-only-key";
     private static final String APIKEY_STANDARD = "standard-key";
     private static final String APIKEY_STANDARD_UPDATE = "standard-update";
+    private static final String APIKEY_INACTIVE = "inactive";
 
     private DataStore _server = mock(DataStore.class);
     private DataCenters _dataCenters = mock(DataCenters.class);
@@ -117,14 +119,15 @@ public class DataStoreJerseyTest extends ResourceTest {
     public ResourceTestRule _resourceTestRule = setupDataStoreResourceTestRule();
 
     private ResourceTestRule setupDataStoreResourceTestRule() {
-        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_TABLE, "id0", ImmutableSet.of("table-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_READ_TABLES_A, "id1", ImmutableSet.of("tables-a-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_READ_TABLES_B, "id2", ImmutableSet.of("tables-b-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_FACADE, "id3", ImmutableSet.of("facade-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_REVIEWS_ONLY, "id4", ImmutableSet.of("reviews-only-role")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_STANDARD, "id5", ImmutableSet.of("standard")));
-        authIdentityManager.updateIdentity(new ApiKey(APIKEY_STANDARD_UPDATE, "id5", ImmutableSet.of("update-with-events")));
+        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>(ApiKey.class);
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_TABLE, "id0", IdentityState.ACTIVE, ImmutableSet.of("table-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_READ_TABLES_A, "id1", IdentityState.ACTIVE, ImmutableSet.of("tables-a-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_READ_TABLES_B, "id2", IdentityState.ACTIVE, ImmutableSet.of("tables-b-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_FACADE, "id3", IdentityState.ACTIVE, ImmutableSet.of("facade-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_REVIEWS_ONLY, "id4", IdentityState.ACTIVE, ImmutableSet.of("reviews-only-role")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_STANDARD, "id5", IdentityState.ACTIVE, ImmutableSet.of("standard")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_STANDARD_UPDATE, "id5", IdentityState.ACTIVE, ImmutableSet.of("update-with-events")));
+        authIdentityManager.updateIdentity(new ApiKey(APIKEY_INACTIVE, "id6", IdentityState.INACTIVE, ImmutableSet.of("table-role")));
 
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(_server, mock(BlobStore.class));
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
@@ -1336,5 +1339,11 @@ public class DataStoreJerseyTest extends ResourceTest {
     @Test (expected = InvalidCredentialException.class)
     public void testClientWithEmptyApiKey() {
         sorClient("");
+    }
+
+    @Test (expected = UnauthorizedException.class)
+    public void testInactiveApiKey() {
+        // APIKEY_INACTIVE has permission to list tables, but since it is inactive this request should be denied
+        sorClient(APIKEY_INACTIVE).listTables(null, 10);
     }
 }

--- a/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
@@ -1,6 +1,7 @@
 package test.integration.throttle;
 
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
@@ -99,8 +100,8 @@ public class AdHocThrottleTest extends ResourceTest {
     public ResourceTestRule _resourceTestRule = setupDataStoreResourceTestRule();
 
     private ResourceTestRule setupDataStoreResourceTestRule() {
-        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
-        authIdentityManager.updateIdentity(new ApiKey(API_KEY, "id", ImmutableList.of("all-sor-role")));
+        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>(ApiKey.class);
+        authIdentityManager.updateIdentity(new ApiKey(API_KEY, "id", IdentityState.ACTIVE, ImmutableList.of("all-sor-role")));
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(_dataStore, mock(BlobStore.class));
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         permissionManager.updateForRole(

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
@@ -9,6 +9,7 @@ import com.bazaarvoice.emodb.auth.dropwizard.DropwizardAuthConfigurator;
 import com.bazaarvoice.emodb.auth.identity.AuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.CacheManagingAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.DeferringAuthIdentityManager;
+import com.bazaarvoice.emodb.auth.identity.IdentityState;
 import com.bazaarvoice.emodb.auth.identity.TableAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.CacheManagingPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.DeferringPermissionManager;
@@ -187,11 +188,11 @@ public class SecurityModule extends PrivateModule {
 
         ImmutableList.Builder<ApiKey> reservedIdentities = ImmutableList.builder();
         reservedIdentities.add(
-                new ApiKey(replicationKey, REPLICATION_INTERNAL_ID, ImmutableSet.of(DefaultRoles.replication.toString())),
-                new ApiKey(adminKey, ADMIN_INTERNAL_ID, ImmutableSet.of(DefaultRoles.admin.toString())));
+                new ApiKey(replicationKey, REPLICATION_INTERNAL_ID, IdentityState.ACTIVE, ImmutableSet.of(DefaultRoles.replication.toString())),
+                new ApiKey(adminKey, ADMIN_INTERNAL_ID, IdentityState.ACTIVE, ImmutableSet.of(DefaultRoles.admin.toString())));
 
         if (anonymousKey.isPresent()) {
-            reservedIdentities.add(new ApiKey(anonymousKey.get(), ANONYMOUS_INTERNAL_ID, ImmutableSet.of(DefaultRoles.anonymous.toString())));
+            reservedIdentities.add(new ApiKey(anonymousKey.get(), ANONYMOUS_INTERNAL_ID, IdentityState.ACTIVE, ImmutableSet.of(DefaultRoles.anonymous.toString())));
         }
 
         AuthIdentityManager<ApiKey> deferring = new DeferringAuthIdentityManager<>(daoManager, reservedIdentities.build());


### PR DESCRIPTION
## Github Issue

[49](https://github.com/bazaarvoice/emodb/issues/49)
## What Are We Doing Here?

This PR implements https://github.com/bazaarvoice/emodb/issues/49 as described.  API keys are no longer deleted but put into an inactive state.  An inactive API key exists but cannot be used to authorize or authenticate any permissions.  In addition there is a third state, _migrated_, to track API keys which have been migrated.

Existing API keys are grandfathered in as active.
## How to Test and Verify
1. Check out this PR
2. Create an API key:
   
   ```
   $ curl -XPOST 'localhost:8081/tasks/api-key?action=create&owner=me&description=desc&role=standard&APIKey=local_admin'
   API key: rbhroxstezbhrbnagekfplr2iw6vzgb5x9myesf8rykh7maj
   
   Warning:  This is your only chance to see this key.  Save it somewhere now.
   ```
3. Verify the API key is working:
   
   ```
   $ curl -XPUT "localhost:8080/bus/1/test-sub" -H "X-BV-API-Key: rbhroxstezbhrbnagekfplr2iw6vzgb5x9myesf8rykh7maj"  -H "Content-Type: application/x.json-condition" -d 'alwaysTrue()'
   {"success":true}
   ```
4. Delete the API key:
   
   ```
   $ curl -XPOST 'localhost:8081/tasks/api-key?action=delete&key=rbhroxstezbhrbnagekfplr2iw6vzgb5x9myesf8rykh7maj&APIKey=local_admin'
   API key deleted
   ```
5. Verify the API key is inactive:
   
   ```
   $ curl -XPOST 'localhost:8081/tasks/api-key?action=view&key=rbhroxstezbhrbnagekfplr2iw6vzgb5x9myesf8rykh7maj&APIKey=local_admin'
   owner: me
   description: desc
   state: INACTIVE
   roles: standard
   issued: 10/20/16 4:49 PM
   ```

6: Verify the API can no longer authenticate:

```
$ curl -XPUT "localhost:8080/bus/1/test-sub" -H "X-BV-API-Key: rbhroxstezbhrbnagekfplr2iw6vzgb5x9myesf8rykh7maj"  -H "Content-Type: application/x.json-condition" -d 'alwaysTrue()'
{"reason":"not authenticated"}
```
## Risk

Most the risk involves backwards compatibility.  If there is an issue with backwards compatibility then existing API keys may not be able to access Emo.
### Level

`Medium`
### Required Testing

`Manual`
### Risk Summary

In my opinion the riskiest area is the interplay between migrating and invalidating keys.  Although I've tested this in detail I'd recommend a close review of the code to migrate API keys and then lookup API keys by internal ID: [here](https://github.com/billkalter/emodb/blob/emo-6138/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/TableAuthIdentityManager.java#L132) and [here](https://github.com/billkalter/emodb/blob/emo-6138/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/TableAuthIdentityManager.java#L188).
## Code Review Checklist
- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.
- [ ] Pulled down the PR and performed verification of at least being able to
  build and run.
- [ ] Well documented, including updates to any necessary markdown files. When
  we inevitably come back to this code it will only take hours to figure out, not
  days.
- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
  a victim of rampaging consistency, and should be using this course of action. 
  We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.
- [ ] PR has a valid summary, and a good description.
