### PR TITLE
Fixed reentrant dependency injection of DataStore in non-system data centers

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -27,7 +27,7 @@ import com.bazaarvoice.emodb.sor.admin.RowKeyTask;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.core.AuditStore;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
-import com.bazaarvoice.emodb.sor.core.DataStoreProxy;
+import com.bazaarvoice.emodb.sor.core.DataStoreProviderProxy;
 import com.bazaarvoice.emodb.sor.core.DataTools;
 import com.bazaarvoice.emodb.sor.core.DefaultAuditStore;
 import com.bazaarvoice.emodb.sor.core.DefaultDataStore;
@@ -106,6 +106,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.inject.Exposed;
 import com.google.inject.Key;
 import com.google.inject.PrivateModule;
+import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
@@ -265,15 +266,16 @@ public class DataStoreModule extends PrivateModule {
     }
 
     @Provides @Singleton
-    DataStore provideDataStore(@LocalDataStore DataStore localDataStore, @SystemDataStore DataStore systemDataStore,
-                                     DataCenterConfiguration dataCenterConfiguration) {
+    DataStore provideDataStore(@LocalDataStore Provider<DataStore> localDataStoreProvider,
+                               @SystemDataStore Provider<DataStore> systemDataStoreProvider,
+                               DataCenterConfiguration dataCenterConfiguration) {
         // Provides the unannotated version of the DataStore
         // If this is the system data center, return the local DataStore implementation
         // Otherwise return a proxy that delegates to local or remote system DataStores
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            return localDataStore;
+            return localDataStoreProvider.get();
         } else {
-            return new DataStoreProxy(localDataStore, systemDataStore);
+            return new DataStoreProviderProxy(localDataStoreProvider, systemDataStoreProvider);
         }
     }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreProviderProxy.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreProviderProxy.java
@@ -14,7 +14,8 @@ import com.bazaarvoice.emodb.sor.api.UnknownTableException;
 import com.bazaarvoice.emodb.sor.api.Update;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
 import com.bazaarvoice.emodb.sor.delta.Delta;
-import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
@@ -27,174 +28,177 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * Supports delegation of DDL operations to the system data center.
+ * Supports delegation of DDL operations to the system data center.  This implementation uses a Providers for
+ * the data stores to prevent re-entrant injection issues.
  */
-public class DataStoreProxy implements DataStore {
+public class DataStoreProviderProxy implements DataStore {
 
-    private final DataStore _local;
-    private final DataStore _system;
+    private final Provider<DataStore> _local;
+    private final Provider<DataStore> _system;
 
-    public DataStoreProxy(DataStore local, DataStore system) {
+    @Inject
+    public DataStoreProviderProxy(@LocalDataStore Provider<DataStore> local, @SystemDataStore Provider<DataStore> system) {
+        // The underlying providers use singletons so using Provider.get() in the implementation methods should be efficient
         _local = local;
         _system = system;
     }
 
     @Override
     public Iterator<Table> listTables(@Nullable String fromTableExclusive, long limit) {
-        return _local.listTables(fromTableExclusive, limit);
+        return _local.get().listTables(fromTableExclusive, limit);
     }
 
     @Override
     public void createTable(String table, TableOptions options, Map<String, ?> template, Audit audit) throws TableExistsException {
         // delegate to system data center
-        _system.createTable(table, options, template, audit);
+        _system.get().createTable(table, options, template, audit);
     }
 
     @Override
     public void dropTable(String table, Audit audit) throws UnknownTableException {
         // delegate to system data center
-        _system.dropTable(table, audit);
+        _system.get().dropTable(table, audit);
     }
 
     @Override
     public void purgeTableUnsafe(String table, Audit audit) throws UnknownTableException {
-        _local.purgeTableUnsafe(table, audit);
+        _local.get().purgeTableUnsafe(table, audit);
     }
 
     @Override
     public boolean getTableExists(String table) {
-        return _local.getTableExists(table);
+        return _local.get().getTableExists(table);
     }
 
     @Override
     public boolean isTableAvailable(String table) {
-        return _local.isTableAvailable(table);
+        return _local.get().isTableAvailable(table);
     }
 
     @Override
     public Table getTableMetadata(String table) {
-        return _local.getTableMetadata(table);
+        return _local.get().getTableMetadata(table);
     }
 
     @Override
     public Map<String, Object> getTableTemplate(String table) throws UnknownTableException {
-        return _local.getTableTemplate(table);
+        return _local.get().getTableTemplate(table);
     }
 
     @Override
     public void setTableTemplate(String table, Map<String, ?> template, Audit audit) throws UnknownTableException {
-        _local.setTableTemplate(table, template, audit);
+        _local.get().setTableTemplate(table, template, audit);
     }
 
     @Override
     public TableOptions getTableOptions(String table) throws UnknownTableException {
-        return _local.getTableOptions(table);
+        return _local.get().getTableOptions(table);
     }
 
     @Override
     public long getTableApproximateSize(String table) throws UnknownTableException {
-        return _local.getTableApproximateSize(table);
+        return _local.get().getTableApproximateSize(table);
     }
 
     @Override
     public long getTableApproximateSize(String table, int limit) throws UnknownTableException {
-        return _local.getTableApproximateSize(table, limit);
+        return _local.get().getTableApproximateSize(table, limit);
     }
 
     @Override
     public Map<String, Object> get(String table, String key) {
-        return _local.get(table, key);
+        return _local.get().get(table, key);
     }
 
     @Override
     public Map<String, Object> get(String table, String key, ReadConsistency consistency) {
-        return _local.get(table, key, consistency);
+        return _local.get().get(table, key, consistency);
     }
 
     @Override
     public Iterator<Change> getTimeline(String table, String key, boolean includeContentData, boolean includeAuditInformation, @Nullable UUID start, @Nullable UUID end, boolean reversed, long limit, ReadConsistency consistency) {
-        return _local.getTimeline(table, key, includeContentData, includeAuditInformation, start, end, reversed, limit, consistency);
+        return _local.get().getTimeline(table, key, includeContentData, includeAuditInformation, start, end, reversed, limit, consistency);
     }
 
     @Override
     public Iterator<Map<String, Object>> scan(String table, @Nullable String fromKeyExclusive, long limit, ReadConsistency consistency) {
-        return _local.scan(table, fromKeyExclusive, limit, consistency);
+        return _local.get().scan(table, fromKeyExclusive, limit, consistency);
     }
 
     @Override
     public Collection<String> getSplits(String table, int desiredRecordsPerSplit) {
-        return _local.getSplits(table, desiredRecordsPerSplit);
+        return _local.get().getSplits(table, desiredRecordsPerSplit);
     }
 
     @Override
     public Iterator<Map<String, Object>> getSplit(String table, String split, @Nullable String fromKeyExclusive, long limit, ReadConsistency consistency) {
-        return _local.getSplit(table, split, fromKeyExclusive, limit, consistency);
+        return _local.get().getSplit(table, split, fromKeyExclusive, limit, consistency);
     }
 
     @Override
     public Iterator<Map<String, Object>> multiGet(List<Coordinate> coordinates) {
-        return _local.multiGet(coordinates);
+        return _local.get().multiGet(coordinates);
     }
 
     @Override
     public Iterator<Map<String, Object>> multiGet(List<Coordinate> coordinates, ReadConsistency consistency) {
-        return _local.multiGet(coordinates, consistency);
+        return _local.get().multiGet(coordinates, consistency);
     }
 
     @Override
     public void update(String table, String key, UUID changeId, Delta delta, Audit audit) {
-        _local.update(table, key, changeId, delta, audit);
+        _local.get().update(table, key, changeId, delta, audit);
     }
 
     @Override
     public void update(String table, String key, UUID changeId, Delta delta, Audit audit, WriteConsistency consistency) {
-        _local.update(table, key, changeId, delta, audit, consistency);
+        _local.get().update(table, key, changeId, delta, audit, consistency);
     }
 
     @Override
     public void updateAll(Iterable<Update> updates) {
-        _local.updateAll(updates);
+        _local.get().updateAll(updates);
     }
 
     @Override
     public void updateAll(Iterable<Update> updates, Set<String> tags) {
-        _local.updateAll(updates, tags);
+        _local.get().updateAll(updates, tags);
     }
 
     @Override
     public void compact(String table, String key, @Nullable Duration ttlOverride, ReadConsistency readConsistency, WriteConsistency writeConsistency) {
-        _local.compact(table, key, ttlOverride, readConsistency, writeConsistency);
+        _local.get().compact(table, key, ttlOverride, readConsistency, writeConsistency);
     }
 
     @Override
     public Collection<String> getTablePlacements() {
-        return _local.getTablePlacements();
+        return _local.get().getTablePlacements();
     }
 
     @Override
     public void createFacade(String table, FacadeOptions options, Audit audit) throws TableExistsException {
         // delegate to system data center
-        _system.createFacade(table, options, audit);
+        _system.get().createFacade(table, options, audit);
     }
 
     @Override
     public void updateAllForFacade(Iterable<Update> updates) {
-        _local.updateAllForFacade(updates);
+        _local.get().updateAllForFacade(updates);
     }
 
     @Override
     public void updateAllForFacade(Iterable<Update> updates, Set<String> tags) {
-        _local.updateAllForFacade(updates, tags);
+        _local.get().updateAllForFacade(updates, tags);
     }
 
     @Override
     public void dropFacade(String table, String placement, Audit audit) throws UnknownTableException {
         // delegate to system data center
-        _system.dropFacade(table, placement, audit);
+        _system.get().dropFacade(table, placement, audit);
     }
 
     @Override
     public URI getStashRoot() throws StashNotAvailableException {
-        return _local.getStashRoot();
+        return _local.get().getStashRoot();
     }
 }


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

After merging in https://github.com/bazaarvoice/emodb/pull/19 EmoDB fails to start with the following exception:

```
com.google.inject.CreationException: Guice creation errors:

1) Provider was reentrant while creating a singleton
  at com.bazaarvoice.emodb.sor.DataStoreModule.provideDataStore(DataStoreModule.java:276)
  while locating com.bazaarvoice.emodb.sor.api.DataStore
  at com.bazaarvoice.emodb.web.auth.SecurityModule.provideAuthIdentityManagerDAO(SecurityModule.java:175)
  at com.bazaarvoice.emodb.web.auth.SecurityModule.provideAuthIdentityManagerDAO(SecurityModule.java:175)
  while locating com.bazaarvoice.emodb.auth.identity.AuthIdentityManager<com.bazaarvoice.emodb.auth.apikey.ApiKey> annotated with @com.google.inject.name.Named(value=dao)
  at com.bazaarvoice.emodb.web.auth.SecurityModule.provideAuthIdentityManager(SecurityModule.java:188)
  at com.bazaarvoice.emodb.web.auth.SecurityModule.provideAuthIdentityManager(SecurityModule.java:188)
  while locating com.bazaarvoice.emodb.auth.identity.AuthIdentityManager<com.bazaarvoice.emodb.auth.apikey.ApiKey>
  at com.bazaarvoice.emodb.web.auth.SecurityModule.provideSecurityManager(SecurityModule.java:114)
  at com.bazaarvoice.emodb.web.auth.SecurityModule.provideSecurityManager(SecurityModule.java:114)
  while locating com.bazaarvoice.emodb.auth.EmoSecurityManager
  while locating com.bazaarvoice.emodb.auth.InternalAuthorizer
    for parameter 0 at com.bazaarvoice.emodb.web.auth.OwnerDatabusAuthorizer.<init>(OwnerDatabusAuthorizer.java:69)
  at com.bazaarvoice.emodb.web.EmoModule$DatabusSetup.configure(EmoModule.java:355)
  while locating com.bazaarvoice.emodb.web.auth.OwnerDatabusAuthorizer
```

This is not the first time an issue similar to this has come up with injecting the DataStore.  The solution taken here is to lazily provide the DataStore when in a non-system data center.  This allows all injections to succeed without circular dependencies.

## How to Test and Verify

1. Check out this PR
2. Run two EmoDB's locally.  They can use the same Cassandra, but change the ports and data centers to make each one unique.
3. Verify both start correctly without errors.

## Risk

Without this change Emo cannot start in a non-system data center.

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

No additional risks.  It's possible to fix the issue in `SecurityModule` using Provider injection for the DataStore, but this approach seems to resolve the issue at its root.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.