### PR TITLE
Added a new multiTableScanWithCutoffTime() method which would ignore …

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataTools.java
@@ -8,10 +8,13 @@ import com.bazaarvoice.emodb.sor.db.ScanRange;
 import com.bazaarvoice.emodb.sor.db.ScanRangeSplits;
 import com.bazaarvoice.emodb.table.db.TableSet;
 import com.google.common.base.Optional;
+import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.UUID;
 
 public interface DataTools {
     /**
@@ -35,9 +38,9 @@ public interface DataTools {
     String getPlacementCluster(String placement);
 
     /**
-     * For performing a raw scan across multiple tables.
+     * For performing a raw scan across multiple tables. If cut off time is provided, then NO Changes after that time will be included.
      */
-    Iterator<MultiTableScanResult> multiTableScan(MultiTableScanOptions query, TableSet tables, LimitCounter limit, ReadConsistency consistency);
+    Iterator<MultiTableScanResult> multiTableScan(MultiTableScanOptions query, TableSet tables, LimitCounter limit, ReadConsistency consistency, @Nullable DateTime cutoffTime);
 
     /**
      * Resolve a scan record into a single JSON literal object + metadata.  If allowAsyncCompaction is true then it may

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
@@ -51,6 +51,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
+import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
@@ -751,12 +752,12 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
     }
 
     @Override
-    public Iterator<MultiTableScanResult> multiTableScan(MultiTableScanOptions query, TableSet tables, LimitCounter limit, ReadConsistency consistency) {
+    public Iterator<MultiTableScanResult> multiTableScan(MultiTableScanOptions query, TableSet tables, LimitCounter limit, ReadConsistency consistency, @Nullable DateTime cutoffTime) {
         checkNotNull(query, "query");
         checkNotNull(tables, "tables");
         checkNotNull(limit, "limit");
         checkNotNull(consistency, "consistency");
-        return _dataReaderDao.multiTableScan(query, tables, limit, consistency);
+        return _dataReaderDao.multiTableScan(query, tables, limit, consistency, cutoffTime);
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DataReaderDAO.java
@@ -6,6 +6,7 @@ import com.bazaarvoice.emodb.sor.api.ReadConsistency;
 import com.bazaarvoice.emodb.table.db.Table;
 import com.bazaarvoice.emodb.table.db.TableSet;
 import com.google.common.base.Optional;
+import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -60,5 +61,5 @@ public interface DataReaderDAO {
 
     /** Retrieves records all records across multiple tables in their natural key order (shard, table UUID, key). */
     Iterator<MultiTableScanResult> multiTableScan(MultiTableScanOptions query, TableSet tables, LimitCounter limit,
-                                                  ReadConsistency consistency);
+                                                  ReadConsistency consistency, @Nullable DateTime cutoffTime);
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataDAO.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
+import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -55,7 +56,9 @@ import java.util.UUID;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-/** In-memory implementation of {@link DataWriterDAO}, for testing. */
+/**
+ * In-memory implementation of {@link DataWriterDAO}, for testing.
+ */
 public class InMemoryDataDAO implements DataReaderDAO, DataWriterDAO {
 
     public final Map<String, NavigableMap<String, Map<UUID, Change>>> _contentChanges = Maps.newHashMap();
@@ -107,7 +110,8 @@ public class InMemoryDataDAO implements DataReaderDAO, DataWriterDAO {
         return safeGet(_contentChanges, table.getName()).size();
     }
 
-    @Override public long count(Table table, @Nullable Integer limit, ReadConsistency consistency) {
+    @Override
+    public long count(Table table, @Nullable Integer limit, ReadConsistency consistency) {
         int actual = safeGet(_contentChanges, table.getName()).size();
         return limit == null ? actual : Math.min(limit, actual);
     }
@@ -186,7 +190,7 @@ public class InMemoryDataDAO implements DataReaderDAO, DataWriterDAO {
 
     @Override
     public Iterator<MultiTableScanResult> multiTableScan(MultiTableScanOptions query, TableSet tables, LimitCounter limit,
-                                                         ReadConsistency consistency) {
+                                                         ReadConsistency consistency, @Nullable DateTime cutoffTime) {
         // TODO:  Create a simulation for this method
         return Iterators.emptyIterator();
     }
@@ -289,7 +293,7 @@ public class InMemoryDataDAO implements DataReaderDAO, DataWriterDAO {
     }
 
     public synchronized void deleteDeltasOnly(Table table, String key, UUID compactionKey, Compaction compaction,
-                                                       UUID changeId, Delta delta, Collection<UUID> changesToDelete, List<History> historyList, WriteConsistency consistency) {
+                                              UUID changeId, Delta delta, Collection<UUID> changesToDelete, List<History> historyList, WriteConsistency consistency) {
         checkNotNull(table, "table");
         checkNotNull(key, "key");
         checkNotNull(compactionKey, "compactionKey");
@@ -306,7 +310,7 @@ public class InMemoryDataDAO implements DataReaderDAO, DataWriterDAO {
     }
 
     public synchronized void addCompactionOnly(Table table, String key, UUID compactionKey, Compaction compaction,
-                                                       UUID changeId, Delta delta, Collection<UUID> changesToDelete, List<History> historyList, WriteConsistency consistency) {
+                                               UUID changeId, Delta delta, Collection<UUID> changesToDelete, List<History> historyList, WriteConsistency consistency) {
         checkNotNull(table, "table");
         checkNotNull(key, "key");
         checkNotNull(compactionKey, "compactionKey");
@@ -423,7 +427,7 @@ public class InMemoryDataDAO implements DataReaderDAO, DataWriterDAO {
                         return new RecordEntryRawMetadata()
                                 .withTimestamp(TimeUUIDs.getTimeMillis(entry.getKey()))
                                 .withSize(1);  // Size is a measure of the raw data, which the in-memory implementation does not have.
-                                               // Return a constant value.
+                        // Return a constant value.
                     }
                 });
             }
@@ -459,7 +463,7 @@ public class InMemoryDataDAO implements DataReaderDAO, DataWriterDAO {
 
             private SortedMap<UUID, Change> getSortedCopy(Map<UUID, Change> changes) {
                 SortedMap<UUID, Change> sortedCopy = null;
-                while (sortedCopy ==  null) {
+                while (sortedCopy == null) {
                     try {
                         sortedCopy = TimeUUIDs.sortedCopy(changes);
                     } catch (ConcurrentModificationException e) {

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiScanCutoffTimeTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiScanCutoffTimeTest.java
@@ -1,0 +1,112 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.sor.db.astyanax.AstyanaxDataReaderDAO;
+import com.bazaarvoice.emodb.sor.db.astyanax.CqlDataReaderDAO;
+import com.datastax.driver.core.Row;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.netflix.astyanax.model.Column;
+import org.joda.time.DateTime;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+public class MultiScanCutoffTimeTest {
+
+    private static final String KEY = "key1";
+
+    @Test
+    public void testCQLRowFilteringBasedOnCutoffTime()
+            throws Exception {
+        long nowInTimeMillis = System.currentTimeMillis();
+
+        UUID uuid1 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis);
+        UUID uuid2 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 5000);
+        UUID uuid3 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 10000);
+        UUID uuid4 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 15000);
+        UUID uuid5 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 20000);
+
+        Row row1 = cqlRow(KEY, uuid1, "a");
+        Row row2 = cqlRow(KEY, uuid2, "b");
+        Row row3 = cqlRow(KEY, uuid3, "c");
+        Row row4 = cqlRow(KEY, uuid4, "d");
+        Row row5 = cqlRow(KEY, uuid5, "e");
+
+        final Iterable<Row> rows = Arrays.asList(row1, row2, row3, row4, row5);
+        assertEquals(Iterables.size(rows), 5);
+
+        Iterable<Row> filteredRows = CqlDataReaderDAO.getFilteredRows(rows, null);
+        assertEquals(Iterables.size(filteredRows), 5);
+
+        filteredRows = CqlDataReaderDAO.getFilteredRows(rows, new DateTime(nowInTimeMillis - 1000));
+        assertEquals(Iterables.size(filteredRows), 0);
+
+        filteredRows = CqlDataReaderDAO.getFilteredRows(rows, new DateTime(nowInTimeMillis + 12000));
+        assertEquals(Iterables.size(filteredRows), 3);
+        assertEquals(Iterables.get(filteredRows, 0).getString(2), "a");
+        assertEquals(Iterables.get(filteredRows, 1).getString(2), "b");
+        assertEquals(Iterables.get(filteredRows, 2).getString(2), "c");
+
+        filteredRows = CqlDataReaderDAO.getFilteredRows(rows, new DateTime(nowInTimeMillis + 21000));
+        assertEquals(Iterables.size(filteredRows), 5);
+    }
+
+
+    @Test
+    public void testAstyanaxColumnFilteringBasedOnCutoffTime()
+            throws Exception {
+        long nowInTimeMillis = System.currentTimeMillis();
+
+        UUID uuid1 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis);
+        UUID uuid2 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 5000);
+        UUID uuid3 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 10000);
+        UUID uuid4 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 15000);
+        UUID uuid5 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 20000);
+
+        Column<UUID> col1 = astyanaxColumn(uuid1, "a");
+        Column<UUID> col2 = astyanaxColumn(uuid2, "b");
+        Column<UUID> col3 = astyanaxColumn(uuid3, "c");
+        Column<UUID> col4 = astyanaxColumn(uuid4, "d");
+        Column<UUID> col5 = astyanaxColumn(uuid5, "e");
+
+        final Iterable<Column<UUID>> columns = Arrays.asList(col1, col2, col3, col4, col5);
+        assertEquals(Iterators.size(columns.iterator()), 5);
+
+        Iterator<Column<UUID>> filteredColumnIter = AstyanaxDataReaderDAO.getFilteredColumnIter(columns.iterator(), null);
+        assertEquals(Iterators.size(filteredColumnIter), 5);
+
+        filteredColumnIter = AstyanaxDataReaderDAO.getFilteredColumnIter(columns.iterator(), new DateTime(nowInTimeMillis - 1000));
+        assertEquals(Iterators.size(filteredColumnIter), 0);
+
+        filteredColumnIter = AstyanaxDataReaderDAO.getFilteredColumnIter(columns.iterator(), new DateTime(nowInTimeMillis + 12000));
+        assertEquals(Iterators.size(filteredColumnIter), 3);
+
+        filteredColumnIter = AstyanaxDataReaderDAO.getFilteredColumnIter(columns.iterator(), new DateTime(nowInTimeMillis + 21000));
+        assertEquals(Iterators.size(filteredColumnIter), 5);
+    }
+
+    private Row cqlRow(String key, UUID column, String value) {
+        Row row = mock(Row.class);
+        when(row.getString(0)).thenReturn(key);
+        when(row.getUUID(1)).thenReturn(column);
+        when(row.getString(2)).thenReturn(value);
+
+        return row;
+    }
+
+    private Column<UUID> astyanaxColumn(UUID uuidValue, String value) {
+        Column<UUID> column = mock(Column.class);
+        when(column.getUUIDValue()).thenReturn(uuidValue);
+        when(column.getStringValue()).thenReturn(value);
+
+        return column;
+    }
+
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/report/AllTablesReportGenerator.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/report/AllTablesReportGenerator.java
@@ -74,7 +74,7 @@ public class AllTablesReportGenerator {
 
                 ReadConsistency consistency = options.isReadOnly() ? ReadConsistency.WEAK : ReadConsistency.STRONG;
                 Iterator<MultiTableScanResult> results =
-                        _dataTools.multiTableScan(scanOptions, tables, LimitCounter.max(), consistency);
+                        _dataTools.multiTableScan(scanOptions, tables, LimitCounter.max(), consistency, null);
 
                 int lastShardId = -1;
                 long lastTableUuid = -1;

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/rangescan/LocalRangeScanUploader.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/rangescan/LocalRangeScanUploader.java
@@ -243,7 +243,7 @@ public class LocalRangeScanUploader implements RangeScanUploader, Managed {
             int partCountForFirstShard = 1;
             Batch batch = new Batch(context, partCountForFirstShard);
 
-            Iterator<MultiTableScanResult> allResults = _dataTools.multiTableScan(multiTableScanOptions, tableSet, LimitCounter.max(), ReadConsistency.STRONG);
+            Iterator<MultiTableScanResult> allResults = _dataTools.multiTableScan(multiTableScanOptions, tableSet, LimitCounter.max(), ReadConsistency.STRONG, null);
 
             // Enforce a maximum number of results based on the scan options
             Iterator<MultiTableScanResult> results = Iterators.limit(allResults, getResplitRowCount(options));

--- a/web/src/test/java/com/bazaarvoice/emodb/web/scanner/ScanUploaderTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/scanner/ScanUploaderTest.java
@@ -244,7 +244,7 @@ public class ScanUploaderTest {
                 ScanRangeSplits.builder()
                         .addScanRange("dummy", "dummy", ScanRange.all())
                         .build());
-        when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class)))
+        when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class), any(DateTime.class)))
                 .thenReturn(createMockScanResults());
         when(dataTools.toContent(any(MultiTableScanResult.class), any(ReadConsistency.class), eq(false)))
                 .thenAnswer(new Answer<Map<String, Object>>() {
@@ -814,10 +814,11 @@ public class ScanUploaderTest {
         final MetricRegistry metricRegistry = new MetricRegistry();
 
         DataTools dataTools = mock(DataTools.class);
-        when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class)))
+        when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class), any(DateTime.class)))
                 .thenAnswer(new Answer<Iterator<MultiTableScanResult>>() {
                     @Override
-                    public Iterator<MultiTableScanResult> answer(InvocationOnMock invocation) throws Throwable {
+                    public Iterator<MultiTableScanResult> answer(InvocationOnMock invocation)
+                            throws Throwable {
                         // For this test return 400 results; if the test is successful it should only pull the first
                         // 300 anyway, but put a hard stop on it so the test cannot infinite loop on failure.
                         return new AbstractIterator<MultiTableScanResult>() {
@@ -1038,7 +1039,7 @@ public class ScanUploaderTest {
             Record record = mock(Record.class);
             when(record.getKey()).thenReturn(key);
 
-            when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class)))
+            when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class), any(DateTime.class)))
                     .thenReturn(Iterators.singletonIterator(
                             new MultiTableScanResult(
                                     ByteBuffer.wrap(new byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),
@@ -1092,7 +1093,7 @@ public class ScanUploaderTest {
         Record record = mock(Record.class);
         when(record.getKey()).thenReturn(key);
 
-        when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class)))
+        when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class), any(DateTime.class)))
                 .thenReturn(Iterators.singletonIterator(
                         new MultiTableScanResult(
                                 ByteBuffer.wrap(new byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),
@@ -1165,7 +1166,7 @@ public class ScanUploaderTest {
         Record record = mock(Record.class);
         when(record.getKey()).thenReturn(key);
 
-        when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class)))
+        when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class), any(DateTime.class)))
                 .thenReturn(Iterators.singletonIterator(
                         new MultiTableScanResult(
                                 ByteBuffer.wrap(new byte[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}),


### PR DESCRIPTION
## Enhancement Task.

Currently, the MultiScan read  operation which is used by stash would resolve all the existing deltas for that record(s) till that point of time. This enhancement is to add a new end point which would touch the deltas only before a certain timestamp.

## How to Test and Verify
1. Check out this PR
2. Run Command X, Click Button Y
3. Profit

## Risk
### Low

## Code Review Checklist
- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.
- [ ] Pulled down the PR and performed verification of at least being able to
  build and run.
- [ ] Well documented, including updates to any necessary markdown files. When
  we inevitably come back to this code it will only take hours to figure out, not
  days.
- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
  a victim of rampaging consistency, and should be using this course of action. 
  We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.
- [ ] PR has a valid summary, and a good description.

