### PR TITLE
Added ability to configure Astyanax max thrift frame size

### DIFF
--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/CassandraConfiguration.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/CassandraConfiguration.java
@@ -40,6 +40,7 @@ import com.netflix.astyanax.connectionpool.impl.Slf4jConnectionPoolMonitorImpl;
 import com.netflix.astyanax.impl.AstyanaxConfigurationImpl;
 import com.netflix.astyanax.shallows.EmptyLatencyScoreStrategyImpl;
 import com.netflix.astyanax.thrift.ThriftFamilyFactory;
+import io.dropwizard.util.Size;
 import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,6 +123,7 @@ public class CassandraConfiguration implements ConnectionPoolConfiguration {
     //    private int _maxOperationsPerConnection = ConnectionPoolConfigurationImpl.DEFAULT_MAX_OPERATIONS_PER_CONNECTION;
     private Optional<Integer> _maxTimeoutWhenExhausted = Optional.absent();
     private SimpleAuthenticationCredentials _authenticationCredentials;
+    private Optional<Size> _maxThriftFrameSize = Optional.absent();
 
     //
     // Post-configuration methods
@@ -240,6 +242,10 @@ public class CassandraConfiguration implements ConnectionPoolConfiguration {
                 .setConnectionPoolType(ConnectionPoolType.TOKEN_AWARE)
                 .setDiscoveryType(NodeDiscoveryType.TOKEN_AWARE)
                 .setTargetCassandraVersion("1.2");
+
+        if (_maxThriftFrameSize.isPresent()) {
+            asConfig.setMaxThriftSize((int) _maxThriftFrameSize.get().toBytes());
+        }
 
         return new AstyanaxContext.Builder()
                 .withAstyanaxConfiguration(asConfig)
@@ -759,6 +765,16 @@ public class CassandraConfiguration implements ConnectionPoolConfiguration {
 
     public CassandraConfiguration setAuthenticationCredentials(SimpleAuthenticationCredentials authenticationCredentials) {
         _authenticationCredentials = authenticationCredentials;
+        return this;
+    }
+
+    @Override
+    public Optional<Size> getMaxThriftFrameSize() {
+        return _maxThriftFrameSize;
+    }
+
+    public CassandraConfiguration setMaxThriftFrameSize(Optional<Size> maxThriftFrameSize) {
+        _maxThriftFrameSize = maxThriftFrameSize;
         return this;
     }
 }

--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/ConnectionPoolConfiguration.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/ConnectionPoolConfiguration.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.common.cassandra;
 
 import com.google.common.base.Optional;
+import io.dropwizard.util.Size;
 
 /**
  * Interface for configuring the Cassandra cluster connection pool.  Note that depending on whether the Astyanax or
@@ -24,4 +25,5 @@ public interface ConnectionPoolConfiguration {
     Optional<Integer> getRetryDelaySlice();
     Optional<Integer> getRetryMaxDelaySlice();
     Optional<Integer> getMaxTimeoutWhenExhausted();
+    Optional<Size> getMaxThriftFrameSize();
 }

--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/FilterConnectionPoolConfiguration.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/FilterConnectionPoolConfiguration.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.common.cassandra;
 
 import com.google.common.base.Optional;
+import io.dropwizard.util.Size;
 
 /**
  * Implementation of ConnectionPoolConfiguration that defers to another instance with the ability to override
@@ -26,6 +27,7 @@ public class FilterConnectionPoolConfiguration implements ConnectionPoolConfigur
     private Optional<Integer> _retryDelaySlice = Optional.absent();
     private Optional<Integer> _retryMaxDelaySlice = Optional.absent();
     private Optional<Integer> _maxTimeoutWhenExhausted = Optional.absent();
+    private Optional<Size> _maxThriftFrameSize = Optional.absent();
 
     public FilterConnectionPoolConfiguration(ConnectionPoolConfiguration config) {
         _config = config;
@@ -173,5 +175,14 @@ public class FilterConnectionPoolConfiguration implements ConnectionPoolConfigur
 
     public void setMaxTimeoutWhenExhausted(int maxTimeoutWhenExhausted) {
         _maxTimeoutWhenExhausted = Optional.of(maxTimeoutWhenExhausted);
+    }
+
+    @Override
+    public Optional<Size> getMaxThriftFrameSize() {
+        return _maxThriftFrameSize.or(_config.getMaxThriftFrameSize());
+    }
+
+    public void setMaxThriftFrameSize(Size maxThriftFrameSize) {
+        _maxThriftFrameSize = Optional.of(maxThriftFrameSize);
     }
 }

--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/KeyspaceConfiguration.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/KeyspaceConfiguration.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.common.cassandra;
 
 import com.google.common.base.Optional;
+import io.dropwizard.util.Size;
 
 import javax.validation.constraints.NotNull;
 
@@ -37,6 +38,7 @@ public class KeyspaceConfiguration implements ConnectionPoolConfiguration {
     private Optional<Integer> _retryDelaySlice = Optional.absent();
     private Optional<Integer> _retryMaxDelaySlice = Optional.absent();
     private Optional<Integer> _maxTimeoutWhenExhausted = Optional.absent();
+    private Optional<Size> _maxThriftFrameSize = Optional.absent();
 
     public String getHealthCheckColumnFamily() {
         return _healthCheckColumnFamily;
@@ -216,6 +218,16 @@ public class KeyspaceConfiguration implements ConnectionPoolConfiguration {
         return this;
     }
 
+    @Override
+    public Optional<Size> getMaxThriftFrameSize() {
+        return _maxThriftFrameSize;
+    }
+
+    public KeyspaceConfiguration setMaxThriftFrameSize(Optional<Size> maxThriftFrameSize) {
+        _maxThriftFrameSize = maxThriftFrameSize;
+        return this;
+    }
+
     public boolean useSharedConnectionPool() {
         return !(getInitialConnectionsPerHost().isPresent() ||
                 getMaxConnectionsPerHost().isPresent() ||
@@ -231,6 +243,7 @@ public class KeyspaceConfiguration implements ConnectionPoolConfiguration {
                 getRetrySuspendWindow().isPresent() ||
                 getRetryDelaySlice().isPresent() ||
                 getRetryMaxDelaySlice().isPresent() ||
-                getMaxTimeoutWhenExhausted().isPresent());
+                getMaxTimeoutWhenExhausted().isPresent() ||
+                getMaxThriftFrameSize().isPresent());
     }
 }


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Making the thrift frame size configurable for Astyanax so it can match the Cassandra value if it is at a non-default value of 15Mb

## How to Test and Verify

1. Check out this PR
2. Set the `maxThriftFrameSize` attirbute to any other value, such as `50MB`, in the Cassandra configuration

## Risk

Low

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

Little risk involved unless someone sets to a value that doesn't agree with Cassandra.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.

