### PR TITLE
Lowered multi-row fetch and prefetch sizes to avoid driver errors on large reads

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
@@ -84,8 +84,8 @@ public class CqlDataReaderDAO implements DataReaderDAO {
     private static final int MAX_RANDOM_ROWS_BATCH = 50;
     private static final int DEFAULT_SINGLE_ROW_FETCH_SIZE = 100;
     private static final int DEFAULT_SINGLE_ROW_PREFETCH_LIMIT = 50;
-    private static final int DEFAULT_MULTI_ROW_FETCH_SIZE = 500;
-    private static final int DEFAULT_MULTI_ROW_PREFETCH_LIMIT = 200;
+    private static final int DEFAULT_MULTI_ROW_FETCH_SIZE = 100;
+    private static final int DEFAULT_MULTI_ROW_PREFETCH_LIMIT = 50;
     private static final int RECORD_CACHE_SIZE = 20;
     private static final int RECORD_SOFT_CACHE_SIZE = 10;
 


### PR DESCRIPTION
## GitHub issue

https://github.com/bazaarvoice/emodb/issues/60

## What Are We Doing Here?

Investigation into related issue showed that lowering the maximum fetch size for scans relieves the effect.  While this is not a fix per-se, since investigation is still underway and there is no guarantee the new values are "right", they solve the immediate need for making the known deployment where this is an issue healthy.

## How to Test and Verify

This cannot be verified until more analysis on which data is causing the issue.  For us, deploying locally-built code with this change in place to the deployment where this is an issue was the test.

## Risk

Low.  Only the limits are updated in this pull request; the actually queries and result set handling are unchanged.

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

The risks are:

- Setting the lower values could cause scans to take longer, possibly affecting response times to clients.
- The lowered limits are only a temporary relief to a deeper problem not-yet uncovered.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.