### PR TITLE
Exposed more metrics from CQL driver

### DIFF
--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/CqlCluster.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/CqlCluster.java
@@ -63,6 +63,26 @@ public class CqlCluster extends AbstractCassandraCluster<Session> implements Man
                 metrics.getOpenConnections());
 
         _metricRegistry.register(
+                MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "trashed-connections"),
+                metrics.getTrashedConnections());
+
+        _metricRegistry.register(
+                MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "executor-queue-depth"),
+                metrics.getExecutorQueueDepth());
+
+        _metricRegistry.register(
+                MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "blocking-executor-queue-depth"),
+                metrics.getBlockingExecutorQueueDepth());
+
+        _metricRegistry.register(
+                MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "reconnection-scheduler-task-count"),
+                metrics.getReconnectionSchedulerQueueSize());
+
+        _metricRegistry.register(
+                MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "task-scheduler-task-count"),
+                metrics.getTaskSchedulerQueueSize());
+
+        _metricRegistry.register(
                 MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "connection-errors"),
                 metrics.getErrorMetrics().getConnectionErrors());
 
@@ -75,6 +95,10 @@ public class CqlCluster extends AbstractCassandraCluster<Session> implements Man
                 metrics.getErrorMetrics().getWriteTimeouts());
 
         _metricRegistry.register(
+                MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "client-timeouts"),
+                metrics.getErrorMetrics().getClientTimeouts());
+
+        _metricRegistry.register(
                 MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "ignores"),
                 metrics.getErrorMetrics().getIgnores());
 
@@ -82,6 +106,9 @@ public class CqlCluster extends AbstractCassandraCluster<Session> implements Man
                 MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "unavailables"),
                 metrics.getErrorMetrics().getUnavailables());
 
+        _metricRegistry.register(
+                MetricRegistry.name("bv.emodb.cql", _metricName, "ConnectionPool", "speculative-executions"),
+                metrics.getErrorMetrics().getSpeculativeExecutions());
     }
 
 }


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

This small PR exposes more metrics from the CQL driver which may be useful for diagnostics.

## How to Test and Verify

1. Check out this PR
2. Verify no regression

## Risk

Low

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

Negligible risk.  These metrics already exists, they are now just being exposed.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.

