### PR TITLE
Cleaning up deprecated BVFLYNN_APP_NAME

### DIFF
--- a/docs/flynn_deployment
+++ b/docs/flynn_deployment
@@ -1,3 +1,3 @@
 #!/bin/bash
-export BVFLYNN_APP_NAME="emodb-gh-pages-twenty"
+export BVFLYNN_APP="emodb-gh-pages-twenty"
 bvflynn push -t emodb-dev@bazaarvoice.com 


### PR DESCRIPTION
BVFLYNN_APP_NAME has been deprecated in favor BVFLYNN_APP, for consistency reasons. Please update when you have a moment.