### PR TITLE
Updated databus poll to explicitly expose if there are more results

### DIFF
--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/AuthDatabus.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/AuthDatabus.java
@@ -68,7 +68,7 @@ public interface AuthDatabus {
      * an event will be returned multiple times.  In practice, it will try to return
      * events in order without duplicates, but there are no promises.
      */
-    List<Event> poll(@Credential String apiKey, String subscription, Duration claimTtl, int limit);
+    PollResult poll(@Credential String apiKey, String subscription, Duration claimTtl, int limit);
 
     /** Renew the claims on events previously returned by {@link #poll}. */
     void renew(@Credential String apiKey, String subscription, Collection<String> eventKeys, Duration claimTtl);

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Databus.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Databus.java
@@ -76,7 +76,7 @@ public interface Databus {
      * an event will be returned multiple times.  In practice, it will try to return
      * events in order without duplicates, but there are no promises.
      */
-    List<Event> poll(String subscription, Duration claimTtl, int limit);
+    PollResult poll(String subscription, Duration claimTtl, int limit);
 
     /** Renew the claims on events previously returned by {@link #poll}. */
     void renew(String subscription, Collection<String> eventKeys, Duration claimTtl);

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/PollResult.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/PollResult.java
@@ -1,0 +1,40 @@
+package com.bazaarvoice.emodb.databus.api;
+
+import org.joda.time.Duration;
+
+import java.util.List;
+
+/**
+ * Result returned from {@link Databus#poll(String, Duration, int)}.  The result contains to attributes:
+ *
+ * <ol>
+ *     <li>
+ *         The list of {@link Event} instances returned from the poll.
+ *     </li>
+ *     <li>
+ *         A boolean indicator for whether there are more events and the caller would benefit from immediately re-polling
+ *         versus delaying for a brief period before polling again.  Because the databus discards redundant events it's
+ *         possible that it will return less than the requested number of events even though the queue is not empty.
+ *         In an extreme example if the queue is deep and contains nothing but redundant events then the poll result may
+ *         contain no events yet still indicate that there are more events.
+ *     </li>
+ * </ol>
+ */
+public class PollResult {
+
+    private final List<Event> _events;
+    private final boolean _moreEvents;
+
+    public PollResult(List<Event> events, boolean moreEvents) {
+        _events = events;
+        _moreEvents = moreEvents;
+    }
+
+    public List<Event> getEvents() {
+        return _events;
+    }
+
+    public boolean hasMoreEvents() {
+        return _moreEvents;
+    }
+}

--- a/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusAuthenticatorProxy.java
+++ b/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusAuthenticatorProxy.java
@@ -4,6 +4,7 @@ import com.bazaarvoice.emodb.databus.api.AuthDatabus;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -74,7 +75,7 @@ class DatabusAuthenticatorProxy implements Databus {
     }
 
     @Override
-    public List<Event> poll(@PartitionKey String subscription, Duration claimTtl, int limit) {
+    public PollResult poll(@PartitionKey String subscription, Duration claimTtl, int limit) {
         return _authDatabus.poll(_apiKey, subscription, claimTtl, limit);
     }
 

--- a/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusClient.java
+++ b/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusClient.java
@@ -11,6 +11,7 @@ import com.bazaarvoice.emodb.common.api.UnauthorizedException;
 import com.bazaarvoice.emodb.databus.api.AuthDatabus;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnauthorizedSubscriptionException;
@@ -53,6 +54,9 @@ public class DatabusClient implements AuthDatabus {
     public static final String SERVICE_PATH = "/bus/1";
 
     private static final MediaType JSON_CONDITION_MEDIA_TYPE = new MediaType("application", "x.json-condition");
+
+    /** Poll header indicating whether the databus subscription is empty. */
+    private static final String POLL_DATABUS_EMPTY_HEADER = "X-BV-Databus-Empty";
 
     private final EmoClient _client;
     private final UriBuilder _databus;
@@ -205,19 +209,35 @@ public class DatabusClient implements AuthDatabus {
     }
 
     @Override
-    public List<Event> poll(String apiKey, @PartitionKey String subscription, Duration claimTtl, int limit) {
+    public PollResult poll(String apiKey, @PartitionKey String subscription, Duration claimTtl, int limit) {
         checkNotNull(subscription, "subscription");
         checkNotNull(claimTtl, "claimTtl");
-        try {
-            URI uri = getPollUriBuilder(subscription, claimTtl, limit).build();
-            return _client.resource(uri)
-                    .queryParam("includeTags", "true")
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
-                    .header(ApiKeyRequest.AUTHENTICATION_HEADER, apiKey)
-                    .get(new TypeReference<List<Event>>() {});
-        } catch (EmoClientException e) {
-            throw convertException(e);
+
+        URI uri = getPollUriBuilder(subscription, claimTtl, limit).build();
+        EmoResponse response = _client.resource(uri)
+                .queryParam("includeTags", "true")
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(ApiKeyRequest.AUTHENTICATION_HEADER, apiKey)
+                .get(EmoResponse.class);
+
+        if (response.getStatus() != Response.Status.OK.getStatusCode()) {
+            throw convertException(new EmoClientException(response));
         }
+
+        List<Event> events = response.getEntity(new TypeReference<List<Event>>() {});
+
+        boolean moreEvents;
+        String databusEmpty = response.getFirstHeader(POLL_DATABUS_EMPTY_HEADER);
+        if (databusEmpty != null) {
+            // Use the header value from the server to determine if the databus subscription is empty
+            moreEvents = !Boolean.parseBoolean(databusEmpty);
+        } else {
+            // Must be polling an older version of Emo which did not include this header.  Infer whether the queue
+            // is empty based on whether any results were returned.
+            moreEvents = !events.isEmpty();
+        }
+
+        return new PollResult(events, moreEvents);
     }
 
     protected UriBuilder getPollUriBuilder(String subscription, Duration claimTtl, int limit) {

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusFactory.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusFactory.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.databus.core;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -89,7 +90,7 @@ public class DatabusFactory {
             }
 
             @Override
-            public List<Event> poll(String subscription, Duration claimTtl, int limit) {
+            public PollResult poll(String subscription, Duration claimTtl, int limit) {
                 return _ownerAwareDatabus.poll(ownerId, subscription, claimTtl, limit);
             }
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OwnerAwareDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OwnerAwareDatabus.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnauthorizedSubscriptionException;
@@ -50,7 +51,7 @@ public interface OwnerAwareDatabus {
     List<Event> peek(String ownerId, String subscription, int limit)
         throws UnauthorizedSubscriptionException;
 
-    List<Event> poll(String ownerId, String subscription, Duration claimTtl, int limit)
+    PollResult poll(String ownerId, String subscription, Duration claimTtl, int limit)
         throws UnauthorizedSubscriptionException;
 
     void renew(String ownerId, String subscription, Collection<String> eventKeys, Duration claimTtl)

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/TrustedDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/TrustedDatabus.java
@@ -5,6 +5,7 @@ import com.bazaarvoice.emodb.databus.api.AuthDatabus;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -102,7 +103,7 @@ public class TrustedDatabus implements AuthDatabus {
         _databus.injectEvent(subscription, table, key);
     }
 
-    public List<Event> poll(@Credential String apiKey, String subscription, Duration claimTtl, int limit) {
+    public PollResult poll(@Credential String apiKey, String subscription, Duration claimTtl, int limit) {
         return _databus.poll(subscription, claimTtl, limit);
     }
 

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
@@ -1,0 +1,155 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import com.bazaarvoice.emodb.databus.api.Databus;
+import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.api.PollResult;
+import com.bazaarvoice.emodb.sor.condition.Condition;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
+import com.bazaarvoice.emodb.table.db.ClusterInfo;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.joda.time.Duration;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+@SuppressWarnings("unchecked")
+public class CanaryTest {
+
+    private Databus _databus;
+    private Canary _canary;
+    private Runnable _iterationRunnable;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        _databus = mock(Databus.class);
+
+        ClusterInfo clusterInfo = new ClusterInfo("cluster", "metric");
+        Condition condition = Conditions.alwaysTrue();
+        RateLimitedLogFactory rateLimitedLogFactory = mock(RateLimitedLogFactory.class);
+        when(rateLimitedLogFactory.from(any(Logger.class))).thenReturn(mock(RateLimitedLog.class));
+
+        ScheduledExecutorService service = mock(ScheduledExecutorService.class);
+        when(service.scheduleWithFixedDelay(any(Runnable.class), eq(0L), eq(1000L), eq(TimeUnit.MILLISECONDS)))
+                .thenAnswer(invocationOnMock -> {
+                    _iterationRunnable = (Runnable) invocationOnMock.getArguments()[0];
+                    return mock(ScheduledFuture.class);
+                });
+
+        _canary = new Canary(clusterInfo, condition, _databus, rateLimitedLogFactory, new MetricRegistry(), service);
+
+        verify(_databus).subscribe("__system_bus:canary-cluster", Conditions.alwaysTrue(),
+                Duration.standardDays(3650), DatabusChannelConfiguration.CANARY_TTL, false);
+
+        _canary.startAsync();
+
+        // Starting the canary sends a single initialization runnable to the service, so execute it now.
+        ArgumentCaptor<Runnable> runnable = ArgumentCaptor.forClass(Runnable.class);
+        verify(service).execute(runnable.capture());
+        runnable.getValue().run();
+
+        _canary.awaitRunning(1, TimeUnit.SECONDS);
+        assertTrue(_canary.isRunning());
+
+        // Verify the first callable was scheduled on startup
+        assertNotNull(_iterationRunnable);
+    }
+
+    @BeforeMethod
+    public void tearDown() {
+        // Verify the canary is still running
+        assertTrue(_canary.isRunning());
+        // No need to shut down the canary since it is running with a mocked executor service
+        verifyNoMoreInteractions(_databus);
+    }
+
+
+    @Test
+    public void testIterationWithNoEvents() throws Exception {
+        when(_databus.poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50))
+                .thenReturn(new PollResult(ImmutableList.of(), false));
+
+        _iterationRunnable.run();
+
+        verify(_databus).poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50);
+    }
+
+    @Test
+    public void testIterationWithEventsInOnePoll() throws Exception {
+        List<Event> events = Lists.newArrayListWithCapacity(20);
+        List<String> eventIds = Lists.newArrayListWithCapacity(20);
+        for (int i=0; i < 20; i++) {
+            String eventId = String.valueOf(i);
+            events.add(new Event(eventId, ImmutableMap.of(), ImmutableList.of()));
+            eventIds.add(eventId);
+        }
+        when(_databus.poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50))
+                .thenReturn(new PollResult(events, false));
+
+        _iterationRunnable.run();
+
+        verify(_databus).poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50);
+        verify(_databus).acknowledge("__system_bus:canary-cluster", eventIds);
+    }
+
+    @Test
+    public void testIterationWithEventsInMultiplePolls() throws Exception {
+        List<List<Event>> events = Lists.newArrayListWithCapacity(3);
+        List<List<String>> eventIds = Lists.newArrayListWithCapacity(3);
+
+        for (int batch=0; batch < 3; batch++) {
+            List<Event> batchEvents = Lists.newArrayListWithCapacity(50);
+            List<String> batchEventIds = Lists.newArrayListWithCapacity(50);
+            events.add(batchEvents);
+            eventIds.add(batchEventIds);
+
+            for (int i=0; i < 50; i++) {
+                String eventId = String.valueOf(batch * 50 + i);
+                batchEvents.add(new Event(eventId, ImmutableMap.of(), ImmutableList.of()));
+                batchEventIds.add(eventId);
+            }
+        }
+
+        when(_databus.poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50))
+                .thenReturn(new PollResult(events.get(0), true))
+                .thenReturn(new PollResult(events.get(1), true))
+                .thenReturn(new PollResult(events.get(2), false));
+
+        _iterationRunnable.run();
+
+        verify(_databus, times(3)).poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50);
+        for (List<String> batchEventIds : eventIds) {
+            verify(_databus).acknowledge("__system_bus:canary-cluster", batchEventIds);
+        }
+    }
+
+    @Test
+    public void testIterationWithDiscardedEvents() throws Exception {
+        when(_databus.poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50))
+                .thenReturn(new PollResult(ImmutableList.of(), true))
+                .thenReturn(new PollResult(ImmutableList.of(), true))
+                .thenReturn(new PollResult(ImmutableList.of(), false));
+
+        _iterationRunnable.run();
+
+        verify(_databus, times(3)).poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50);
+    }
+}

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
@@ -3,11 +3,14 @@ package com.bazaarvoice.emodb.databus.core;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.bazaarvoice.emodb.databus.auth.ConstantDatabusAuthorizer;
 import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
+import com.bazaarvoice.emodb.event.api.DedupEventStore;
 import com.bazaarvoice.emodb.event.api.EventData;
 import com.bazaarvoice.emodb.event.api.EventSink;
+import com.bazaarvoice.emodb.event.api.EventStore;
 import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
 import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.sor.api.Coordinate;
@@ -36,8 +39,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class ConsolidationTest {
@@ -61,12 +69,14 @@ public class ConsolidationTest {
         Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
-        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
+        PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
+        List<Event> events = result.getEvents();
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
         assertEquals(EventKeyFormat.decodeAll(Collections.singleton(first.getEventKey())), actualIds);
         assertEquals(events.size(), 1);
+        assertTrue(result.hasMoreEvents());
     }
 
     /** EventStore.poll() returns 1000 events, all for the same coordinate. */
@@ -90,12 +100,14 @@ public class ConsolidationTest {
         Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
-        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
+        PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
+        List<Event> events = result.getEvents();
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
         assertEquals(EventKeyFormat.decodeAll(Collections.singleton(first.getEventKey())), Ordering.natural().immutableSortedCopy(actualIds));
         assertEquals(events.size(), 1);
+        assertTrue(result.hasMoreEvents());
     }
 
     @Test
@@ -121,12 +133,14 @@ public class ConsolidationTest {
         Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
-        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
+        PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
+        List<Event> events = result.getEvents();
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
         assertEquals(EventKeyFormat.decodeAll(Collections.singleton(first.getEventKey())), actualIds);
         assertEquals(events.size(), 1);
+        assertTrue(result.hasMoreEvents());
     }
 
     @Test
@@ -155,7 +169,8 @@ public class ConsolidationTest {
         Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
-        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
+        PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
+        List<Event> events = result.getEvents();
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -167,6 +182,7 @@ public class ConsolidationTest {
                 .add(ImmutableList.of("tag2", "tag3", "tag4"))
                 .build());
         assertEquals(events.size(), 1);
+        assertTrue(result.hasMoreEvents());
     }
 
     @Test
@@ -203,7 +219,8 @@ public class ConsolidationTest {
         DefaultDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content), clock);
 
         // Use a limit of 2 to force multiple calls to the event store.
-        List<Event> events = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 2);
+        PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 2);
+        List<Event> events = result.getEvents();
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -215,6 +232,82 @@ public class ConsolidationTest {
                 .add(ImmutableList.of("tag2", "tag3", "tag4"))
                 .build());
         assertEquals(events.size(), 1);
+        assertFalse(result.hasMoreEvents());
+    }
+
+    @Test
+    public void testDiscardedUpdates() {
+        final List<String> actualIds = Lists.newArrayList();
+        DedupEventStore dedupEventStore = mock(DedupEventStore.class);
+        DatabusEventStore eventStore = new DatabusEventStore(mock(EventStore.class), dedupEventStore, Suppliers.ofInstance(true)) {
+            @Override
+            public boolean poll(String subscription, Duration claimTtl, EventSink sink) {
+                // The single poll will supply 10 redundant events followed by an empty queue return value
+                for (int i=0; i < 10; i++) {
+                    String id = "a" + i;
+                    actualIds.add(id);
+                    assertTrue(sink.remaining() > 0);
+                    EventSink.Status status = sink.accept(newEvent(id, "table", "key", TimeUUIDs.newUUID()));
+                    assertEquals(status, EventSink.Status.ACCEPTED_CONTINUE);
+                }
+                return false;
+            }
+        };
+        Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
+        // Create a custom annotated content which returns all changes as redundant
+        DataProvider.AnnotatedContent annotatedContent = mock(DataProvider.AnnotatedContent.class);
+        when(annotatedContent.getContent()).thenReturn(content);
+        when(annotatedContent.isChangeDeltaRedundant(any(UUID.class))).thenReturn(true);
+        OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(annotatedContent));
+
+        PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 2);
+        assertTrue(result.getEvents().isEmpty());
+        assertFalse(result.hasMoreEvents());
+
+        // Since all events came from the same batch from the underlying event store they should all be deleted in one call.
+        verify(dedupEventStore).delete("test-subscription", actualIds, true);
+        verifyNoMoreInteractions(dedupEventStore);
+    }
+
+    @Test
+    public void testDiscardedUpdatesOverMultipleEventStorePolls() {
+        final List<String> actualIds = Lists.newArrayList();
+        DedupEventStore dedupEventStore = mock(DedupEventStore.class);
+        DatabusEventStore eventStore = new DatabusEventStore(mock(EventStore.class), dedupEventStore, Suppliers.ofInstance(true)) {
+            int iteration = 0;
+
+            @Override
+            public boolean poll(String subscription, Duration claimTtl, EventSink sink) {
+                // The first 10 polls will supply a single redundant update each, then the 11th poll will return
+                // an empty queue return value
+                if (iteration++ < 10) {
+                    String id = "a" + iteration;
+                    actualIds.add(id);
+                    assertTrue(sink.remaining() > 0);
+                    EventSink.Status status = sink.accept(newEvent(id, "table", "key", TimeUUIDs.newUUID()));
+                    assertEquals(status, EventSink.Status.ACCEPTED_CONTINUE);
+                    return true;
+                }
+                return false;
+            }
+        };
+        Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
+        // Create a custom annotated content which returns all changes as redundant
+        DataProvider.AnnotatedContent annotatedContent = mock(DataProvider.AnnotatedContent.class);
+        when(annotatedContent.getContent()).thenReturn(content);
+        when(annotatedContent.isChangeDeltaRedundant(any(UUID.class))).thenReturn(true);
+        OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(annotatedContent));
+
+        PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
+        assertTrue(result.getEvents().isEmpty());
+        assertFalse(result.hasMoreEvents());
+
+        // Since each event came from a separate batch from the underlying event store they should each be deleted
+        // in separate calls.
+        for (String actualId : actualIds) {
+            verify(dedupEventStore).delete("test-subscription", ImmutableList.of(actualId), true);
+        }
+        verifyNoMoreInteractions(dedupEventStore);
     }
 
     private DefaultDatabus newDatabus(DatabusEventStore eventStore, DataProvider dataProvider) {

--- a/docs/_posts/2014-08-07-databus.markdown
+++ b/docs/_posts/2014-08-07-databus.markdown
@@ -244,7 +244,7 @@ HTTP:
 Java:
 
 ```java
-List<Event> poll(String subscription, Duration claimTtl, int limit);
+PollResult poll(String subscription, Duration claimTtl, int limit);
 ```
 
 Request URL Parameters:
@@ -255,6 +255,27 @@ Request URL Parameters:
     events before the claim expires.  But if the claim period is too long, it may take a while for events to be
     re-processed if an application dies while holding claims.
 *   `limit` - optional - The maximum number of events to return.  The default `limit` is 10.
+
+In addition to any claimed events the HTTP response also includes the following header:
+
+```
+X-BV-Databus-Empty: [true|false]
+```
+
+If at the time the poll completed there are no more events for the subscription this header value will be `true`, otherwise
+it will be `false`.  Client code can take advantage of this information to poll again immediately if the databus is
+not empty, otherwise wait a brief period before polling again since an immediate subsequent call to `poll` is
+unlikely to return any events.  Note that because of EmoDB internals it is possible that a poll may return less than
+`limit` events yet still be non-empty.
+
+The Java response contains the following method which returns `true` if the databus is non-empty,
+`false` otherwise.
+
+Java:
+
+```java:
+pollResult.hasMoreEvents()
+```
 
 ### Renew Claims
 

--- a/quality/integration/src/test/java/test/integration/sor/SorStressTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/SorStressTest.java
@@ -119,7 +119,7 @@ public class SorStressTest  {
         loop(new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
-                List<Event> events = _databus.poll(SUBSCRIPTION, Duration.standardSeconds(30), 10);
+                List<Event> events = _databus.poll(SUBSCRIPTION, Duration.standardSeconds(30), 10).getEvents();
                 if (events.isEmpty()) {
                     _numIdle.incrementAndGet();
                     return false;  // idle

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/AbstractSubjectDatabus.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/AbstractSubjectDatabus.java
@@ -4,6 +4,7 @@ import com.bazaarvoice.emodb.auth.jersey.Subject;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -72,7 +73,7 @@ public abstract class AbstractSubjectDatabus implements SubjectDatabus {
     }
 
     @Override
-    public List<Event> poll(Subject subject, @PartitionKey String subscription, Duration claimTtl, int limit) {
+    public PollResult poll(Subject subject, @PartitionKey String subscription, Duration claimTtl, int limit) {
         return databus(subject).poll(subscription, claimTtl, limit);
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResourcePoller.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResourcePoller.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.web.resources.databus;
 import com.bazaarvoice.emodb.auth.jersey.Subject;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
@@ -43,6 +44,8 @@ public class DatabusResourcePoller {
     private static final Duration LONG_POLL_RETRY_TIME = Duration.standardSeconds(2);
     private static final Duration LONG_POLL_SEND_REFRESH_TIME = Duration.millis(200);
     private static final Duration KEEP_ALIVE_SAFETY_BUFFER_TIME = Duration.standardSeconds(10);
+
+    private static final String POLL_DATABUS_EMPTY_HEADER = "X-BV-Databus-Empty";
 
     private final Timer _pollTimer;
 
@@ -129,23 +132,23 @@ public class DatabusResourcePoller {
                 }
                 if (_pollingActive) {
                     boolean pollFailed = false;
-                    List<Event> events;
+                    PollResult result;
                     try {
                         // Issue a polling call with our server-side client. This ensures that we execute a synchronous
                         // call on the other end and receive a quick response - we do NOT want to execute a long-poll here
                         // and spend up to 20 seconds waiting for a response (occupying this thread all the while).
-                        events = _databus.poll(_subject, _subscription, _claimTtl, _limit);
+                        result = _databus.poll(_subject, _subscription, _claimTtl, _limit);
                     } catch (Exception e) {
                         // We're in an async context and have already returned a 200 response.  Since we can't
                         // retroactively change to 500 finish the request with an empty response and log the error.
                         _log.error("Failed to perform asynchronous poll on subscription {}", _subscription, e);
-                        events = ImmutableList.of();
+                        result = new PollResult(ImmutableList.of(), false);
                         pollFailed = true;
                     }
 
                     // Go ahead and output the response if we either 1.) find events to output, 2.) exceed our time
                     // limit, or 3.) received an exception during the last poll
-                    if (events.size() > 0
+                    if (result.getEvents().size() > 0
                             || (System.currentTimeMillis() + LONG_POLL_RETRY_TIME.getMillis()) >= _longPollStopTime
                             || pollFailed) {
                         // Lock the context before writing the response to ensure that the KeepAliveRunnable doesn't
@@ -153,13 +156,18 @@ public class DatabusResourcePoller {
                         synchronized (_asyncContext) {
                             if (_pollingActive) {
                                 _keepAliveRunnable.cancelKeepAlive();
-                                populateResponse(events, (HttpServletResponse) _asyncContext.getResponse(), _helper);
+                                populateResponse(result, (HttpServletResponse) _asyncContext.getResponse(), _helper);
                             }
                         }
                     } else {
-                        // Nothing to output; schedule the job to check again in a few seconds
+                        // Nothing to output; schedule the job to check again.  If the result had more events then poll
+                        // again immediately, otherwise wait a few seconds.
                         _lastRunTime = System.currentTimeMillis();
-                        _pollingExecutorService.schedule(this, LONG_POLL_RETRY_TIME.getMillis(), TimeUnit.MILLISECONDS);
+                        if (result.hasMoreEvents()) {
+                            _pollingExecutorService.execute(this);
+                        } else {
+                            _pollingExecutorService.schedule(this, LONG_POLL_RETRY_TIME.getMillis(), TimeUnit.MILLISECONDS);
+                        }
                         rescheduled = true;
                     }
                 }
@@ -239,9 +247,9 @@ public class DatabusResourcePoller {
         }
     }
 
-    private static void populateResponse(List<Event> events, HttpServletResponse response, PeekOrPollResponseHelper helper) {
+    private static void populateResponse(PollResult result, HttpServletResponse response, PeekOrPollResponseHelper helper) {
         try {
-            helper.getJson().writeJson(response.getOutputStream(), events);
+            helper.getJson().writeJson(response.getOutputStream(), result.getEvents());
         } catch (IOException ex) {
             _log.error("Failed to write response to the client");
         }
@@ -271,15 +279,18 @@ public class DatabusResourcePoller {
             // that the thread will stall if "databus" is an instance of DatabusClient and we are stuck waiting for a
             // response - however, since we use the server-side client we know that it will always execute synchronously
             // itself (no long-polling) and return in a reasonable period of time.
-            List<Event> events = databus.poll(subject, subscription, claimTtl, limit);
-            if (ignoreLongPoll || !events.isEmpty() || _keepAliveExecutorService == null || _pollingExecutorService == null) {
+            PollResult result = databus.poll(subject, subscription, claimTtl, limit);
+            if (ignoreLongPoll || !result.getEvents().isEmpty() || _keepAliveExecutorService == null || _pollingExecutorService == null) {
                 // If ignoreLongPoll == true or we have no executor services to schedule long-polling on then always
                 // return a response, even if it's empty. Alternatively, if we have data to return - return it!
-                response = Response.ok().entity(helper.asEntity(events)).build();
+                response = Response.ok()
+                        .header(POLL_DATABUS_EMPTY_HEADER, String.valueOf(!result.hasMoreEvents()))
+                        .entity(helper.asEntity(result.getEvents()))
+                        .build();
             } else {
                 // If the response is empty then go into async-mode and start up the runnables for our long-polling.
                 response = scheduleLongPollingRunnables(request, longPollStopTime, subject, databus, claimTtl, limit, subscription,
-                        helper, timerContext);
+                        result.hasMoreEvents(), helper, timerContext);
                 synchronousResponse = false;
             }
         } finally {
@@ -295,12 +306,18 @@ public class DatabusResourcePoller {
 
     private Response scheduleLongPollingRunnables(HttpServletRequest request, long longPollStopTime, Subject subject,
                                                   SubjectDatabus databus, Duration claimTtl, int limit, String subscription,
-                                                  PeekOrPollResponseHelper helper, Timer.Context timerContext) {
+                                                  boolean firstPollHadMoreEvents, PeekOrPollResponseHelper helper,
+                                                  Timer.Context timerContext) {
         final AsyncContext ctx = request.startAsync();
         boolean jobsScheduled = false;
 
         try {
             ctx.getResponse().setContentType("application/json");
+            //  We can't know at this point if the queue will be fully drained or not, so base the "databus empty"
+            // header on whether the original empty poll had more results.  Worst case the caller has a single false empty
+            // header which gets set correctly on the next poll.
+            ((HttpServletResponse) ctx.getResponse()).setHeader(POLL_DATABUS_EMPTY_HEADER, String.valueOf(!firstPollHadMoreEvents));
+
             // Immediately send a client refresh since we've already executed a poll() call and we don't know how long it
             // will take for our scheduled refresh to do its thing. It's probably not needed 99.9% of the time, but we
             // keep it here as a precaution.

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/SubjectDatabus.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/SubjectDatabus.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.web.resources.databus;
 import com.bazaarvoice.emodb.auth.jersey.Subject;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
+import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -56,7 +57,7 @@ public interface SubjectDatabus {
 
     List<Event> peek(Subject subject, String subscription, int limit);
 
-    List<Event> poll(Subject subject, String subscription, Duration claimTtl, int limit);
+    PollResult poll(Subject subject, String subscription, Duration claimTtl, int limit);
 
     void renew(Subject subject, String subscription, Collection<String> eventKeys, Duration claimTtl);
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Recently we encountered an issue where a client wrote a flood up non-mutative updates to Emo.  As a result most databus subscriptions grew to contain millions of raw events.  However, the databus poller automatically filters out any non-mutative updates and puts a fixed time limit on how long it will work before returning whatever events it has to the caller.  This resulted a paradoxical situation where the client's metrics tracking databus subscription size were in the millions while each call to poll returned an empty list of events.

While the extended consequences of this are substantial this pull request is aimed to address the following limited piece of the overall issue:  Most clients, including Emo's own canary, assume that when poll returns an empty list this implies that the subscription's queue is empty.  In response the clients wait a brief period, in canary's case 1 second, before polling again.  However, in this situation this proper behavior actually made a bad situation worse because the queues were continually growing while the clients paused between polls.

This pull request changes the poll call to explicitly return whether the databus queue for a subscription is empty or not.  The caller then can use this explicit information to re-poll immediately or back off as appropriate, rather than inferring emptiness from an empty returned set.  It also updates the Emo canary to use this new information to poll continuously so long as the queue contains more events.

The HTTP calll for poll has been updated to include a new response header, `X-BV-Databus-Empty`, which will have the value "true" or "false" as appropriate.  Because the body of the poll call has not changed it is fully backwards compatible with existing clients.

## How to Test and Verify

1. Check out this PR
2. Create a databus subscription
3. Create a table and numerous documents
4. Poll the subscription with varying limits and validate the "empty" header returns true or false as appropriate.

## Risk

There are two risks with this change:

1. Any existing client which fails when an unexpected header is present will fail.  Arguably, this is unlikely and not good client behavior in the first place.
2. If the "empty" header isn't working correctly this could encourage clients to poll too aggressively or two slowly, depending on which way the defect goes.

### Level 

`Medium`

### Required Testing

`Manual`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
