### PR TITLE
Drain the queue asynchronously if it's overloaded with redundant items.

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/QueueDrainExecutorService.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/QueueDrainExecutorService.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.databus;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for the ExecutorService to drain queues when having redundant items.
+ */
+@BindingAnnotation
+@Target ({FIELD, PARAMETER, METHOD})
+@Retention (RUNTIME)
+public @interface QueueDrainExecutorService {
+}

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -155,10 +156,18 @@ public class ConsolidationTest {
                     assertTrue(sink.remaining() > 0);
                     Set<String> tags;
                     switch (i % 4) {
-                        case 0:  tags = ImmutableSet.of("tag2", "tag3");  break;
-                        case 1:  tags = ImmutableSet.of("tag1", "tag2");  break;
-                        case 2:  tags = ImmutableSet.of();  break;
-                        default: tags = ImmutableSet.of("tag2", "tag3", "tag4");  break;
+                        case 0:
+                            tags = ImmutableSet.of("tag2", "tag3");
+                            break;
+                        case 1:
+                            tags = ImmutableSet.of("tag1", "tag2");
+                            break;
+                        case 2:
+                            tags = ImmutableSet.of();
+                            break;
+                        default:
+                            tags = ImmutableSet.of("tag2", "tag3", "tag4");
+                            break;
                     }
                     EventSink.Status status = sink.accept(newEvent(id, "table", "key", TimeUUIDs.newUUID(), tags));
                     assertEquals(status, EventSink.Status.ACCEPTED_CONTINUE);
@@ -199,10 +208,18 @@ public class ConsolidationTest {
                     assertTrue(sink.remaining() > 0);
                     Set<String> tags;
                     switch (iteration % 4) {
-                        case 0:  tags = ImmutableSet.of("tag2", "tag3");  break;
-                        case 1:  tags = ImmutableSet.of("tag1", "tag2");  break;
-                        case 2:  tags = ImmutableSet.of();  break;
-                        default: tags = ImmutableSet.of("tag2", "tag3", "tag4");  break;
+                        case 0:
+                            tags = ImmutableSet.of("tag2", "tag3");
+                            break;
+                        case 1:
+                            tags = ImmutableSet.of("tag1", "tag2");
+                            break;
+                        case 2:
+                            tags = ImmutableSet.of();
+                            break;
+                        default:
+                            tags = ImmutableSet.of("tag2", "tag3", "tag4");
+                            break;
                     }
                     EventSink.Status status = sink.accept(newEvent(id, "table", "key", TimeUUIDs.newUUID(), tags));
                     assertEquals(status, EventSink.Status.ACCEPTED_CONTINUE);
@@ -323,8 +340,8 @@ public class ConsolidationTest {
         JobHandlerRegistry jobHandlerRegistry = mock(JobHandlerRegistry.class);
         DatabusAuthorizer databusAuthorizer = ConstantDatabusAuthorizer.ALLOW_ALL;
         return new DefaultDatabus(lifeCycle, eventBus, dataProvider, subscriptionDao, eventStore, subscriptionEvaluator,
-                jobService, jobHandlerRegistry,  databusAuthorizer, "replication",
-                Suppliers.ofInstance(Conditions.alwaysFalse()), new MetricRegistry(), clock);
+                jobService, jobHandlerRegistry, databusAuthorizer, "replication",
+                Suppliers.ofInstance(Conditions.alwaysFalse()), mock(ExecutorService.class), new MetricRegistry(), clock);
     }
 
     private static EventData newEvent(final String id, String table, String key, UUID changeId) {

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusSizeCachingTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusSizeCachingTest.java
@@ -13,6 +13,7 @@ import com.google.common.eventbus.EventBus;
 import org.testng.annotations.Test;
 
 import java.time.Clock;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.mock;
@@ -35,7 +36,7 @@ public class DatabusSizeCachingTest {
      * The cache is expired after every 15 seconds.
      */
     @Test
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings ("unchecked")
     public void testSizeCache() {
         final Clock clock = mock(Clock.class);
         long start = System.currentTimeMillis();
@@ -45,7 +46,7 @@ public class DatabusSizeCachingTest {
         DefaultDatabus testDatabus = new DefaultDatabus(
                 mock(LifeCycleRegistry.class), mock(EventBus.class), mock(DataProvider.class), mock(SubscriptionDAO.class),
                 mockEventStore, mock(SubscriptionEvaluator.class), mock(JobService.class), mock(JobHandlerRegistry.class),
-                mock(DatabusAuthorizer.class), "replication", Suppliers.ofInstance(Conditions.alwaysFalse()),
+                mock(DatabusAuthorizer.class), "replication", Suppliers.ofInstance(Conditions.alwaysFalse()), mock(ExecutorService.class),
                 mock(MetricRegistry.class), clock);
 
         // At limit=500, size estimate should be at 4800
@@ -69,7 +70,7 @@ public class DatabusSizeCachingTest {
         verify(mockEventStore, times(1)).getSizeEstimate("testsubscription", 500L);
 
         // verify that it does *not* interact if the accuracy is decreased limit=50 over the next 14 seconds
-        for (int i=1; i <= 14; i++) {
+        for (int i = 1; i <= 14; i++) {
             when(clock.millis()).thenReturn(start + TimeUnit.SECONDS.toMillis(i));
             size = testDatabus.getEventCountUpTo("id", "testsubscription", 50L);
             assertEquals(size, 4800L, "Size should still be 4800");

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
@@ -1,10 +1,17 @@
 package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
+import com.bazaarvoice.emodb.event.api.DedupEventStore;
+import com.bazaarvoice.emodb.event.api.EventData;
+import com.bazaarvoice.emodb.event.api.EventSink;
+import com.bazaarvoice.emodb.event.api.EventStore;
 import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
 import com.bazaarvoice.emodb.job.api.JobService;
+import com.bazaarvoice.emodb.sor.api.Coordinate;
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
@@ -12,16 +19,32 @@ import com.bazaarvoice.emodb.sor.core.UpdateRef;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;
+import com.google.common.util.concurrent.MoreExecutors;
 import org.joda.time.Duration;
 import org.testng.annotations.Test;
 
+import java.nio.ByteBuffer;
 import java.time.Clock;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class DefaultDatabusTest {
     @Test
@@ -38,7 +61,7 @@ public class DefaultDatabusTest {
         DefaultDatabus testDatabus = new DefaultDatabus(
                 mock(LifeCycleRegistry.class), mock(EventBus.class), mock(DataProvider.class), mockSubscriptionDao,
                 mock(DatabusEventStore.class), mock(SubscriptionEvaluator.class), mock(JobService.class),
-                mock(JobHandlerRegistry.class), mock(DatabusAuthorizer.class), "replication", ignoreReEtl,
+                mock(JobHandlerRegistry.class), mock(DatabusAuthorizer.class), "replication", ignoreReEtl, mock(ExecutorService.class),
                 mock(MetricRegistry.class), Clock.systemUTC());
         Condition originalCondition = Conditions.mapBuilder().contains("foo", "bar").build();
         testDatabus.subscribe("id", "test-subscription", originalCondition, Duration.standardDays(7),
@@ -60,5 +83,168 @@ public class DefaultDatabusTest {
                 Duration.standardDays(7));
         verify(mockSubscriptionDao).getSubscription("test-subscription");
         verifyNoMoreInteractions(mockSubscriptionDao);
+    }
+
+    @Test
+    public void testDrainQueueForAllNonRedundantItemsInOnePeek() {
+
+        Supplier<Condition> ignoreReEtl = Suppliers.ofInstance(
+                Conditions.not(Conditions.mapBuilder().matches(UpdateRef.TAGS_NAME, Conditions.containsAny("re-etl")).build()));
+        final List<String> actualIds = Lists.newArrayList();
+        DedupEventStore dedupEventStore = mock(DedupEventStore.class);
+        DatabusEventStore eventStore = new DatabusEventStore(mock(EventStore.class), dedupEventStore, Suppliers.ofInstance(true)) {
+            @Override
+            public boolean peek(String subscription, EventSink sink) {
+                // The single peek will supply 3 redundant events followed by an empty queue return value
+                for (int i = 0; i < 3; i++) {
+                    String id = "a" + i;
+                    actualIds.add(id);
+                    assertTrue(sink.remaining() > 0);
+                    EventSink.Status status = sink.accept(newEvent(id, "table", "key", TimeUUIDs.newUUID()));
+                    assertEquals(status, EventSink.Status.ACCEPTED_CONTINUE);
+                }
+                return false;
+            }
+        };
+        Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
+        // Create a custom annotated content which returns all changes as not redundant
+        DataProvider.AnnotatedContent annotatedContent = mock(DataProvider.AnnotatedContent.class);
+        when(annotatedContent.getContent()).thenReturn(content);
+        when(annotatedContent.isChangeDeltaRedundant(any(UUID.class))).thenReturn(false); // Items are not redundant.
+
+        DefaultDatabus testDatabus = new DefaultDatabus(
+                mock(LifeCycleRegistry.class), mock(EventBus.class), new TestDataProvider().add(annotatedContent), mock(SubscriptionDAO.class),
+                eventStore, mock(SubscriptionEvaluator.class), mock(JobService.class),
+                mock(JobHandlerRegistry.class), mock(DatabusAuthorizer.class), "systemOwnerId", ignoreReEtl, MoreExecutors.sameThreadExecutor(),
+                mock(MetricRegistry.class), Clock.systemUTC());
+
+        // Call the drainQueue method.
+        testDatabus.drainQueueAsync("test-subscription");
+
+        // no deletes should be happening.
+        verifyZeroInteractions(dedupEventStore);
+
+        // the entry should be removed from map.
+        assertEquals(testDatabus.getDrainedSubscriptionsMap().size(), 0);
+    }
+
+    @Test
+    public void testDrainQueueForAllRedundantItemsInOnePeek() {
+
+        Supplier<Condition> ignoreReEtl = Suppliers.ofInstance(
+                Conditions.not(Conditions.mapBuilder().matches(UpdateRef.TAGS_NAME, Conditions.containsAny("re-etl")).build()));
+        final List<String> actualIds = Lists.newArrayList();
+        DedupEventStore dedupEventStore = mock(DedupEventStore.class);
+        DatabusEventStore eventStore = new DatabusEventStore(mock(EventStore.class), dedupEventStore, Suppliers.ofInstance(true)) {
+            @Override
+            public boolean peek(String subscription, EventSink sink) {
+                // The single peek will supply 3 redundant events followed by an empty queue return value
+                for (int i = 0; i < 3; i++) {
+                    String id = "a" + i;
+                    actualIds.add(id);
+                    assertTrue(sink.remaining() > 0);
+                    EventSink.Status status = sink.accept(newEvent(id, "table", "key", TimeUUIDs.newUUID()));
+                    assertEquals(status, EventSink.Status.ACCEPTED_CONTINUE);
+                }
+                return false;
+            }
+        };
+        Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
+        // Create a custom annotated content which returns all changes as redundant
+        DataProvider.AnnotatedContent annotatedContent = mock(DataProvider.AnnotatedContent.class);
+        when(annotatedContent.getContent()).thenReturn(content);
+        when(annotatedContent.isChangeDeltaRedundant(any(UUID.class))).thenReturn(true); // Items are redundant.
+
+        DefaultDatabus testDatabus = new DefaultDatabus(
+                mock(LifeCycleRegistry.class), mock(EventBus.class), new TestDataProvider().add(annotatedContent), mock(SubscriptionDAO.class),
+                eventStore, mock(SubscriptionEvaluator.class), mock(JobService.class),
+                mock(JobHandlerRegistry.class), mock(DatabusAuthorizer.class), "systemOwnerId", ignoreReEtl, MoreExecutors.sameThreadExecutor(),
+                mock(MetricRegistry.class), Clock.systemUTC());
+
+        // Call the drainQueue method.
+        testDatabus.drainQueueAsync("test-subscription");
+
+        // deletes should happen.
+        verify(dedupEventStore).delete("test-subscription", actualIds, true);
+        verifyNoMoreInteractions(dedupEventStore);
+
+        // the entry should be removed from map.
+        assertEquals(testDatabus.getDrainedSubscriptionsMap().size(), 0);
+    }
+
+    @Test
+    public void testDrainQueueForItemsInMultiplePeeks() {
+        Supplier<Condition> ignoreReEtl = Suppliers.ofInstance(
+                Conditions.not(Conditions.mapBuilder().matches(UpdateRef.TAGS_NAME, Conditions.containsAny("re-etl")).build()));
+        final List<String> actualIds = Lists.newArrayList();
+        DedupEventStore dedupEventStore = mock(DedupEventStore.class);
+        DatabusEventStore eventStore = new DatabusEventStore(mock(EventStore.class), dedupEventStore, Suppliers.ofInstance(true)) {
+            private int iteration = 0;
+
+            @Override
+            public boolean peek(String subscription, EventSink sink) {
+                // The single peek will return one item followed with a "more":true value. Finally, a "more":false value when done.
+                if (iteration++ < 3) {
+                    String id = "a" + iteration;
+                    actualIds.add(id);
+                    assertTrue(sink.remaining() > 0);
+                    EventSink.Status status = sink.accept(newEvent(id, "table", "key", TimeUUIDs.newUUID()));
+                    assertEquals(status, EventSink.Status.ACCEPTED_CONTINUE);
+                    return true;
+                }
+                return false;
+            }
+        };
+        Map<String, Object> content = entity("table", "key", ImmutableMap.of("rating", "5"));
+        // Create a custom annotated content which returns all changes as redundant
+        DataProvider.AnnotatedContent annotatedContent = mock(DataProvider.AnnotatedContent.class);
+        when(annotatedContent.getContent()).thenReturn(content);
+        when(annotatedContent.isChangeDeltaRedundant(any(UUID.class))).thenReturn(true);
+
+        DefaultDatabus testDatabus = new DefaultDatabus(
+                mock(LifeCycleRegistry.class), mock(EventBus.class), new TestDataProvider().add(annotatedContent), mock(SubscriptionDAO.class),
+                eventStore, mock(SubscriptionEvaluator.class), mock(JobService.class),
+                mock(JobHandlerRegistry.class), mock(DatabusAuthorizer.class), "systemOwnerId", ignoreReEtl, MoreExecutors.sameThreadExecutor(),
+                mock(MetricRegistry.class), Clock.systemUTC());
+
+        // Call the drainQueue method.
+        testDatabus.drainQueueAsync("test-subscription");
+
+        assertEquals(testDatabus.getDrainedSubscriptionsMap().size(), 0);
+
+        for (String actualId : actualIds) {
+            verify(dedupEventStore).delete("test-subscription", ImmutableList.of(actualId), true);
+        }
+        verifyNoMoreInteractions(dedupEventStore);
+
+        // the entry should be removed from map.
+        assertEquals(testDatabus.getDrainedSubscriptionsMap().size(), 0);
+    }
+
+    private static EventData newEvent(final String id, String table, String key, UUID changeId) {
+        return newEvent(id, table, key, changeId, ImmutableSet.<String>of());
+    }
+
+    private static EventData newEvent(final String id, String table, String key, UUID changeId, Set<String> tags) {
+        final ByteBuffer data = UpdateRefSerializer.toByteBuffer(new UpdateRef(table, key, changeId, tags));
+        return new EventData() {
+            @Override
+            public String getId() {
+                return id;
+            }
+
+            @Override
+            public ByteBuffer getData() {
+                return data;
+            }
+        };
+    }
+
+    private static Map<String, Object> entity(String table, String key, Map<String, ?> data) {
+        return ImmutableMap.<String, Object>builder()
+                .put(Intrinsic.VERSION, 1)
+                .putAll(data)
+                .putAll(Coordinate.of(table, key).asJson())
+                .build();
     }
 }


### PR DESCRIPTION
## Github Issue #

[1234](https://github.com/bazaarvoice/emodb/issues/11)

## What Are We Doing Here?

Recently we encountered an issue where a client wrote a flood up non-mutative updates to Emo. As a result most databus subscriptions grew to contain millions of raw events. In such cases, we would like to drain the queue asynchronously to delete the redundant events from the queue. 

## How to Test and Verify

1. Check out this PR
2. Create a table and with a document. 
3. Create a databus subscription and then add non-mutative deltas to the table.
4. Poll the subscription for non-mutative deltas, verify the draining task has kicked in from the logs and also check the size of the queue to confirm if all are deleted.

## Risk

### Level 

`Low`, `Medium`, or `High`. Give an indication of what you think is the level of change introduced by this PR. `High` means a massive change to a core functionality. 
`Low` means a really minor change that shouldn't have any regression effect. 

### Required Testing

`Smoke`, `Regression`, or `Manual`. (All changes except documentation need smoke
testing at a minimum).

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.