### PR TITLE
Updated partition forwarding errors to return appropriate response

### DIFF
--- a/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreClient.java
+++ b/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreClient.java
@@ -17,6 +17,7 @@ import com.bazaarvoice.emodb.client.EmoClientException;
 import com.bazaarvoice.emodb.client.EmoResource;
 import com.bazaarvoice.emodb.client.EmoResponse;
 import com.bazaarvoice.emodb.client.uri.EmoUriBuilder;
+import com.bazaarvoice.emodb.common.api.ServiceUnavailableException;
 import com.bazaarvoice.emodb.common.api.Ttls;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
 import com.bazaarvoice.emodb.common.json.RisonHelper;
@@ -589,6 +590,13 @@ public class BlobStoreClient implements AuthBlobStore {
                 return (RuntimeException) response.getEntity(UnauthorizedException.class).initCause(e);
             } else {
                 return (RuntimeException) new UnauthorizedException().initCause(e);
+            }
+        } else if (response.getStatus() == Response.Status.SERVICE_UNAVAILABLE.getStatusCode() &&
+                ServiceUnavailableException.class.getName().equals(exceptionType)) {
+            if (response.hasEntity()) {
+                return (RuntimeException) response.getEntity(ServiceUnavailableException.class).initCause(e);
+            } else {
+                return (RuntimeException) new ServiceUnavailableException().initCause(e);
             }
         }
 

--- a/common/api/src/main/java/com/bazaarvoice/emodb/common/api/ServiceUnavailableException.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/common/api/ServiceUnavailableException.java
@@ -1,0 +1,32 @@
+package com.bazaarvoice.emodb.common.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+/**
+ * Exception thrown when the service is unavailable or overloaded and the caller should retry again later.
+ * Corresponds to an HTTP 503 response.
+ */
+@JsonIgnoreProperties ({"cause", "localizedMessage", "stackTrace"})
+public class ServiceUnavailableException extends RuntimeException {
+
+    private Integer _retryAfterSeconds;
+
+    public ServiceUnavailableException() {
+        super();
+    }
+
+    @JsonCreator
+    public ServiceUnavailableException(@JsonProperty("message") String message,
+                                       @JsonProperty("retryAfterSeconds") @Nullable Integer retryAfterSeconds) {
+        super(message);
+        _retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public Integer getRetryAfterSeconds() {
+        return _retryAfterSeconds;
+    }
+}

--- a/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusClient.java
+++ b/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusClient.java
@@ -6,6 +6,7 @@ import com.bazaarvoice.emodb.client.EmoClient;
 import com.bazaarvoice.emodb.client.EmoClientException;
 import com.bazaarvoice.emodb.client.EmoResponse;
 import com.bazaarvoice.emodb.client.uri.EmoUriBuilder;
+import com.bazaarvoice.emodb.common.api.ServiceUnavailableException;
 import com.bazaarvoice.emodb.common.api.Ttls;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
 import com.bazaarvoice.emodb.databus.api.AuthDatabus;
@@ -433,6 +434,13 @@ public class DatabusClient implements AuthDatabus {
                 return (RuntimeException) response.getEntity(UnauthorizedException.class).initCause(e);
             } else {
                 return (RuntimeException) new UnauthorizedException().initCause(e);
+            }
+        } else if (response.getStatus() == Response.Status.SERVICE_UNAVAILABLE.getStatusCode() &&
+                ServiceUnavailableException.class.getName().equals(exceptionType)) {
+            if (response.hasEntity()) {
+                return (RuntimeException) response.getEntity(ServiceUnavailableException.class).initCause(e);
+            } else {
+                return (RuntimeException) new ServiceUnavailableException().initCause(e);
             }
         }
 

--- a/queue-client-common/src/main/java/com/bazaarvoice/emodb/queue/client/AbstractQueueClient.java
+++ b/queue-client-common/src/main/java/com/bazaarvoice/emodb/queue/client/AbstractQueueClient.java
@@ -5,6 +5,7 @@ import com.bazaarvoice.emodb.client.EmoClient;
 import com.bazaarvoice.emodb.client.EmoClientException;
 import com.bazaarvoice.emodb.client.EmoResponse;
 import com.bazaarvoice.emodb.client.uri.EmoUriBuilder;
+import com.bazaarvoice.emodb.common.api.ServiceUnavailableException;
 import com.bazaarvoice.emodb.common.api.Ttls;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
 import com.bazaarvoice.emodb.queue.api.Message;
@@ -283,6 +284,13 @@ abstract class AbstractQueueClient {
                 return (RuntimeException) response.getEntity(UnauthorizedException.class).initCause(e);
             } else {
                 return (RuntimeException) new UnauthorizedException().initCause(e);
+            }
+        } else if (response.getStatus() == Response.Status.SERVICE_UNAVAILABLE.getStatusCode() &&
+                ServiceUnavailableException.class.getName().equals(exceptionType)) {
+            if (response.hasEntity()) {
+                return (RuntimeException) response.getEntity(ServiceUnavailableException.class).initCause(e);
+            } else {
+                return (RuntimeException) new ServiceUnavailableException().initCause(e);
             }
         }
         return e;

--- a/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/DataStoreClient.java
+++ b/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/DataStoreClient.java
@@ -6,6 +6,7 @@ import com.bazaarvoice.emodb.client.EmoClient;
 import com.bazaarvoice.emodb.client.EmoClientException;
 import com.bazaarvoice.emodb.client.EmoResponse;
 import com.bazaarvoice.emodb.client.uri.EmoUriBuilder;
+import com.bazaarvoice.emodb.common.api.ServiceUnavailableException;
 import com.bazaarvoice.emodb.common.api.Ttls;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
 import com.bazaarvoice.emodb.common.json.JsonStreamProcessingException;
@@ -674,6 +675,13 @@ public class DataStoreClient implements AuthDataStore {
                 return (RuntimeException) response.getEntity(UnauthorizedException.class).initCause(e);
             } else {
                 return (RuntimeException) new UnauthorizedException().initCause(e);
+            }
+        } else if (response.getStatus() == Response.Status.SERVICE_UNAVAILABLE.getStatusCode() &&
+                ServiceUnavailableException.class.getName().equals(exceptionType)) {
+            if (response.hasEntity()) {
+                return (RuntimeException) response.getEntity(ServiceUnavailableException.class).initCause(e);
+            } else {
+                return (RuntimeException) new ServiceUnavailableException().initCause(e);
             }
         }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -420,7 +420,7 @@ public class EmoModule extends AbstractModule {
             SubjectDatabus client = ServicePoolBuilder.create(SubjectDatabus.class)
                     .withHostDiscovery(hostDiscovery)
                     .withServiceFactory(
-                            new PartitionAwareServiceFactory<>(serviceFactory, localSubjectDatabus, self, healthCheckRegistry))
+                            new PartitionAwareServiceFactory<>(SubjectDatabus.class, serviceFactory, localSubjectDatabus, self, healthCheckRegistry))
                     .withMetricRegistry(metricRegistry)
                     .withCachingPolicy(ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy())
                     .buildProxy(new ExponentialBackoffRetry(5, 50, 1000, TimeUnit.MILLISECONDS));
@@ -462,6 +462,7 @@ public class EmoModule extends AbstractModule {
                                                      @SelfHostAndPort HostAndPort self, @Global CuratorFramework curator,
                                                      MetricRegistry metricRegistry, HealthCheckRegistry healthCheckRegistry) {
             MultiThreadedServiceFactory<AuthQueueService> serviceFactory = new PartitionAwareServiceFactory<>(
+                    AuthQueueService.class,
                     QueueClientFactory.forClusterAndHttpClient(_configuration.getCluster(), jerseyClient),
                     new TrustedQueueService(queueService), self, healthCheckRegistry);
             AuthQueueService client = ServicePoolBuilder.create(AuthQueueService.class)
@@ -499,7 +500,7 @@ public class EmoModule extends AbstractModule {
             AuthDedupQueueService client = ServicePoolBuilder.create(AuthDedupQueueService.class)
                     .withHostDiscovery(hostDiscovery)
                     .withServiceFactory(new PartitionAwareServiceFactory<>(
-                            serviceFactory, new TrustedDedupQueueService(databus), self, healthCheckRegistry))
+                            AuthDedupQueueService.class, serviceFactory, new TrustedDedupQueueService(databus), self, healthCheckRegistry))
                     .withMetricRegistry(_environment.metrics())
                     .withCachingPolicy(ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy())
                     .buildProxy(new ExponentialBackoffRetry(5, 50, 1000, TimeUnit.MILLISECONDS));

--- a/web/src/main/java/com/bazaarvoice/emodb/web/jersey/ExceptionMappers.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/jersey/ExceptionMappers.java
@@ -25,11 +25,13 @@ public class ExceptionMappers {
                 new StashNotAvailableExceptionMapper(),
                 new DeltaSizeLimitExceptionMapper(),
                 new AuditSizeLimitExceptionMapper(),
-                new UnauthorizedSubscriptionExceptionMapper());
+                new UnauthorizedSubscriptionExceptionMapper(),
+                new ServiceUnavailableExceptionMapper());
     }
 
     public static Iterable<Class> getMapperTypes() {
         return ImmutableList.<Class>of(
-                UncheckedExecutionExceptionMapper.class);
+                UncheckedExecutionExceptionMapper.class,
+                PartitionForwardingExceptionMapper.class);
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/jersey/PartitionForwardingExceptionMapper.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/jersey/PartitionForwardingExceptionMapper.java
@@ -1,0 +1,35 @@
+package com.bazaarvoice.emodb.web.jersey;
+
+import com.bazaarvoice.emodb.common.api.ServiceUnavailableException;
+import com.bazaarvoice.emodb.web.partition.PartitionForwardingException;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.Providers;
+import java.util.Random;
+
+/**
+ * Exception mapper for when a partition-aware request is forwarded to another server and communication with that
+ * server fails.  Don't propagate the root cause exception, which is likely meaningless to the caller, but rather
+ * advise the caller to try again shortly.
+ */
+@Provider
+public class PartitionForwardingExceptionMapper implements ExceptionMapper<PartitionForwardingException> {
+
+    private final Providers _providers;
+
+    public PartitionForwardingExceptionMapper(@Context Providers providers) {
+        _providers = providers;
+    }
+
+    @SuppressWarnings("ThrowableNotThrown")
+    @Override
+    public Response toResponse(PartitionForwardingException exception) {
+
+        // To prevent herding advise the caller to retry after 1 to 5 seconds, chosen randomly.
+        return _providers.getExceptionMapper(ServiceUnavailableException.class)
+                .toResponse(new ServiceUnavailableException("Service unavailable, try again later", new Random().nextInt(5) + 1));
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/jersey/ServiceUnavailableExceptionMapper.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/jersey/ServiceUnavailableExceptionMapper.java
@@ -1,0 +1,26 @@
+package com.bazaarvoice.emodb.web.jersey;
+
+import com.bazaarvoice.emodb.common.api.ServiceUnavailableException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Exception mapper for when a resource explicitly returns that it is under heavy load or is otherwise unavailable
+ * and the caller should try again later.
+ */
+@Provider
+public class ServiceUnavailableExceptionMapper implements ExceptionMapper<ServiceUnavailableException> {
+
+    @Override
+    public Response toResponse(ServiceUnavailableException exception) {
+        return Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                .header("X-BV-Exception", ServiceUnavailableException.class.getName())
+                .header("Retry-After", exception.getRetryAfterSeconds())
+                .entity(exception)
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build();
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/partition/PartitionForwardingException.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/partition/PartitionForwardingException.java
@@ -1,0 +1,16 @@
+package com.bazaarvoice.emodb.web.partition;
+
+/**
+ * Encapsulating exception for when a forwarding call to another partition fails due to issues such as connection
+ * timeouts.
+ */
+public class PartitionForwardingException extends RuntimeException {
+
+    public PartitionForwardingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public PartitionForwardingException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/web/src/test/java/com/bazaarvoice/emodb/web/partition/PartitionAwareServiceFactoryTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/partition/PartitionAwareServiceFactoryTest.java
@@ -1,0 +1,132 @@
+package com.bazaarvoice.emodb.web.partition;
+
+import com.bazaarvoice.emodb.common.dropwizard.healthcheck.HealthCheckRegistry;
+import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.google.common.net.HostAndPort;
+import com.sun.jersey.api.client.ClientHandlerException;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.nio.BufferOverflowException;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+@SuppressWarnings("unchecked")
+public class PartitionAwareServiceFactoryTest {
+
+    // Just an interface with a single method with a declared non-runtime exception
+    public interface TestInterface {
+        void doIt() throws JsonParseException;
+    }
+
+    private PartitionAwareServiceFactory<TestInterface> _serviceFactory;
+    private MultiThreadedServiceFactory<TestInterface> _delegateServiceFactory;
+    private TestInterface _local;
+    private TestInterface _delegate;
+
+    private ServiceEndPoint _localEndPoint = mock(ServiceEndPoint.class);
+    private ServiceEndPoint _remoteEndPoint = mock(ServiceEndPoint.class);
+
+    @BeforeClass
+    public void setupEndPoints() {
+        when(_localEndPoint.getId()).thenReturn("localhost:8080");
+        when(_remoteEndPoint.getId()).thenReturn("remotehost:8080");
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        _local = mock(TestInterface.class);
+        _delegate = mock(TestInterface.class);
+
+        _delegateServiceFactory = mock(MultiThreadedServiceFactory.class);
+        when(_delegateServiceFactory.create(_remoteEndPoint)).thenReturn(_delegate);
+
+        _serviceFactory = new PartitionAwareServiceFactory<>(TestInterface.class, _delegateServiceFactory, _local,
+                HostAndPort.fromParts("localhost", 8080), mock(HealthCheckRegistry.class));
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        verifyNoMoreInteractions(_delegateServiceFactory, _local, _delegate);
+    }
+
+    @Test
+    public void testLocalService() {
+        TestInterface service = _serviceFactory.create(_localEndPoint);
+        assertSame(service, _local);
+    }
+
+    @Test
+    public void testDelegateService() throws Exception {
+        TestInterface service = _serviceFactory.create(_remoteEndPoint);
+        assertNotSame(service, _local);
+        service.doIt();
+        _serviceFactory.destroy(_remoteEndPoint, service);
+
+        verify(_delegateServiceFactory).create(_remoteEndPoint);
+        verify(_delegate).doIt();
+        verify(_delegateServiceFactory).destroy(_remoteEndPoint, _delegate);
+    }
+
+    public void testDelegateDeclaredExceptionPropagation() throws Exception {
+        doThrow(new JsonParseException("Simulated declared exception", JsonLocation.NA)).when(_delegate).doIt();
+        TestInterface service = _serviceFactory.create(_remoteEndPoint);
+
+        try {
+            service.doIt();
+            fail("JsonParseException not thrown");
+        } catch (JsonParseException e) {
+            assertEquals(e.getMessage(), "Simulated declared exception");
+        }
+
+        verify(_delegateServiceFactory).create(_remoteEndPoint);
+        verify(_delegate).doIt();
+    }
+
+    @Test
+    public void testDelegateUndeclaredExceptionPropagation() throws Exception {
+        // Just need some undeclared runtime exception, so BufferOverflowException it is
+        doThrow(new BufferOverflowException()).when(_delegate).doIt();
+        TestInterface service = _serviceFactory.create(_remoteEndPoint);
+
+        try {
+            service.doIt();
+        } catch (BufferOverflowException e) {
+            // ok
+        }
+
+        verify(_delegateServiceFactory).create(_remoteEndPoint);
+        verify(_delegate).doIt();
+    }
+
+    @Test
+    public void testDelegateConnectionTimeoutException() throws Exception {
+        doThrow(new ClientHandlerException(new ConnectTimeoutException())).when(_delegate).doIt();
+        TestInterface service = _serviceFactory.create(_remoteEndPoint);
+
+        try {
+            service.doIt();
+        } catch (PartitionForwardingException e) {
+            assertTrue(e.getCause() instanceof ConnectTimeoutException);
+        }
+
+        verify(_delegateServiceFactory).create(_remoteEndPoint);
+        verify(_delegate).doIt();
+
+    }
+}


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Emo uses a partitioning scheme to determine which instance owns resources such as databus subscriptions and queues.  Many API calls for those services, such as polling and acking events, must be performed on the owning instance.  If a request for that resource comes in to a non-owning resource it uses a Jersey client to forward the request to the correct instance.

On occasion the owning instance fails to respond before the HTTP connection to it times out.  The causes for the slow responses are a topic for a separate issue.  The problem addressed in this PR is that when this happens the Jersey exception goes uncaught all the way up to the resource layer, at which point it is converted into a generic 500 exception.  A better approach would be to return a "service temporarily unavailable" 503 response and cleanly advise the caller to retry later.

This PR:

- Propagates connection issues when partitioning forwarding into 503 responses at the Rest API.
- Updates all Java clients to convert these responses into a Java `ServiceUnavailableException` exception.


## How to Test and Verify

Testing locally is difficult to do since it requires two Emo instances and fine control over the network connection between the two.  However, if possible you could:

1. Start two Emo processes in the same cluster using the same ZooKeeper.
2. Through whatever means available, such as IP tables or intentional hosts file poisoning, prevent the instances from being able to directly communicate with each other.
3. Create a dedup queue and verify which is the owner using the leader task.
4. Make a poll request to the queue on the non-owning Emo.
5. Verify that a 503 error is returned.

## Risk

Risk is fairly low since the only real change is that we're trading one exception for another.  The biggest risk is that the proxy used to capture Jersey errors itself introduces exceptions.

### Level 

`Medium-Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
