### PR TITLE
Fixed tests which were failing after the addition of metrics.

### DIFF
--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
@@ -116,7 +116,7 @@ public class DefaultDatabusTest {
                 mock(LifeCycleRegistry.class), mock(EventBus.class), new TestDataProvider().add(annotatedContent), mock(SubscriptionDAO.class),
                 eventStore, mock(SubscriptionEvaluator.class), mock(JobService.class),
                 mock(JobHandlerRegistry.class), mock(DatabusAuthorizer.class), "systemOwnerId", ignoreReEtl, MoreExecutors.sameThreadExecutor(),
-                mock(MetricRegistry.class), Clock.systemUTC());
+                new MetricRegistry(), Clock.systemUTC());
 
         // Call the drainQueue method.
         testDatabus.drainQueueAsync("test-subscription");
@@ -159,7 +159,7 @@ public class DefaultDatabusTest {
                 mock(LifeCycleRegistry.class), mock(EventBus.class), new TestDataProvider().add(annotatedContent), mock(SubscriptionDAO.class),
                 eventStore, mock(SubscriptionEvaluator.class), mock(JobService.class),
                 mock(JobHandlerRegistry.class), mock(DatabusAuthorizer.class), "systemOwnerId", ignoreReEtl, MoreExecutors.sameThreadExecutor(),
-                mock(MetricRegistry.class), Clock.systemUTC());
+                new MetricRegistry(), Clock.systemUTC());
 
         // Call the drainQueue method.
         testDatabus.drainQueueAsync("test-subscription");
@@ -205,7 +205,7 @@ public class DefaultDatabusTest {
                 mock(LifeCycleRegistry.class), mock(EventBus.class), new TestDataProvider().add(annotatedContent), mock(SubscriptionDAO.class),
                 eventStore, mock(SubscriptionEvaluator.class), mock(JobService.class),
                 mock(JobHandlerRegistry.class), mock(DatabusAuthorizer.class), "systemOwnerId", ignoreReEtl, MoreExecutors.sameThreadExecutor(),
-                mock(MetricRegistry.class), Clock.systemUTC());
+                new MetricRegistry(), Clock.systemUTC());
 
         // Call the drainQueue method.
         testDatabus.drainQueueAsync("test-subscription");


### PR DESCRIPTION
## What Are We Doing Here?

This PR is to the fix the tests added in the scope of PR # 76 (Drain the queue asynchronously if it's overloaded with redundant items) that were failing after the addition of metrics. 
