### PR TITLE
Performance updates for databus poll

### DIFF
--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonHelper.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonHelper.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.common.json;
 
+import com.bazaarvoice.emodb.common.json.deferred.LazyJsonModule;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -18,7 +19,10 @@ import java.util.Date;
 
 public abstract class JsonHelper {
 
-    private static final ObjectMapper JSON = Jackson.newObjectMapper().disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    private static final ObjectMapper JSON = Jackson.newObjectMapper()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .registerModule(new LazyJsonModule());
+
     private static final ObjectWriter DEFAULT_WRITER = JSON.writer();
 
     public static String asJson(Object value) {

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/deferred/LazyJsonMap.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/deferred/LazyJsonMap.java
@@ -1,0 +1,356 @@
+package com.bazaarvoice.emodb.common.json.deferred;
+
+import com.bazaarvoice.emodb.common.json.JsonHelper;
+import com.bazaarvoice.emodb.common.json.OrderedJson;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.Maps;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * This object takes a string which contains a JSON object and lazily provides a Map&lt;String, Object&gt; interface
+ * around it.  A sequence similar to the following is performed frequently by Emo:
+ *
+ * <ol>
+ *     <li>
+ *         A request for a document comes in from the API, such as a DataStore request for a single record.
+ *     </li>
+ *     <li>
+ *         The document is retrieved from the backend and contains a single, large compacted JSON object.
+ *     </li>
+ *     <li>
+ *         The JSON object is converted into a Java map.  Usually a few more attributes are added to the map,
+ *         such as intrinsics and table attributes.
+ *     </li>
+ *     <li>
+ *         The object is returned to the web application layer, which in turn converts the Java map back into
+ *         a JSON stream.
+ *     </li>
+ * </ol>
+ *
+ * With large records and in aggregate over many records tests have shown that it is significantly more efficient to
+ * avoid generating the Java map as much as possible and stream the original JSON back to the web application.  In
+ * the best case the server responds more efficiently.  In those cases where an object representation is needed
+ * the implementation lazily deserializes the JSON into a <code>Map</code>, which in the end doesn't perform any additional
+ * work beyond what would have been done were the JSON deserialized to a <code>Map</code> in the first place.
+ *
+ * This implementation is not thread safe on updates such as {@link #put(String, Object)}.  Because the underlying map
+ * may be lazily deserialized a race condition could result in updates being lost if the instance is updated concurrently
+ * by multiple threads.
+ *
+ * CAUTION!
+ *
+ * The JSON string is itself lazily resolved.  Passing in a string which is not valid JSON or is not a JSON object
+ * will result in deferred errors when interacting with the map.  This class should only be used in situations where
+ * the input string is known to contain a valid JSON object.
+ */
+@JsonSerialize(using = LazyJsonMapSerializer.class)
+public class LazyJsonMap implements Map<String, Object> {
+
+    private final AtomicReference<DeserializationState> _deserState;
+
+    @JsonCreator
+    public LazyJsonMap(String json) {
+        this(new DeserializationState(checkNotNull(json, "json")));
+    }
+
+    private LazyJsonMap(DeserializationState deserState) {
+        _deserState = new AtomicReference<>(deserState);
+    }
+
+    /**
+     * At any time the map could be in one of two states:
+     * <ol>
+     *     <li>JSON string, in which case the state consists of the original JSON string and a map of any updates
+     *         which have been performed on the map, and</li>
+     *     <li>Deserialized, in which case the state consists of the Java Map object representation.</li>
+     * </ol>
+     */
+    private static class DeserializationState {
+        // Initial JSON string attributes
+        private final String json;
+        private final Map<String, Object> overrides;
+        // Deserialized attributes
+        private final Map<String, Object> deserialized;
+
+        DeserializationState(String json) {
+            this.json = json;
+            this.overrides = Maps.newHashMap();
+            this.deserialized = null;
+        }
+
+        DeserializationState(Map<String, Object> deserialized) {
+            this.deserialized = deserialized;
+            this.json = null;
+            this.overrides = null;
+        }
+
+        boolean isDeserialized() {
+            return deserialized != null;
+        }
+
+        DeserializationState copy() {
+            DeserializationState copy;
+            if (deserialized != null) {
+                copy = new DeserializationState(Maps.newHashMap(deserialized));
+            } else {
+                copy = new DeserializationState(json);
+                copy.overrides.putAll(overrides);
+            }
+            return copy;
+        }
+    }
+
+    /**
+     * Returns the JSON as a Map.  If necessary the JSON is converted to a Map as a result of this call.
+     */
+    private Map<String, Object> deserialized() {
+        // Written as a loop to prevent the need for locking
+        DeserializationState deserState;
+        while (!(deserState = _deserState.get()).isDeserialized()) {
+            Map<String, Object> deserialized = JsonHelper.fromJson(deserState.json, new TypeReference<Map<String, Object>>() {});
+            deserialized.putAll(deserState.overrides);
+            DeserializationState newDeserState = new DeserializationState(deserialized);
+            _deserState.compareAndSet(deserState, newDeserState);
+        }
+        return deserState.deserialized;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        DeserializationState deserializationState = _deserState.get();
+        if (deserializationState.isDeserialized()) {
+            return deserializationState.deserialized.isEmpty();
+        }
+        // If the JSON is empty it will contain only '{', '}', and possibly white space.  If it is not empty it must
+        // contain at least one '"' to open the first field name string.  So a shortcut to test emptiness is to check
+        // whether '"' does not exist in the string.
+        return deserializationState.overrides.isEmpty() && deserializationState.json.indexOf('"') == -1;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        DeserializationState deserializationState = _deserState.get();
+        if (deserializationState.isDeserialized()) {
+            return deserializationState.deserialized.containsKey(key);
+        }
+        // If the overrides contains the key then we can still hold off on deserializing the map
+        return deserializationState.overrides.containsKey(key) || deserialized().containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        DeserializationState deserializationState = _deserState.get();
+        if (deserializationState.isDeserialized()) {
+            return deserializationState.deserialized.containsValue(value);
+        }
+        // If the overrides contains the value then we can still hold off on deserializing the map
+        return deserializationState.overrides.containsValue(value) || deserialized().containsValue(value);
+    }
+
+    @Override
+    public Object get(Object key) {
+        DeserializationState deserializationState = _deserState.get();
+        if (deserializationState.isDeserialized()) {
+            return deserializationState.deserialized.get(key);
+        }
+        // If the overrides contains the key then we can still hold off on deserializing the map
+        if (deserializationState.overrides.containsKey(key)) {
+            return deserializationState.overrides.get(key);
+        }
+        return deserialized().get(key);
+    }
+
+    /**
+     * For efficiency this method breaks the contract that the old value is returned.  Otherwise common operations such
+     * as adding intrinsics and template attributes would require deserializing the object.
+     */
+    @Override
+    public Object put(String key, Object value) {
+        DeserializationState deserializationState = _deserState.get();
+        if (deserializationState.isDeserialized()) {
+            return deserializationState.deserialized.put(key, value);
+        }
+        return deserializationState.overrides.put(key, value);
+    }
+
+    @Override
+    public Object remove(Object key) {
+        // It's possible to handle removals without deserializing by creating a special "removed" object in the
+        // overrides.  However, removing attributes from literals is uncommon and slows down other operations,
+        // so always deserialize on remove.
+        return deserialized().remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ?> map) {
+        DeserializationState deserializationState = _deserState.get();
+        if (deserializationState.isDeserialized()) {
+            deserializationState.deserialized.putAll(map);
+        } else {
+            deserializationState.overrides.putAll(map);
+        }
+    }
+
+    @Override
+    public void clear() {
+        // No need to deserialize if not already deserialized
+        _deserState.set(new DeserializationState(Maps.newHashMap()));
+    }
+
+    @Override
+    public Set<String> keySet() {
+        // Must deserialize to get all keys
+        return deserialized().keySet();
+    }
+
+    @Override
+    public Collection<Object> values() {
+        // Must deserialize to get all values
+        return deserialized().values();
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+        // Must deserialize to get all entries
+        return deserialized().entrySet();
+    }
+
+    @Override
+    public int size() {
+        // Must deserialize to get size
+        return deserialized().size();
+    }
+
+    /**
+     * Writes this record to the provided generator in the most efficient manner possible in the current state.
+     */
+    void writeTo(JsonGenerator generator) throws IOException {
+        DeserializationState deserState = _deserState.get();
+
+        if (deserState.isDeserialized()) {
+            // Object has already been deserialized, use standard writer
+            generator.writeObject(deserState.deserialized);
+            return;
+        }
+
+        if (deserState.overrides.isEmpty()) {
+            // With no overrides the most efficient action is to copy the original JSON verbatim.
+            try {
+                generator.writeRaw(deserState.json);
+                return;
+            } catch (UnsupportedOperationException e) {
+                // Not all parsers are guaranteed to support this.  If this is one then use the default
+                // generator implementation which follows.
+            }
+        }
+
+        ObjectCodec codec = generator.getCodec();
+        if (codec == null) {
+            // No codec, defer to generator
+            generator.writeObject(deserialized());
+            return;
+        }
+
+        JsonParser parser = codec.getFactory().createParser(deserState.json);
+        checkState(parser.nextToken() == JsonToken.START_OBJECT, "JSON did not contain an object");
+        generator.writeStartObject();
+
+        // Typically the JSON string has been pre-sorted.  Insert the overrides in order.  If it turns out the
+        // JSON wasn't sorted then we'll just dump the remaining overrides at the end; it's valid JSON
+        // one way or the other.
+
+        //noinspection unchecked
+        Iterator<Map.Entry<String, Object>> sortedOverrides =
+                ((Map<String, Object>) OrderedJson.ordered(deserState.overrides)).entrySet().iterator();
+
+        Map.Entry<String, Object> nextOverride = sortedOverrides.hasNext() ? sortedOverrides.next() : null;
+
+        JsonToken token;
+        while ((token = parser.nextToken()) != JsonToken.END_OBJECT) {
+            assert token == JsonToken.FIELD_NAME;
+
+            String field = parser.getText();
+            if (deserState.overrides.containsKey(field)) {
+                // There's an override for this entry; skip it
+                token = parser.nextToken();
+                if (token.isStructStart()) {
+                    parser.skipChildren();
+                }
+            } else {
+                // Write all overrides which sort prior to this field
+                while (nextOverride != null && OrderedJson.KEY_COMPARATOR.compare(nextOverride.getKey(), field) < 0) {
+                    generator.writeFieldName(nextOverride.getKey());
+                    generator.writeObject(nextOverride.getValue());
+                    nextOverride = sortedOverrides.hasNext() ? sortedOverrides.next() : null;
+                }
+
+                // Copy this field name and value to the generator
+                generator.copyCurrentStructure(parser);
+            }
+            // Both of the above operations leave the current token immediately prior to the next
+            // field or the end object token.
+        }
+
+        // Write any remaining overrides
+        while (nextOverride != null) {
+            generator.writeFieldName(nextOverride.getKey());
+            generator.writeObject(nextOverride.getValue());
+            nextOverride = sortedOverrides.hasNext() ? sortedOverrides.next() : null;
+        }
+
+        generator.writeEndObject();
+    }
+
+    public LazyJsonMap lazyCopy() {
+        return new LazyJsonMap(_deserState.get().copy());
+    }
+
+    public boolean isDeserialized() {
+        return _deserState.get().isDeserialized();
+    }
+
+    /**
+     * Returns the overrides on the map if it has not been deserialized, or null if the map is deserialized.
+     */
+    @Nullable
+    public Map<String, Object> getOverrides() {
+        return _deserState.get().overrides;
+    }
+
+    @Override
+    public String toString() {
+        return JsonHelper.asJson(this);
+    }
+
+    @Override
+    public int hashCode() {
+        // For consistency must use the deserialized map
+        return deserialized().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        // Delay deserialization if we can rule out equality by class
+        if (!(obj instanceof Map)) {
+            return false;
+        }
+        // For consistency must use the deserialized map
+        return deserialized().equals(obj);
+    }
+}

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/deferred/LazyJsonMapSerializer.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/deferred/LazyJsonMapSerializer.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.common.json.deferred;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+/**
+ * Serializer for {@link LazyJsonMap}.  The serialization logic is contained in {@link LazyJsonMap#writeTo(JsonGenerator)};
+ * this object merely satisfies the {@link JsonSerializer} class hierarchy.
+ */
+public class LazyJsonMapSerializer extends JsonSerializer<LazyJsonMap> {
+    @Override
+    public void serialize(LazyJsonMap lazyJsonMap, JsonGenerator generator, SerializerProvider provider)
+            throws IOException, JsonProcessingException {
+        lazyJsonMap.writeTo(generator);
+    }
+}

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/deferred/LazyJsonModule.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/deferred/LazyJsonModule.java
@@ -1,0 +1,98 @@
+package com.bazaarvoice.emodb.common.json.deferred;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.util.VersionUtil;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+import com.fasterxml.jackson.databind.ser.ContextualSerializer;
+import com.fasterxml.jackson.databind.type.MapType;
+import com.fasterxml.jackson.databind.type.SimpleType;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Module for efficiently serializing {@link LazyJsonMap}.  Since LazyJsonMap implements {@link Map} the standard
+ * JSON serializer will serialize it by iterating over its {@link Map#entrySet()}.  This forces the LazyJsonMap to
+ * be deserialized, which bypasses the entire purpose of not requiring unnecessary deserilization for serialization.
+ *
+ * This module overrides the standard {@link com.fasterxml.jackson.databind.ser.std.MapSerializer} to use the
+ * lazy implementation when the input Map is a LazyJsonMap instance, otherwise to use the standard Map serializer.
+ */
+public class LazyJsonModule extends Module {
+
+    private final static JsonSerializer<LazyJsonMap> _lazyMapSerializer = new LazyJsonMapSerializer();
+
+    @Override
+    public String getModuleName() {
+        return "LazyJson";
+    }
+
+    @Override
+    public Version version() {
+        return VersionUtil.parseVersion("1.0", "com.bazaarvoice.emodb.common.json", "lazy-json");
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        // Modify the Map serializer to the delegate if it matches Map<String, ?>
+        context.addBeanSerializerModifier(new BeanSerializerModifier() {
+            @Override
+            public JsonSerializer<?> modifyMapSerializer(SerializationConfig config, MapType valueType, BeanDescription beanDesc,
+                                                         JsonSerializer<?> serializer) {
+                if (valueType.getKeyType().equals(SimpleType.construct(String.class))) {
+                    return new DelegatingMapSerializer(serializer);
+                }
+                return serializer;
+            }
+        });
+    }
+
+    /**
+     * Map serializer implementation which uses a {@link LazyJsonMapSerializer} for LazyJsonMap instances and delegates
+     * to a default serializer for all other Map classes.
+     */
+    private static class DelegatingMapSerializer extends JsonSerializer<Map<String, Object>> implements ContextualSerializer {
+
+        private final JsonSerializer<Map<String, Object>> _delegateSerializer;
+
+        DelegatingMapSerializer(JsonSerializer<?> delegateSerializer) {
+            //noinspection unchecked
+            _delegateSerializer = (JsonSerializer<Map<String, Object>>) delegateSerializer;
+        }
+
+        @Override
+        public void serialize(Map<String, Object> value, JsonGenerator jgen, SerializerProvider provider)
+                throws IOException, JsonProcessingException {
+            if (value instanceof LazyJsonMap) {
+                _lazyMapSerializer.serialize((LazyJsonMap) value, jgen, provider);
+            } else {
+                _delegateSerializer.serialize(value, jgen, provider);
+            }
+        }
+
+        /**
+         * Override to preserve the delegating behavior when a contextualized serializer is created.
+         */
+        @Override
+        public JsonSerializer<?> createContextual(SerializerProvider prov, BeanProperty property)
+                throws JsonMappingException {
+            if (_delegateSerializer instanceof ContextualSerializer) {
+                JsonSerializer<?> contextualDelegate = ((ContextualSerializer) _delegateSerializer).createContextual(prov, property);
+                // Check for different instance
+                if (contextualDelegate != _delegateSerializer) {
+                    return new DelegatingMapSerializer(contextualDelegate);
+                }
+            }
+            return this;
+        }
+    }
+}

--- a/common/json/src/test/java/com/bazaarvoice/emodb/common/json/deferred/LazyJsonMapTest.java
+++ b/common/json/src/test/java/com/bazaarvoice/emodb/common/json/deferred/LazyJsonMapTest.java
@@ -1,0 +1,211 @@
+package com.bazaarvoice.emodb.common.json.deferred;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import io.dropwizard.jackson.Jackson;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class LazyJsonMapTest {
+
+    @Test
+    public void testGet() {
+        LazyJsonMap map = new LazyJsonMap("{\"key\":[\"value\"]}");
+        Object actual = map.get("key");
+        assertEquals(actual, ImmutableList.of("value"));
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testKeySet() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        Set<String> actual = map.keySet();
+        assertEquals(actual, ImmutableSet.of("k1", "k2"));
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testValues() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        Collection<Object> actual = map.values();
+        assertEquals(actual.size(), 2);
+        assertEquals(ImmutableSet.copyOf(actual), ImmutableSet.of("v1", "v2"));
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testEntrySet() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        Map<String, Object> expected = Maps.newHashMapWithExpectedSize(2);
+        expected.put("k1", "v1");
+        expected.put("k2", "v2");
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            assertEquals(entry.getValue(), expected.remove(entry.getKey()));
+        }
+        assertTrue(expected.isEmpty());
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testGetSize() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        assertEquals(map.size(), 2);
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testGetWithOverrides() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":1}");
+        map.put("k1", 100);
+        map.put("k2", 200);
+        assertEquals(map.get("k1"), 100);
+        assertEquals(map.get("k2"), 200);
+        assertFalse(map.isDeserialized());
+    }
+
+    @Test
+    public void testKeySetWithOverride() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        map.put("k2", "v22");
+        map.put("k3", "v3");
+        Set<String> actual = map.keySet();
+        assertEquals(actual, ImmutableSet.of("k1", "k2", "k3"));
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testValuesWithOverride() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        map.put("k2", "v22");
+        map.put("k3", "v3");
+        Collection<Object> actual = map.values();
+        assertEquals(actual.size(), 3);
+        assertEquals(ImmutableSet.copyOf(actual), ImmutableSet.of("v1", "v22", "v3"));
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testEntrySetWithOverride() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        map.put("k2", "v22");
+        map.put("k3", "v3");
+        Map<String, Object> expected = Maps.newHashMapWithExpectedSize(3);
+        expected.put("k1", "v1");
+        expected.put("k2", "v22");
+        expected.put("k3", "v3");
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            assertEquals(entry.getValue(), expected.remove(entry.getKey()));
+        }
+        assertTrue(expected.isEmpty());
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testGetSizeWithOverride() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        map.put("k2", "v22");
+        map.put("k3", "v3");
+        assertEquals(map.size(), 3);
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testContainsKey() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        map.put("k2", "v22");
+        map.put("k3", "v3");
+
+        assertTrue(map.containsKey("k2"));
+        assertTrue(map.containsKey("k3"));
+        assertFalse(map.isDeserialized());
+        // Checking for any other key requires deserializing the map
+        assertTrue(map.containsKey("k1"));
+        assertFalse(map.containsKey("k999"));
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testContainsValue() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        map.put("k2", "v22");
+        map.put("k3", "v3");
+
+        assertTrue(map.containsValue("v22"));
+        assertTrue(map.containsValue("v3"));
+        assertFalse(map.isDeserialized());
+        // Checking for any other value requires deserializing the map
+        assertTrue(map.containsValue("v1"));
+        assertFalse(map.containsValue("v999"));
+        assertTrue(map.isDeserialized());
+    }
+
+    @Test
+    public void testIsEmptyWithEmptyJson() {
+        // Empty JSON, no overrides
+        LazyJsonMap map = new LazyJsonMap("{}");
+        assertTrue(map.isEmpty());
+        // Empty check shouldn't have serialized
+        assertFalse(map.isDeserialized());
+        // Add an override
+        map.put("k1", "v1");
+        assertFalse(map.isEmpty());
+        // Still shouldn't have serialized
+        assertFalse(map.isDeserialized());
+    }
+
+    @Test
+    public void testIsEmptyWithNonEmptyJson() {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\"}");
+        assertFalse(map.isEmpty());
+        // Empty check shouldn't have serialized
+        assertFalse(map.isDeserialized());
+    }
+
+    @Test
+    public void testJsonSerializeNoDeserialization() throws Exception {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        map.put("k2", "v22");
+        map.put("k3", "v3");
+
+        ObjectMapper objectMapper = Jackson.newObjectMapper();
+        objectMapper.registerModule(new LazyJsonModule());
+
+        // Write to JSON, then read back
+        String asJson = objectMapper.writeValueAsString(map);
+        Map<String, Object> actual = objectMapper.readValue(asJson, new TypeReference<Map<String, Object>>() {});
+        Map<String, Object> expected = ImmutableMap.of("k1", "v1", "k2", "v22", "k3", "v3");
+        assertEquals(actual, expected);
+        // Serialization should not have forced deserialize
+        assertFalse(map.isDeserialized());
+    }
+
+    @Test
+    public void testJsonSerializeAfterDeserialization() throws Exception {
+        LazyJsonMap map = new LazyJsonMap("{\"k1\":\"v1\",\"k2\":\"v2\"}");
+        map.put("k2", "v22");
+        map.put("k3", "v3");
+        // Perform a size call which should force the map to deserialize
+        map.size();
+        assertTrue(map.isDeserialized());
+
+        ObjectMapper objectMapper = Jackson.newObjectMapper();
+        objectMapper.registerModule(new LazyJsonModule());
+
+        // Write to JSON, then read back
+        String asJson = objectMapper.writeValueAsString(map);
+        Map<String, Object> actual = objectMapper.readValue(asJson, new TypeReference<Map<String, Object>>() {});
+        Map<String, Object> expected = ImmutableMap.of("k1", "v1", "k2", "v22", "k3", "v3");
+        assertEquals(actual, expected);
+    }
+}

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Event.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Event.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.databus.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.base.Objects;
@@ -31,9 +32,21 @@ public class Event {
         return _eventKey;
     }
 
-    @JsonView(EventViews.ContentOnly.class)
+    @JsonIgnore
     public Map<String, Object> getContent() {
         return Collections.unmodifiableMap(_content);
+    }
+
+    /**
+     * For purposes of JSON serialization wrapping the content in an unmodifiable view may cause the serializer
+     * to choose a less-optimal implementation.  Since JSON serialization cannot modify the underlying content
+     * it is safe to return the original content object to the serializer.
+     */
+    @JsonView(EventViews.ContentOnly.class)
+    @JsonProperty("content")
+    private Map<String, Object> getJsonSerializingContent() {
+        //noinspection unchecked
+        return (Map<String, Object>) _content;
     }
 
     @JsonView(EventViews.WithTags.class)

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -476,91 +476,105 @@ public class DefaultDatabus implements OwnerAwareDatabus, Managed {
             List<String> recentUnknownEventIds = Lists.newArrayList();
             List<String> eventIdsToUnclaim = Lists.newArrayList();
 
-            // Query the events from the data store in batch to reduce latency.
-            DataProvider.AnnotatedGet annotatedGet = _dataProvider.prepareGetAnnotated(ReadConsistency.STRONG);
-            for (Map.Entry<Coordinate, EventList> entry : rawEvents.entrySet()) {
-                Coordinate coord = entry.getKey();
+            // There's a delicate balance being targeted here.  On the one had we want to query the events from the data
+            // store in batch to reduce latency.  On the other hand querying too many large records at once may
+            // adversely delay a response.  Therefore, query for the annotated content in batches of 10.
 
-                // Query the table/key pair.
-                try {
-                    annotatedGet.add(coord.getTable(), coord.getId());
-                } catch (UnknownTableException e) {
-                    // It's likely the table was dropped since the event was queued.  Discard the events.
-                    EventList list = entry.getValue();
-                    for (Pair<String, UUID> pair : list.getEventAndChangeIds()) {
-                        eventIdsToDiscard.add(pair.first());
-                    }
-                    _discardedMeter.mark(list.size());
-                }
+            Iterator<Map.Entry<Coordinate, EventList>> rawEventIterator = rawEvents.entrySet().iterator();
 
-                // Keep track of the order in which we received the events from the EventStore.
-                if (!eventOrder.containsKey(coord)) {
-                    eventOrder.put(coord, eventOrder.size());
-                }
-            }
-            Iterator<DataProvider.AnnotatedContent> readResultIter = annotatedGet.execute();
+            do {
+                int annotatedBatchRemaining = 10;
 
-            // Loop through the results of the data store query.
-            while (readResultIter.hasNext()) {
-                DataProvider.AnnotatedContent readResult = readResultIter.next();
+                DataProvider.AnnotatedGet annotatedGet = _dataProvider.prepareGetAnnotated(ReadConsistency.STRONG);
+                while (rawEventIterator.hasNext() && annotatedBatchRemaining != 0) {
+                    Map.Entry<Coordinate, EventList> entry = rawEventIterator.next();
+                    Coordinate coord = entry.getKey();
 
-                // Get the JSON System of Record entity for this piece of content
-                Map<String, Object> content = readResult.getContent();
-
-                // Find the original event IDs that correspond to this piece of content
-                Coordinate coord = Coordinate.fromJson(content);
-                EventList eventList = rawEvents.get(coord);
-
-                // Get all databus event tags for the original event(s) for this coordinate
-                List<List<String>> tags = eventList.getTags();
-
-                // Loop over the Databus events for this piece of content.  Usually there's just one, but not always...
-                for (Pair<String, UUID> eventData : eventList.getEventAndChangeIds()) {
-                    String eventId = eventData.first();
-                    UUID changeId = eventData.second();
-
-                    // Has the content replicated yet?  If not, abandon the event and we'll try again when the claim expires.
-                    if (readResult.isChangeDeltaPending(changeId)) {
-                        if (isRecent(changeId)) {
-                            recentUnknownEventIds.add(eventId);
-                            _recentUnknownMeter.mark();
-                        } else {
-                            _staleUnknownMeter.mark();
+                    // Query the table/key pair.
+                    try {
+                        annotatedGet.add(coord.getTable(), coord.getId());
+                        annotatedBatchRemaining -= 1;
+                    } catch (UnknownTableException e) {
+                        // It's likely the table was dropped since the event was queued.  Discard the events.
+                        EventList list = entry.getValue();
+                        for (Pair<String, UUID> pair : list.getEventAndChangeIds()) {
+                            eventIdsToDiscard.add(pair.first());
                         }
-                        continue;
+                        _discardedMeter.mark(list.size());
                     }
 
-                    // Is the change redundant?  If so, no need to fire databus events for it.  Ack it now.
-                    if (readResult.isChangeDeltaRedundant(changeId)) {
-                        eventIdsToDiscard.add(eventId);
-                        _redundantMeter.mark();
-                        continue;
+                    // Keep track of the order in which we received the events from the EventStore.
+                    if (!eventOrder.containsKey(coord)) {
+                        eventOrder.put(coord, eventOrder.size());
                     }
-
-                    // Check whether we've already added this piece of content to the poll result.  If so, consolidate
-                    // the two together to reduce the amount of work a client must do.  Note that the previous item
-                    // might be from a previous batch of events and it's possible that we have read two different
-                    // versions of the same item of content.  This will prefer the most recent.
-                    Item previousItem = uniqueItems.get(coord);
-                    if (previousItem != null && previousItem.consolidateWith(eventId, content, tags)) {
-                        _consolidatedMeter.mark();
-                        continue;
-                    }
-
-                    // If, due to "padding" we asked for too many events, release the claims for the next poll().
-                    if (items.size() == limit) {
-                        eventIdsToUnclaim.add(eventId);
-                        continue;
-                    }
-
-                    // We have found a new item of content to return!
-                    Item item = new Item(eventId, eventOrder.get(coord), content, tags);
-                    items.add(item);
-                    uniqueItems.put(coord, item);
                 }
-            }
+                Iterator<DataProvider.AnnotatedContent> readResultIter = annotatedGet.execute();
 
-            // Abandon claims when we claimed more items than necessary to satisfy the specified limit.
+                // Loop through the results of the data store query.
+                while (readResultIter.hasNext()) {
+                    DataProvider.AnnotatedContent readResult = readResultIter.next();
+
+                    // Get the JSON System of Record entity for this piece of content
+                    Map<String, Object> content = readResult.getContent();
+
+                    // Find the original event IDs that correspond to this piece of content
+                    Coordinate coord = Coordinate.fromJson(content);
+                    EventList eventList = rawEvents.get(coord);
+
+                    // Get all databus event tags for the original event(s) for this coordinate
+                    List<List<String>> tags = eventList.getTags();
+
+                    // Loop over the Databus events for this piece of content.  Usually there's just one, but not always...
+                    for (Pair<String, UUID> eventData : eventList.getEventAndChangeIds()) {
+                        String eventId = eventData.first();
+                        UUID changeId = eventData.second();
+
+                        // Has the content replicated yet?  If not, abandon the event and we'll try again when the claim expires.
+                        if (readResult.isChangeDeltaPending(changeId)) {
+                            if (isRecent(changeId)) {
+                                recentUnknownEventIds.add(eventId);
+                                _recentUnknownMeter.mark();
+                            } else {
+                                _staleUnknownMeter.mark();
+                            }
+                            continue;
+                        }
+
+                        // Is the change redundant?  If so, no need to fire databus events for it.  Ack it now.
+                        if (readResult.isChangeDeltaRedundant(changeId)) {
+                            eventIdsToDiscard.add(eventId);
+                            _redundantMeter.mark();
+                            continue;
+                        }
+
+                        // Check whether we've already added this piece of content to the poll result.  If so, consolidate
+                        // the two together to reduce the amount of work a client must do.  Note that the previous item
+                        // might be from a previous batch of events and it's possible that we have read two different
+                        // versions of the same item of content.  This will prefer the most recent.
+                        Item previousItem = uniqueItems.get(coord);
+                        if (previousItem != null && previousItem.consolidateWith(eventId, content, tags)) {
+                            _consolidatedMeter.mark();
+                            continue;
+                        }
+
+                        // If, due to "padding" we asked for too many events, release the claims for the next poll().
+                        if (items.size() == limit) {
+                            eventIdsToUnclaim.add(eventId);
+                            continue;
+                        }
+
+                        // We have found a new item of content to return!
+                        Item item = new Item(eventId, eventOrder.get(coord), content, tags);
+                        items.add(item);
+                        uniqueItems.put(coord, item);
+                    }
+                }
+            } while (rawEventIterator.hasNext() && stopwatch.elapsed(TimeUnit.MILLISECONDS) < MAX_POLL_TIME.getMillis());
+
+            // Abandon claims in excess of what could be resolved within a reasonable amount of time
+            rawEventIterator.forEachRemaining(entry ->
+                    entry.getValue().getEventAndChangeIds().forEach(eventData -> eventIdsToUnclaim.add(eventData.first())));
+            // Abandon claims from above plus if we claimed more items than necessary to satisfy the specified limit.
             if (!eventIdsToUnclaim.isEmpty()) {
                 _eventStore.renew(subscription, eventIdsToUnclaim, Duration.ZERO, false);
             }
@@ -579,7 +593,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, Managed {
                 eventsAvailableForNextPoll = true;
             } else {
                 // Didn't get a full batch, that means there are no more events to be had.
-                // If we unclaimed any events due to padding then the result should indicate there are more events
+                // If we unclaimed any events then the result should indicate there are more events
                 eventsAvailableForNextPoll = !eventIdsToUnclaim.isEmpty();
                 break;
             }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/JsonTokener.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/JsonTokener.java
@@ -378,4 +378,12 @@ public class JsonTokener {
     public String toString() {
         return " at character " + this.myIndex + " of " + this.mySource;
     }
+
+    /**
+     * Returns the current position in the source string from the beginning, 0-based.  This function is not
+     * commonly used but is useful to perform custom handling of the remaining source.
+     */
+    public int pos() {
+        return myIndex;
+    }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
@@ -54,6 +54,11 @@ public class DataStoreConfiguration {
 
     @Valid
     @NotNull
+    @JsonProperty("deltaEncodingVersion")
+    private int _deltaEncodingVersion = 3;
+
+    @Valid
+    @NotNull
     @JsonProperty("stashRoot")
     private Optional<String> _stashRoot = Optional.absent();
 
@@ -139,6 +144,15 @@ public class DataStoreConfiguration {
 
     public DataStoreConfiguration setStashRoot(Optional<String> stashRoot) {
         _stashRoot = stashRoot;
+        return this;
+    }
+
+    public int getDeltaEncodingVersion() {
+        return _deltaEncodingVersion;
+    }
+
+    public DataStoreConfiguration setDeltaEncodingVersion(int deltaEncodingVersion) {
+        _deltaEncodingVersion = deltaEncodingVersion;
         return this;
     }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultResolver.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultResolver.java
@@ -52,7 +52,7 @@ public class DefaultResolver implements Resolver {
         _compactionCutoffSignature = compaction.getCutoffSignature();
         _lastCompactedMutationId = compaction.getLastMutation();
         _lastMutationId = _lastCompactedMutationId;
-        if (compaction.getCompactedDelta() != null) {
+        if (compaction.hasCompactedDelta()) {
             // We have compacted delta in this compaction. No cutoff delta was mutated as a part of this compaction.
             _content = DeltaEvaluator.eval(compaction.getCompactedDelta(), _content, _intrinsics);
             _lastAppliedTags = compaction.getLastTags();

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
@@ -58,7 +58,7 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
         Map.Entry<UUID, Compaction> compactionEntry = findEffectiveCompaction(record.passOneIterator(), keysToDelete, compactionConsistencyTimeStamp);
 
         // Check to see if this is a legacy compaction
-        if (compactionEntry != null && compactionEntry.getValue().getCompactedDelta() == null) {
+        if (compactionEntry != null && !compactionEntry.getValue().hasCompactedDelta()) {
             // Legacy compaction found. Can't use this compactor.
             return _legacyCompactor.doExpand(record, fullConsistencyTimestamp, intrinsics, ignoreRecent, compactionEntry);
         }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/LazyDelta.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/LazyDelta.java
@@ -1,0 +1,60 @@
+package com.bazaarvoice.emodb.sor.db;
+
+import com.bazaarvoice.emodb.sor.delta.Delta;
+import com.bazaarvoice.emodb.sor.delta.DeltaVisitor;
+import com.bazaarvoice.emodb.sor.delta.deser.DeltaParser;
+import com.bazaarvoice.emodb.sor.delta.deser.JsonTokener;
+import com.bazaarvoice.emodb.sor.delta.impl.AbstractDelta;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Delta implementation which takes an JSON token stream amd lazily deserializes it if needed.  There are numerous
+ * circumstances where a delta is read but never used, such as if the delta is behind a compaction record but has
+ * not yet been deleted.
+ *
+ * To avoid deserializing the delta to determine if it is constant the instance takes as a parameter whether the
+ * deserialized delta is constant.  It is up to the caller to ensure that this is accurate, since there are no checks
+ * for whether calling {@link Delta#isConstant()} on the deserialized delta matches the provided value.
+ */
+public class LazyDelta extends AbstractDelta {
+
+    private volatile JsonTokener _tokener;
+    private volatile Delta _delta;
+    private final boolean _constant;
+
+    public LazyDelta(JsonTokener tokener, boolean constant) {
+        _tokener = checkNotNull(tokener, "tokener");
+        _constant = constant;
+    }
+
+    private Delta getDelta() {
+        if (_delta == null) {
+            synchronized (this) {
+                if (_delta == null) {
+                    _delta = DeltaParser.parse(_tokener);
+                    _tokener = null;
+                }
+            }
+        }
+        return _delta;
+    }
+
+    @Override
+    public <T, V> V visit(DeltaVisitor<T, V> visitor, @Nullable T context) {
+        return getDelta().visit(visitor, context);
+    }
+
+    @Override
+    public boolean isConstant() {
+        return _constant;
+    }
+
+    @Override
+    public void appendTo(Appendable buf) throws IOException {
+        getDelta().appendTo(buf);
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
@@ -116,9 +116,9 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO {
     private final Meter _copyMeter;
 
     @Inject
-    public AstyanaxDataReaderDAO(PlacementCache placementCache, MetricRegistry metricRegistry) {
+    public AstyanaxDataReaderDAO(PlacementCache placementCache, ChangeEncoder changeEncoder, MetricRegistry metricRegistry) {
         _placementCache = placementCache;
-        _changeEncoder = new DefaultChangeEncoder();
+        _changeEncoder = changeEncoder;
         _readBatchTimer = metricRegistry.timer(getMetricName("readBatch"));
         _scanBatchTimer = metricRegistry.timer(getMetricName("scanBatch"));
         _randomReadMeter = metricRegistry.meter(getMetricName("random-reads"));

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataWriterDAO.java
@@ -95,12 +95,13 @@ public class AstyanaxDataWriterDAO implements DataWriterDAO, DataPurgeDAO {
     public AstyanaxDataWriterDAO(AstyanaxDataReaderDAO readerDao,
                                  FullConsistencyTimeProvider fullConsistencyTimeProvider, AuditStore auditStore,
                                  HintsConsistencyTimeProvider rawConsistencyTimeProvider,
+                                 ChangeEncoder changeEncoder,
                                  MetricRegistry metricRegistry) {
         _readerDao = checkNotNull(readerDao, "readerDao");
         _fullConsistencyTimeProvider = checkNotNull(fullConsistencyTimeProvider, "fullConsistencyTimeProvider");
         _rawConsistencyTimeProvider = checkNotNull(rawConsistencyTimeProvider, "rawConsistencyTimeProvider");
         _auditStore = checkNotNull(auditStore, "auditStore");
-        _changeEncoder = new DefaultChangeEncoder();
+        _changeEncoder = checkNotNull(changeEncoder, "changeEncoder");
         _updateMeter = metricRegistry.meter(getMetricName("updates"));
         _oversizeUpdateMeter = metricRegistry.meter(getMetricName("oversizeUpdates"));
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/ChangeEncoder.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/ChangeEncoder.java
@@ -5,13 +5,15 @@ import com.bazaarvoice.emodb.sor.api.Change;
 import com.bazaarvoice.emodb.sor.api.Compaction;
 import com.bazaarvoice.emodb.sor.api.History;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
+import java.util.EnumSet;
 import java.util.Set;
 import java.util.UUID;
 
 interface ChangeEncoder {
 
-    String encodeDelta(String delta, Set<String> tags);
+    String encodeDelta(String delta, @Nullable EnumSet<ChangeFlag> changeFlags, Set<String> tags);
 
     String encodeAudit(Audit audit);
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/ChangeFlag.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/ChangeFlag.java
@@ -1,0 +1,36 @@
+package com.bazaarvoice.emodb.sor.db.astyanax;
+
+/**
+ * Flags to help with encoding and decoding changes by {@link ChangeEncoder}.  Currently there is only one,
+ * but this could be expanded as necessary.
+ */
+public enum ChangeFlag {
+
+    MAP_DELTA('M'),
+    CONSTANT_DELTA('C'),
+    // Provide a default "unsupported" to be forward-compatible with future as-yet-undefined flags.
+    UNSUPPORTED('!');
+
+    private final char _serializedChar;
+
+    ChangeFlag(char serializedChar) {
+        _serializedChar = serializedChar;
+    }
+
+    public char serialize() {
+        return _serializedChar;
+    }
+
+    public static ChangeFlag deserialize(char serializedChar) {
+        // As there grow to be more flags this can grow as necessary.  For now, since there's
+        // only two, no need to be complicated.
+        switch (serializedChar) {
+            case 'M':
+                return MAP_DELTA;
+            case 'C':
+                return CONSTANT_DELTA;
+            default:
+                return UNSUPPORTED;
+        }
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
@@ -115,11 +115,12 @@ public class CqlDataReaderDAO implements DataReaderDAO {
 
     @Inject
     public CqlDataReaderDAO(@CqlReaderDAODelegate DataReaderDAO delegate, PlacementCache placementCache,
-                            CqlDriverConfiguration driverConfig, MetricRegistry metricRegistry) {
+                            CqlDriverConfiguration driverConfig, ChangeEncoder changeEncoder,
+                            MetricRegistry metricRegistry) {
         _astyanaxReaderDAO = checkNotNull(delegate, "delegate");
         _placementCache = placementCache;
         _driverConfig = driverConfig;
-        _changeEncoder = new DefaultChangeEncoder();
+        _changeEncoder = changeEncoder;
         _randomReadMeter = metricRegistry.meter(getMetricName("random-reads"));
         _readBatchTimer = metricRegistry.timer(getMetricName("readBatch"));
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DAOModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DAOModule.java
@@ -1,0 +1,44 @@
+package com.bazaarvoice.emodb.sor.db.astyanax;
+
+import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
+import com.bazaarvoice.emodb.sor.db.DataReaderDAO;
+import com.bazaarvoice.emodb.sor.db.DataWriterDAO;
+import com.bazaarvoice.emodb.sor.db.cql.CqlReaderDAODelegate;
+import com.bazaarvoice.emodb.table.db.astyanax.DataCopyDAO;
+import com.bazaarvoice.emodb.table.db.astyanax.DataPurgeDAO;
+import com.google.inject.PrivateModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+/**
+ * Guice module for DAO implementations.  Separate from {@link com.bazaarvoice.emodb.sor.DataStoreModule} to allow
+ * private bindings only used by the DAOs.  Required bindings are documented in DataStoreModule.
+ *
+ * @see com.bazaarvoice.emodb.sor.DataStoreModule
+ */
+public class DAOModule extends PrivateModule {
+
+    @Override
+    protected void configure() {
+        bind(DataReaderDAO.class).annotatedWith(CqlReaderDAODelegate.class).to(AstyanaxDataReaderDAO.class).asEagerSingleton();
+        bind(DataReaderDAO.class).to(CqlDataReaderDAO.class).asEagerSingleton();
+        bind(DataWriterDAO.class).to(AstyanaxDataWriterDAO.class).asEagerSingleton();
+        bind(DataCopyDAO.class).to(AstyanaxDataReaderDAO.class).asEagerSingleton();
+        bind(DataPurgeDAO.class).to(AstyanaxDataWriterDAO.class).asEagerSingleton();
+
+        // Explicit bindings so objects don't get created as a just-in-time binding in the root injector.
+        // This needs to be done for just about anything that has only public dependencies.
+        bind(AstyanaxDataReaderDAO.class).asEagerSingleton();
+
+        expose(DataReaderDAO.class);
+        expose(DataWriterDAO.class);
+        expose(DataCopyDAO.class);
+        expose(DataPurgeDAO.class);
+    }
+
+    @Provides
+    @Singleton
+    ChangeEncoder provideChangeEncoder(DataStoreConfiguration configuration) {
+        return new DefaultChangeEncoder(configuration.getDeltaEncodingVersion());
+    }
+}

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/db/astyanax/DefaultChangeEncoderTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/db/astyanax/DefaultChangeEncoderTest.java
@@ -1,24 +1,32 @@
 package com.bazaarvoice.emodb.sor.db.astyanax;
 
+import com.bazaarvoice.emodb.common.json.deferred.LazyJsonMap;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.sor.api.Change;
+import com.bazaarvoice.emodb.sor.api.Compaction;
+import com.bazaarvoice.emodb.sor.delta.Delete;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.bazaarvoice.emodb.sor.delta.Literal;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.astyanax.serializers.StringSerializer;
 import org.testng.annotations.Test;
 
+import java.util.EnumSet;
 import java.util.Set;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class DefaultChangeEncoderTest {
 
     @Test
-    public void testD2Decoding() {
-        String noTags = "D2:[]:{..,\"name\":\"bob\"}";
-        String oneTag = "D2:[\"one\"]:{..,\"name\":\"bob\"}";
-        String tags = "D2:[\"one\",\"two\",\"three\"]:{..,\"name\":\"bob\"}";
+    public void testD3Decoding() {
+        String noTags = "D3:[]:0:{..,\"name\":\"bob\"}";
+        String oneTag = "D3:[\"one\"]:0:{..,\"name\":\"bob\"}";
+        String tags = "D3:[\"one\",\"two\",\"three\"]:0:{..,\"name\":\"bob\"}";
 
         Delta expectedDelta = Deltas.fromString("{..,\"name\":\"bob\"}");
 
@@ -26,7 +34,6 @@ public class DefaultChangeEncoderTest {
         verifyDecodedChange(noTags, expectedDelta, ImmutableSet.<String>of());
         verifyDecodedChange(oneTag, expectedDelta, ImmutableSet.of("one"));
         verifyDecodedChange(tags, expectedDelta, ImmutableSet.of("one", "two", "three"));
-
     }
 
     @Test
@@ -37,24 +44,75 @@ public class DefaultChangeEncoderTest {
     }
 
     @Test
+    public void testLegacyD2Decoding() {
+        String legacyD2 = "D2:[\"tag0\",\"tag1\"]:{..,\"name\":\"bob\"}";
+        Delta expectedDelta = Deltas.fromString("{..,\"name\":\"bob\"}");
+        verifyDecodedChange(legacyD2, expectedDelta, ImmutableSet.of("tag0", "tag1"));
+    }
+
+    @Test
     public void testEncodeDecodeD2() {
         Delta delta = Deltas.mapBuilder().put("name", "bob").remove("x").build();
         Set<String> tags = ImmutableSet.of("tag0","tag1");
-        ChangeEncoder changeEncoder = new DefaultChangeEncoder();
+        ChangeEncoder changeEncoder = new DefaultChangeEncoder(true);
         // Encode and then decode the said delta, and verify if Change is as expected
-        Change change = changeEncoder.decodeChange(TimeUUIDs.newUUID(),
-                StringSerializer.get().fromString(changeEncoder.encodeDelta(delta.toString(), tags)));
+        String encodedDelta = changeEncoder.encodeDelta(delta.toString(), EnumSet.of(ChangeFlag.MAP_DELTA), tags);
+        assertEquals(encodedDelta, "D2:[\"tag0\",\"tag1\"]:{..,\"name\":\"bob\",\"x\":~}");
+        Change change = changeEncoder.decodeChange(TimeUUIDs.newUUID(), StringSerializer.get().fromString(encodedDelta));
         assertEquals(change.getDelta(), delta);
         assertEquals(change.getTags(), tags);
+    }
+
+    @Test
+    public void testEncodeDecodeD3() {
+        Delta delta = Deltas.mapBuilder().put("name", "bob").remove("x").build();
+        Set<String> tags = ImmutableSet.of("tag0","tag1");
+        ChangeEncoder changeEncoder = new DefaultChangeEncoder(false);
+        // Encode and then decode the said delta, and verify if Change is as expected
+        String encodedDelta = changeEncoder.encodeDelta(delta.toString(), EnumSet.of(ChangeFlag.MAP_DELTA), tags);
+        assertEquals(encodedDelta, "D3:[\"tag0\",\"tag1\"]:M:{..,\"name\":\"bob\",\"x\":~}");
+        Change change = changeEncoder.decodeChange(TimeUUIDs.newUUID(), StringSerializer.get().fromString(encodedDelta));
+        // Because the change contains a lazy delta it will not be the exact same instance as "delta"
+        assertEquals(change.getDelta().toString(), delta.toString());
+        assertFalse(change.getDelta().isConstant());
+        assertEquals(change.getTags(), tags);
+    }
+
+    @Test
+    public void testDecodeCompactionWithMapLiteral() {
+        String c1 = "C1:{\"count\":4,\"first\":\"6b6dff41-e50b-11e5-b18e-0e83e95d75a9\",\"cutoff\":\"741bb5bc-a5dc-11e6-8d58-123665dcce6e\"," +
+                    "\"cutoffSignature\":\"b6fe61d13972264e9d7ab0c230c82855\",\"lastContentMutation\":\"cef920a5-fbd4-11e5-b18e-0e83e95d75a9\"," +
+                    "\"lastMutation\":\"cef920a5-fbd4-11e5-b18e-0e83e95d75a9\",\"compactedDelta\":\"{\\\"active\\\":true}\",\"lastTags\":[\"tag1\"]}";
+        ChangeEncoder changeEncoder = new DefaultChangeEncoder(false);
+        Compaction compaction = changeEncoder.decodeCompaction(StringSerializer.get().fromString(c1));
+        assertEquals(compaction.getCount(), 4);
+        assertEquals(compaction.getLastTags(), ImmutableSet.of("tag1"));
+        // Compacted delta should be a lazy map literal
+        assertTrue(compaction.getCompactedDelta().isConstant());
+        assertTrue(compaction.getCompactedDelta() instanceof Literal);
+        assertTrue(((Literal) compaction.getCompactedDelta()).getValue() instanceof LazyJsonMap);
+        assertEquals(compaction.getCompactedDelta(), Deltas.literal(ImmutableMap.of("active", true)));
+    }
+
+    @Test
+    public void testDecodeCompactionWithDeletionDelta() {
+        String c1 = "C1:{\"count\":4,\"first\":\"6b6dff41-e50b-11e5-b18e-0e83e95d75a9\",\"cutoff\":\"741bb5bc-a5dc-11e6-8d58-123665dcce6e\"," +
+                "\"cutoffSignature\":\"b6fe61d13972264e9d7ab0c230c82855\",\"lastContentMutation\":\"cef920a5-fbd4-11e5-b18e-0e83e95d75a9\"," +
+                "\"lastMutation\":\"cef920a5-fbd4-11e5-b18e-0e83e95d75a9\",\"compactedDelta\":\"~\",\"lastTags\":[\"tag1\"]}";
+        ChangeEncoder changeEncoder = new DefaultChangeEncoder(false);
+        Compaction compaction = changeEncoder.decodeCompaction(StringSerializer.get().fromString(c1));
+        assertEquals(compaction.getCount(), 4);
+        assertEquals(compaction.getLastTags(), ImmutableSet.of("tag1"));
+        // Compacted delta should be a delete delta
+        assertTrue(compaction.getCompactedDelta().isConstant());
+        assertTrue(compaction.getCompactedDelta() instanceof Delete);
+        assertEquals(compaction.getCompactedDelta(), Deltas.delete());
     }
 
     private void verifyDecodedChange(String encodedDelta, Delta expectedDelta, ImmutableSet<String> tags) {
         ChangeEncoder changeEncoder = new DefaultChangeEncoder();
         Change change = changeEncoder.decodeChange(TimeUUIDs.newUUID(), StringSerializer.get().toByteBuffer(encodedDelta));
-        assertEquals(change.getDelta(), expectedDelta);
+        assertEquals(change.getDelta().toString(), expectedDelta.toString());
         assertEquals(change.getTags(), tags);
     }
-
-
-
 }

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/db/astyanax/DefaultChangeEncoderTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/db/astyanax/DefaultChangeEncoderTest.java
@@ -54,7 +54,7 @@ public class DefaultChangeEncoderTest {
     public void testEncodeDecodeD2() {
         Delta delta = Deltas.mapBuilder().put("name", "bob").remove("x").build();
         Set<String> tags = ImmutableSet.of("tag0","tag1");
-        ChangeEncoder changeEncoder = new DefaultChangeEncoder(true);
+        ChangeEncoder changeEncoder = new DefaultChangeEncoder(2);
         // Encode and then decode the said delta, and verify if Change is as expected
         String encodedDelta = changeEncoder.encodeDelta(delta.toString(), EnumSet.of(ChangeFlag.MAP_DELTA), tags);
         assertEquals(encodedDelta, "D2:[\"tag0\",\"tag1\"]:{..,\"name\":\"bob\",\"x\":~}");
@@ -67,7 +67,7 @@ public class DefaultChangeEncoderTest {
     public void testEncodeDecodeD3() {
         Delta delta = Deltas.mapBuilder().put("name", "bob").remove("x").build();
         Set<String> tags = ImmutableSet.of("tag0","tag1");
-        ChangeEncoder changeEncoder = new DefaultChangeEncoder(false);
+        ChangeEncoder changeEncoder = new DefaultChangeEncoder(3);
         // Encode and then decode the said delta, and verify if Change is as expected
         String encodedDelta = changeEncoder.encodeDelta(delta.toString(), EnumSet.of(ChangeFlag.MAP_DELTA), tags);
         assertEquals(encodedDelta, "D3:[\"tag0\",\"tag1\"]:M:{..,\"name\":\"bob\",\"x\":~}");
@@ -83,7 +83,7 @@ public class DefaultChangeEncoderTest {
         String c1 = "C1:{\"count\":4,\"first\":\"6b6dff41-e50b-11e5-b18e-0e83e95d75a9\",\"cutoff\":\"741bb5bc-a5dc-11e6-8d58-123665dcce6e\"," +
                     "\"cutoffSignature\":\"b6fe61d13972264e9d7ab0c230c82855\",\"lastContentMutation\":\"cef920a5-fbd4-11e5-b18e-0e83e95d75a9\"," +
                     "\"lastMutation\":\"cef920a5-fbd4-11e5-b18e-0e83e95d75a9\",\"compactedDelta\":\"{\\\"active\\\":true}\",\"lastTags\":[\"tag1\"]}";
-        ChangeEncoder changeEncoder = new DefaultChangeEncoder(false);
+        ChangeEncoder changeEncoder = new DefaultChangeEncoder();
         Compaction compaction = changeEncoder.decodeCompaction(StringSerializer.get().fromString(c1));
         assertEquals(compaction.getCount(), 4);
         assertEquals(compaction.getLastTags(), ImmutableSet.of("tag1"));
@@ -99,7 +99,7 @@ public class DefaultChangeEncoderTest {
         String c1 = "C1:{\"count\":4,\"first\":\"6b6dff41-e50b-11e5-b18e-0e83e95d75a9\",\"cutoff\":\"741bb5bc-a5dc-11e6-8d58-123665dcce6e\"," +
                 "\"cutoffSignature\":\"b6fe61d13972264e9d7ab0c230c82855\",\"lastContentMutation\":\"cef920a5-fbd4-11e5-b18e-0e83e95d75a9\"," +
                 "\"lastMutation\":\"cef920a5-fbd4-11e5-b18e-0e83e95d75a9\",\"compactedDelta\":\"~\",\"lastTags\":[\"tag1\"]}";
-        ChangeEncoder changeEncoder = new DefaultChangeEncoder(false);
+        ChangeEncoder changeEncoder = new DefaultChangeEncoder();
         Compaction compaction = changeEncoder.decodeCompaction(StringSerializer.get().fromString(c1));
         assertEquals(compaction.getCount(), 4);
         assertEquals(compaction.getLastTags(), ImmutableSet.of("tag1"));

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -10,6 +10,7 @@ import com.bazaarvoice.emodb.common.dropwizard.metrics.EmoGarbageCollectorMetric
 import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
 import com.bazaarvoice.emodb.common.json.CustomJsonObjectMapperFactory;
 import com.bazaarvoice.emodb.common.json.ISO8601DateFormat;
+import com.bazaarvoice.emodb.common.json.deferred.LazyJsonModule;
 import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
 import com.bazaarvoice.emodb.databus.core.DatabusEventStore;
 import com.bazaarvoice.emodb.databus.repl.ReplicationSource;
@@ -141,6 +142,7 @@ public class EmoService extends Application<EmoConfiguration> {
         bootstrap.addCommand(new EncryptConfigurationApiKeyCommand());
         // Write Date objects using ISO8601 strings instead of numeric milliseconds-since-1970.
         bootstrap.getObjectMapper().setDateFormat(new ISO8601DateFormat());
+        bootstrap.getObjectMapper().registerModule(new LazyJsonModule());
 
         bootstrap.getMetricRegistry().register("jvm.gc.totals", new EmoGarbageCollectorMetricSet());
     }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/PeekOrPollResponseHelper.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/PeekOrPollResponseHelper.java
@@ -1,15 +1,12 @@
 package com.bazaarvoice.emodb.web.resources.databus;
 
 import com.bazaarvoice.emodb.common.json.JsonHelper;
-import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.EventViews;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.StreamingOutput;
-
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,12 +34,7 @@ public class PeekOrPollResponseHelper {
     /**
      * Returns an object that can be serialized as a response entity to output the event list using the proper view.
      */
-    public StreamingOutput asEntity(final List<Event> events) {
-        return new StreamingOutput() {
-            @Override
-            public void write(OutputStream out) throws IOException, WebApplicationException {
-                _json.writeJson(out, events);
-            }
-        };
+    public StreamingOutput asEntity(final Object events) {
+        return out -> _json.writeJson(out, events);
     }
 }


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

We've been seeing issues with databus polls taking an excessively long time.  After investigation we found two related issues:

**Time consuming polls**

When polling the databus the default implementation will:
1. Poll for up to _limit_ raw events (fast)
1. Resolve all raw events found into content (slow)
1. Return the events + content to Jersey for streaming to the client.

Either of the following can cause a single poll request to take seconds, sometimes tens of seconds:

1. Requesting a large _limit_ of events, such as 500, and there are over _limit_ events in the queue.
1. Requesting a lower _limit_ of events but the first _limit_ events in the queue take longer than usual to resolve, either because of a high delta count or because the records themselves resolve to large deltas.

Because no data is returned to Jersey until all _limit_ records are fully prepared there can be a long delay between the receiving the request and the writing back the response.

Implementing a streaming protocol would definitely help with this.  However, there are several non-trivial challenges with that approach.  First, it would potentially require breaking the `Databus` interface into multiple interfaces, since the `poll` method for `Databus` returns a `PollResult`  which has a `List<Event>` attribute and we'd need it to return something more like `Iterator<Event>`.  Second, the "databus empty" header needs to be set before the first value is returned, but with a streaming approach it may not be known _a priori_ whether the queue is empty.  This can be mitigated with conservative estimates but would still need to be addressed.

While the streaming approach is achievable it is a larger change than what is done here and is more appropriate for a dedicated pull request.  This pull request takes the slower step of resolving the raw events into content and performs it in smaller batches of 10.  If there are more raw events but the total amount of time exceeds 100ms it returns what it has and releases the remaining raw events.  The trade-off is returning results faster at the expense of requiring additional API calls to get the remaining events.  However, with our current approach some clients were seeing response times well above their socket connection timeouts depending on the data in the queue, so this change makes response times more predictable.

**Large Content**

As mentioned in the previous section, large documents can slow down poll times.  Much of the time is spent parsing the delta JSON literals into Java Maps.  However, the most common use case is for those Maps to be returned from the Jersey resource only to be serialized back into JSON.  Tests have shown savings of 50-66% by delaying deserialization of JSON literal Map deltas until absolutely necessary and, if it is never necessary, streaming the JSON directly back to Jersey for the API response.

This pull request introduces a new Map implementation, `LazyJsonMap`, which does exactly this.  For the most common path from low level DAO to API Resource response it maintains the JSON as a String for as long as possible, streaming it efficiently to the response if it was never deserialized.

## How to Test and Verify

There's no new functionality, only performance improvements, so really the focus should be on data store and databus regression.  Note that while this PR contains the code for `LazyJsonMap` to maintain compatibility with the existing Emo release it is not yet active.  Only after a release is made with these changes is it then safe to make another release which activates that code path.  Otherwise it would not be possible to perform an in-flight upgrade of Emo.

## Risk

1. Something broke.
1. Clients will see faster poll responses but with fewer results per poll.  If they are not responsive they may lag more than usual.

### Level 

`High`, because the changes involve compaction and deltas which are central to Emo

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
