### PR TITLE
Fixed potential vulnerabilities caused by unchecked use of readLine()

### DIFF
--- a/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/RestartingS3InputStream.java
+++ b/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/RestartingS3InputStream.java
@@ -38,7 +38,7 @@ public class RestartingS3InputStream extends InputStream {
 
         // Get the object synchronously so any immediate S3 errors, such as file not found, are thrown inline.
         if (range == null) {
-            s3Object = _s3.getObject(_bucket, _key);
+            s3Object = _s3.getObject(new GetObjectRequest(_bucket, _key));
             _pos = 0;
             _length = s3Object.getObjectMetadata().getContentLength();
         } else {


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

A recent independent penetration test found use of `BufferedReader.readLine()` as a potential DoS vulnerability.  Even though 1) the vulnerable code only exists in client classes, not any executed by the web application, and 2) the only files read using these methods are Stash files which should be safe, this PR adds safeguards to protect against buffer overruns.  In theory this could happen if someone breached the Emo Stash s3 repository and replaced one or more files with intentionally crafted content to exploit the issue.

## How to Test and Verify

1. Use the `StashReader` client to read Stash data from S3.  Otherwise there is no way to test locally.

## Risk

As noted, the only changed code is run by clients and not the Emo web application, so risk is minimal.

### Level 

`Low`

### Required Testing

`Smoke`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
