### PR TITLE
Added ability to restrict blob store "Content-Type" response headers

### DIFF
--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreConfiguration.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreConfiguration.java
@@ -38,6 +38,11 @@ public class BlobStoreConfiguration {
     @JsonProperty("placementsUnderMove")
     private Map<String, String> _placementsUnderMove;
 
+    @Valid
+    @NotNull
+    @JsonProperty("approvedContentTypes")
+    private Set<String> _approvedContentTypes = ImmutableSet.of();
+
     public String getSystemTablePlacement() {
         return _systemTablePlacement;
     }
@@ -79,6 +84,15 @@ public class BlobStoreConfiguration {
 
     public BlobStoreConfiguration setPlacementsUnderMove(Map<String, String> placementsUnderMove) {
         _placementsUnderMove = placementsUnderMove;
+        return this;
+    }
+
+    public Set<String> getApprovedContentTypes() {
+        return _approvedContentTypes;
+    }
+
+    public BlobStoreConfiguration setApprovedContentTypes(Set<String> approvedContentTypes) {
+        _approvedContentTypes = approvedContentTypes;
         return this;
     }
 }

--- a/quality/integration/src/test/resources/config-blob-role.yaml
+++ b/quality/integration/src/test/resources/config-blob-role.yaml
@@ -125,6 +125,25 @@ blobStore:
       keyspaces:
         media_global: {}
 
+  approvedContentTypes:
+  - application/json
+  - audio/aac
+  - audio/mp4
+  - audio/mpeg
+  - audio/ogg
+  - audio/wav
+  - image/bmp
+  - image/gif
+  - image/jpeg
+  - image/png
+  - image/tiff
+  - image/x-xbitmap
+  - text/plain
+  - video/mp4
+  - video/mpeg
+  - video/ogg
+  - video/quicktime
+  - video/x-msvideo
 
 queueService:
   # Cassandra connection settings

--- a/sdk/src/main/resources/emodb-default-config.yaml
+++ b/sdk/src/main/resources/emodb-default-config.yaml
@@ -131,6 +131,26 @@ blobStore:
       keyspaces:
         media_global: {}
 
+  approvedContentTypes:
+  - application/json
+  - audio/aac
+  - audio/mp4
+  - audio/mpeg
+  - audio/ogg
+  - audio/wav
+  - image/bmp
+  - image/gif
+  - image/jpeg
+  - image/png
+  - image/tiff
+  - image/x-xbitmap
+  - text/plain
+  - video/mp4
+  - video/mpeg
+  - video/ogg
+  - video/quicktime
+  - video/x-msvideo
+
 queueService:
   # Cassandra connection settings
   cassandra:

--- a/web-local/config-local-blob-role.yaml
+++ b/web-local/config-local-blob-role.yaml
@@ -158,6 +158,25 @@ blobStore:
         media_global_mirror: {}
         blob_global: {}
 
+  approvedContentTypes:
+  - application/json
+  - audio/aac
+  - audio/mp4
+  - audio/mpeg
+  - audio/ogg
+  - audio/wav
+  - image/bmp
+  - image/gif
+  - image/jpeg
+  - image/png
+  - image/tiff
+  - image/x-xbitmap
+  - text/plain
+  - video/mp4
+  - video/mpeg
+  - video/ogg
+  - video/quicktime
+  - video/x-msvideo
 
 queueService:
   # Cassandra connection settings

--- a/web-local/config-local-main-role.yaml
+++ b/web-local/config-local-main-role.yaml
@@ -157,6 +157,26 @@ blobStore:
         blob_global:
           healthCheckColumnFamily: media_blob
 
+  approvedContentTypes:
+  - application/json
+  - audio/aac
+  - audio/mp4
+  - audio/mpeg
+  - audio/ogg
+  - audio/wav
+  - image/bmp
+  - image/gif
+  - image/jpeg
+  - image/png
+  - image/tiff
+  - image/x-xbitmap
+  - text/plain
+  - video/mp4
+  - video/mpeg
+  - video/ogg
+  - video/quicktime
+  - video/x-msvideo
+
 queueService:
   # Cassandra connection settings
   cassandra:

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -156,6 +156,26 @@ blobStore:
         media_global_mirror: {}
         blob_global: {}
 
+  approvedContentTypes:
+  - application/json
+  - audio/aac
+  - audio/mp4
+  - audio/mpeg
+  - audio/ogg
+  - audio/wav
+  - image/bmp
+  - image/gif
+  - image/jpeg
+  - image/png
+  - image/tiff
+  - image/x-xbitmap
+  - text/plain
+  - video/mp4
+  - video/mpeg
+  - video/ogg
+  - video/quicktime
+  - video/x-msvideo
+
 queueService:
   # Cassandra connection settings
   cassandra:

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -84,6 +84,7 @@ import com.bazaarvoice.emodb.web.partition.PartitionAwareClient;
 import com.bazaarvoice.emodb.web.partition.PartitionAwareServiceFactory;
 import com.bazaarvoice.emodb.web.plugins.DefaultPluginServerMetadata;
 import com.bazaarvoice.emodb.web.report.ReportsModule;
+import com.bazaarvoice.emodb.web.resources.blob.ApprovedBlobContentTypes;
 import com.bazaarvoice.emodb.web.resources.databus.DatabusRelayClientFactory;
 import com.bazaarvoice.emodb.web.resources.databus.DatabusResourcePoller;
 import com.bazaarvoice.emodb.web.resources.databus.LocalSubjectDatabus;
@@ -141,6 +142,7 @@ import org.slf4j.LoggerFactory;
 import java.net.URI;
 import java.time.Clock;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -339,6 +341,11 @@ public class EmoModule extends AbstractModule {
         protected void configure() {
             bind(BlobStoreConfiguration.class).toInstance(_configuration.getBlobStoreConfiguration());
             install(new BlobStoreModule(_serviceMode, "bv.emodb.blob", _environment.metrics()));
+        }
+
+        @Provides @ApprovedBlobContentTypes
+        Set<String> provideApprovedBlobContentTypes(BlobStoreConfiguration config) {
+            return config.getApprovedContentTypes();
         }
 
         /** Provide ZooKeeper namespaced to BlobStore data. */

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -33,6 +33,7 @@ import com.bazaarvoice.emodb.web.jersey.ExceptionMappers;
 import com.bazaarvoice.emodb.web.partition.PartitionAwareClient;
 import com.bazaarvoice.emodb.web.report.ReportLoader;
 import com.bazaarvoice.emodb.web.resources.FaviconResource;
+import com.bazaarvoice.emodb.web.resources.blob.ApprovedBlobContentTypes;
 import com.bazaarvoice.emodb.web.resources.blob.BlobStoreResource1;
 import com.bazaarvoice.emodb.web.resources.databus.DatabusResource1;
 import com.bazaarvoice.emodb.web.resources.databus.DatabusResourcePoller;
@@ -83,6 +84,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.blackList;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.blobStore_web;
@@ -238,9 +240,11 @@ public class EmoService extends Application<EmoConfiguration> {
 
         DataCenters dataCenters = _injector.getInstance(DataCenters.class);
         BlobStore blobStore = _injector.getInstance(BlobStore.class);
+        Set<String> approvedContentTypes = _injector.getInstance(
+                Key.get(new TypeLiteral<Set<String>>(){}, ApprovedBlobContentTypes.class));
         // Start the Blob service
         ResourceRegistry resources = _injector.getInstance(ResourceRegistry.class);
-        resources.addResource(_cluster, "emodb-blob-1", new BlobStoreResource1(blobStore, dataCenters));
+        resources.addResource(_cluster, "emodb-blob-1", new BlobStoreResource1(blobStore, dataCenters, approvedContentTypes));
     }
 
     private void evaluateDatabus()

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/ApprovedBlobContentTypes.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/ApprovedBlobContentTypes.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.web.resources.blob;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for the set of content types which are safe to return in the "Content-Type" header when a
+ * blob is retrieved.
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface ApprovedBlobContentTypes {
+}


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

A recent independent penetration test found a vulnerability by allowing blob writers to influence the content type of the blob when read.  A malicious actor could write a blob with an id such as "evil.png" which has a content type of "text/html" and whose content is not a PNG but a harmful snippet of HTML script.

This PR allows the Emo administrator to restrict which content types are safe to return to the client.  Any unapproved types will have the content type set to a generic "application/octet-stream".  Note that the "X-BVA-Content-Type" header will still be present, so the metadata is not lost.  The only change is that the "Content-Type" header won't be inferred from this value unless predetermined to be safe

## How to Test and Verify

1. Check out this PR
2. Start Emo locally
3. Run the following sequence:

```
$ curl -s -XPUT -H "Content-Type: application/json" "http://localhost:8080/blob/1/_table/test?options=placement:'media_global:ugc'&audit=comment:test" --data-binary '{}' | jq .
{
  "success": true
}

$ curl -s -XPUT -H "X-BVA-contentType: image/png" "http://localhost:8080/blob/1/test/safe" -d '...' | jq .
{
  "success":true
}

curl "http://localhost:8080/blob/1/test/safe" -v
*   Trying ::1...
* Connected to localhost (::1) port 8080 (#0)
> GET /blob/1/test/safe HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 30 Jan 2017 22:59:32 GMT
< Last-Modified: Mon, 30 Jan 2017 22:58:57 GMT
< Content-MD5: L0O0L9gz0ed0IKja50GQAA==
< ETag: "6eae3a5b062c6d0d79f070c26e6d62486b40cb46"
< Content-Type: image/png
< X-BV-Length: 3
< X-BVA-contentType: image/png
< Content-Length: 3
< 
...

$ curl -s -XPUT -H "X-BVA-contentType: text/html" "http://localhost:8080/blob/1/test/unsafe" -d '...' | jq .
{
  "success":true
}

$ curl "http://localhost:8080/blob/1/test/unsafe" -v
*   Trying ::1...
* Connected to localhost (::1) port 8080 (#0)
> GET /blob/1/test/unsafe HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 30 Jan 2017 23:00:22 GMT
< Last-Modified: Mon, 30 Jan 2017 22:59:52 GMT
< Content-MD5: L0O0L9gz0ed0IKja50GQAA==
< ETag: "6eae3a5b062c6d0d79f070c26e6d62486b40cb46"
< Content-Type: application/octet-stream
< X-BV-Length: 3
< X-BVA-contentType: text/html
< Content-Length: 3
< 
...
```

In particular note that the "X-BVA-contentType" and "Content-Type" headers for "safe" are "image/png" while for "unsafe" the "X-BVA-contentType" is "text/html" as originally set but the "Content-Type" is "application/octet-stream".

## Risk

The greatest risk is if any of Emo's clients are relying on the "Content-Type" header's current behavior.  However, this was always a nicety rather than an advertised feature, and Emo's own `BlobStoreClient` doesn't in any way surface the "Content-Type", only the metadata provided originally as "X-BVA" headers.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
