### PR TITLE
Changed databus to set "hasMoreEvents" correctly on edge condition

### DIFF
--- a/event/src/main/java/com/bazaarvoice/emodb/event/api/EventStore.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/api/EventStore.java
@@ -16,13 +16,13 @@ public interface EventStore extends BaseEventStore {
      * Equivalent to {@code addAll(channel, events)} followed immediately by {@code peek(channel, limit)}, but likely
      * more efficient.  The events added will be passed to the sink until the sink limit is satisfied.
      */
-    void addAllAndPeek(String channel, Collection<ByteBuffer> events, EventSink sink);
+    boolean addAllAndPeek(String channel, Collection<ByteBuffer> events, EventSink sink);
 
     /**
      * Equivalent to {@code addAll(channel, events)} followed immediately by {@code poll(channel, claimTtl, limit)},
      * but likely more efficient.  The events added will be passed to the sink until the sink limit is satisfied.
      */
-    void addAllAndPoll(String channel, Collection<ByteBuffer> events, Duration claimTtl, EventSink sink);
+    boolean addAllAndPoll(String channel, Collection<ByteBuffer> events, Duration claimTtl, EventSink sink);
 
     /** Reads all events in the channel, passing them to the specified sink {@code batchSize} at a time. */
     void scan(String channel, Predicate<ByteBuffer> filter, ScanSink sink, int batchSize, Date since);


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

There exists an edge case in databus polling where the "hasMoreEvents" flag may be false even though there are more events.  This is caused by the underlying way event polling works.  It always goes one event beyond the requested limit as part of consolidating duplicate events.  This can cause incorrect behavior in instances such as a poll for 10 events when the sorted queue has exactly 11 events.  When draining from the sorted queue to the read queue it moves 11 events to the read queue (10 plus the one extra).  However, the "is empty" logic then only checks if the sorted queue is empty, which in this case it is.  The correct approach is to check if the sorted queue is empty AND that all events drained from the sorted queue were accepted by the sink.  This PR makes that change. 

## How to Test and Verify

1. Check out this PR
2. Create a table and a subscription to that table.
3. Write 11 events to the table.
4. Poll the subscription with a limit of 10.  The poll should return 10 events and the "databus empty" header should be false.
5. Poll the subscription again with a limit of 10.  This should return the single remaining event and the "databus empty" header should be true.

## Risk

The risk is low.  The incorrect value only happens on edge cases in the first place, and if the value returned is incorrect the poller will still poll again anyway, only perhaps not as quickly as she could.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
