### PR TITLE
Add support for role namespaces

### DIFF
--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/AuthZooKeeper.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/AuthZooKeeper.java
@@ -1,0 +1,19 @@
+package com.bazaarvoice.emodb.auth;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation for the ZooKeeper curator namespaced for the authentication framework.
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface AuthZooKeeper {
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/SecurityManagerBuilder.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/SecurityManagerBuilder.java
@@ -3,8 +3,8 @@ package com.bazaarvoice.emodb.auth;
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeyRealm;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeySecurityManager;
-import com.bazaarvoice.emodb.auth.identity.AuthIdentityManager;
-import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
+import com.bazaarvoice.emodb.auth.identity.AuthIdentityReader;
+import com.bazaarvoice.emodb.auth.permissions.PermissionReader;
 import com.bazaarvoice.emodb.auth.shiro.GuavaCacheManager;
 import org.apache.shiro.cache.CacheManager;
 import org.apache.shiro.mgt.SecurityManager;
@@ -22,8 +22,8 @@ public class SecurityManagerBuilder {
     private final static String DEFAULT_REALM_NAME = "DefaultRealm";
 
     protected String _realmName = DEFAULT_REALM_NAME;
-    protected AuthIdentityManager<ApiKey> _authIdentityManager;
-    protected PermissionManager _permissionManager;
+    protected AuthIdentityReader<ApiKey> _authIdentityReader;
+    protected PermissionReader _permissionReader;
     protected String _anonymousId;
     protected CacheManager _cacheManager;
 
@@ -43,13 +43,13 @@ public class SecurityManagerBuilder {
         return this;
     }
 
-    public SecurityManagerBuilder withAuthIdentityManager(AuthIdentityManager<ApiKey> authIdentityManager) {
-        _authIdentityManager = checkNotNull(authIdentityManager, "authIdentityManager");
+    public SecurityManagerBuilder withAuthIdentityReader(AuthIdentityReader<ApiKey> authIdentityReader) {
+        _authIdentityReader = checkNotNull(authIdentityReader, "authIdentityReader");
         return this;
     }
 
-    public SecurityManagerBuilder withPermissionManager(PermissionManager permissionManager) {
-        _permissionManager = checkNotNull(permissionManager, "permissionManager");
+    public SecurityManagerBuilder withPermissionReader(PermissionReader permissionReader) {
+        _permissionReader = checkNotNull(permissionReader, "permissionReader");
         return this;
     }
 
@@ -69,12 +69,12 @@ public class SecurityManagerBuilder {
     }
 
     public EmoSecurityManager build() {
-        checkNotNull(_authIdentityManager, "authIdentityManager not set");
-        checkNotNull(_permissionManager, "permissionManager not set");
+        checkNotNull(_authIdentityReader, "authIdentityManager not set");
+        checkNotNull(_permissionReader, "permissionManager not set");
         if(_cacheManager == null) { // intended for test use
             _cacheManager = new GuavaCacheManager(null);
         }
-        ApiKeyRealm realm = new ApiKeyRealm(_realmName, _cacheManager, _authIdentityManager, _permissionManager, _anonymousId);
+        ApiKeyRealm realm = new ApiKeyRealm(_realmName, _cacheManager, _authIdentityReader, _permissionReader, _anonymousId);
         LifecycleUtils.init(realm);
 
         return new ApiKeySecurityManager(realm);

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/dropwizard/DropwizardAuthConfigurator.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/dropwizard/DropwizardAuthConfigurator.java
@@ -21,8 +21,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  *     SecurityManager securityManager = SecurityManagerBuilder.create()
  *             .withRealmName("MyRealm")
- *             .withAuthIdentityManager(identityManager)
- *             .withPermissionManager(permissionManager)
+ *             .withAuthIdentityReader(identityManager)
+ *             .withPermissionReader(permissionManager)
  *             .build();
  *
  *     new DropWizardAuthConfigurator(securityManager).configure(environment);

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentityManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentityManager.java
@@ -1,16 +1,9 @@
 package com.bazaarvoice.emodb.auth.identity;
 
-import java.util.Set;
-
 /**
  * Manager for identities.
  */
-public interface AuthIdentityManager<T extends AuthIdentity> {
-
-    /**
-     * Gets an entity by ID.  Returns the identity, or null if no such identity exists.
-     */
-    T getIdentity(String id);
+public interface AuthIdentityManager<T extends AuthIdentity> extends AuthIdentityReader<T> {
 
     /**
      * Updates an identity, or creates one if no matching identity already exists.
@@ -21,9 +14,4 @@ public interface AuthIdentityManager<T extends AuthIdentity> {
      * Deletes an identity.
      */
     void deleteIdentity(String id);
-
-    /**
-     * Gets the roles associated with an identity by its internal ID.
-     */
-    Set<String> getRolesByInternalId(String internalId);
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentityReader.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/identity/AuthIdentityReader.java
@@ -1,0 +1,26 @@
+package com.bazaarvoice.emodb.auth.identity;
+
+import org.apache.shiro.authz.AuthorizationInfo;
+
+import java.util.Set;
+
+/**
+ * Minimal interface for read-only access to authentication identities.
+ */
+public interface AuthIdentityReader<T extends AuthIdentity> {
+
+    /**
+     * Gets an entity by ID, such as its API key.  Returns the identity, or null if no such identity exists.
+     */
+    T getIdentity(String id);
+
+    /**
+     * Gets the roles associated with an identity by its internal ID.
+     *
+     * Although role management is done using {@link com.bazaarvoice.emodb.auth.role.RoleIdentifier} Shiro's
+     * authorization framework represents roles as Strings, as demonstrated by {@link AuthorizationInfo#getRoles())}.
+     * Since this reader is used as part of the authorization framework it provides an interface compatible with what
+     * Shiro requires.
+     */
+    Set<String> getRolesByInternalId(String internalId);
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/permissions/PermissionIDs.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/permissions/PermissionIDs.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.auth.permissions;
+
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+
+/**
+ * Static helper class for converting type-specific permissions to flat namespaced Strings used by
+ * {@link PermissionReader#getPermissions(String)}.  While currently only roles can have permissions attached to them
+ * this convention allows for future additional permission types without need for a separate permission management
+ * system.
+ */
+public final class PermissionIDs {
+
+    public static String forRole(RoleIdentifier id) {
+        return forRole(id.toString());
+    }
+
+    public static String forRole(String role) {
+        return "role:" + role;
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/permissions/PermissionManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/permissions/PermissionManager.java
@@ -1,7 +1,6 @@
 package com.bazaarvoice.emodb.auth.permissions;
 
 import org.apache.shiro.authz.Permission;
-import org.apache.shiro.authz.permission.PermissionResolver;
 
 import java.util.Map;
 import java.util.Set;
@@ -9,34 +8,23 @@ import java.util.Set;
 /**
  * Manager for permissions.
  */
-public interface PermissionManager {
-
+public interface PermissionManager extends PermissionReader {
+    
     /**
-     * Gets all permissions granted to this role.  If none, returns an empty set, not null,
-     * just like {@link com.google.common.collect.Multimap#get(Object)}
+     * Updates the permissions associated with an ID, such as a role.
      */
-    Set<Permission> getAllForRole(String role);
+    void updatePermissions(String id, PermissionUpdateRequest updates);
 
     /**
-     * Updates the permissions for a role.
+     * Revokes all permissions associated with an ID, such as a role.
      */
-    void updateForRole(String role, PermissionUpdateRequest updates);
+    void revokePermissions(String id);
 
     /**
-     * Revokes all permissions for a role.
-     */
-    void revokeAllForRole(String role);
-
-    /**
-     * Gets all roles with permissions attached.  Each record returned by the iterable maps a role name to the set
-     * of permissions that would be returned by calling {@link #getAllForRole(String)} for that role.
+     * Gets all IDs with permissions attached.  Each record returned by the iterable maps an ID to the set
+     * of permissions that would be returned by calling {@link #getPermissions(String)} for that role.
      * Note that if a role is in use but has no permissions attached then it is up to the implementation whether
      * to include a record with an empty set of permissions or omit the record entirely.
      */
     Iterable<Map.Entry<String, Set<Permission>>> getAll();
-
-    /**
-     * Gets the permission resolver for this manager.
-     */
-    PermissionResolver getPermissionResolver();
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/permissions/PermissionReader.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/permissions/PermissionReader.java
@@ -1,0 +1,24 @@
+package com.bazaarvoice.emodb.auth.permissions;
+
+import org.apache.shiro.authz.Permission;
+import org.apache.shiro.authz.permission.PermissionResolver;
+
+import java.util.Set;
+
+/**
+ * Minimal interface for read-only access to permissions.  The convention for determining permission IDs is orthogonal
+ * to this interface and is managed using {@link PermissionIDs}.
+ */
+public interface PermissionReader {
+
+    /**
+     * Gets all permissions granted to this ID, such as a role.  If none, returns an empty set, not null,
+     * just like {@link com.google.common.collect.Multimap#get(Object)}
+     */
+    Set<Permission> getPermissions(String id);
+
+    /**
+     * Gets the permission resolver for this reader.
+     */
+    PermissionResolver getPermissionResolver();
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/permissions/PermissionUpdateRequest.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/permissions/PermissionUpdateRequest.java
@@ -9,11 +9,12 @@ import java.util.Map;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Helper class for updating permissions using {@link PermissionManager#updateForRole(String, PermissionUpdateRequest)}
+ * Helper class for updating permissions using {@link PermissionManager#updatePermissions(String, PermissionUpdateRequest)}
  */
 public class PermissionUpdateRequest {
 
     private final Map<String, Boolean> _permissions = Maps.newLinkedHashMap();
+    private boolean _revokeRest = false;
 
     public PermissionUpdateRequest permit(Iterable<String> permissions) {
         update(Boolean.TRUE, permissions);
@@ -46,5 +47,14 @@ public class PermissionUpdateRequest {
 
     public Iterable<String> getRevoked() {
         return Maps.filterValues(_permissions, Predicates.equalTo(Boolean.FALSE)).keySet();
+    }
+
+    public PermissionUpdateRequest revokeRest() {
+        _revokeRest = true;
+        return this;
+    }
+
+    public boolean isRevokeRest() {
+        return _revokeRest;
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/InMemoryRoleManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/InMemoryRoleManager.java
@@ -75,6 +75,9 @@ public class InMemoryRoleManager implements RoleManager {
         if (role == null) {
             throw new RoleNotFoundException(id.getGroup(), id.getId());
         }
+        if (request.isNamePresent()) {
+            role.setName(request.getName());
+        }
         if (request.isDescriptionPresent()) {
             role.setDescription(request.getDescription());
         }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/InMemoryRoleManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/InMemoryRoleManager.java
@@ -1,0 +1,87 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import com.bazaarvoice.emodb.auth.permissions.PermissionIDs;
+import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Maps;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Simple in-memory implementation of a {@link RoleManager}.
+ */
+public class InMemoryRoleManager implements RoleManager {
+
+    private final Map<RoleIdentifier, Role> _rolesById = Maps.newConcurrentMap();
+    private final PermissionManager _permissionManager;
+
+    public InMemoryRoleManager(PermissionManager permissionManager) {
+        _permissionManager = permissionManager;
+    }
+
+    @Override
+    public Role getRole(RoleIdentifier id) {
+        return _rolesById.get(id);
+    }
+
+    @Override
+    public List<Role> getRolesByGroup(@Nullable String group) {
+        return _rolesById.values().stream()
+                .filter(role -> Objects.equals(role.getGroup(), group))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Iterator<Role> getAll() {
+        return _rolesById.values().iterator();
+    }
+
+    @Override
+    public Set<String> getPermissionsForRole(RoleIdentifier id) {
+        return ImmutableSortedSet.copyOf(
+                _permissionManager.getPermissions(PermissionIDs.forRole(id))
+                        .stream()
+                        .map(Objects::toString)
+                        .iterator());
+    }
+
+    @Override
+    public Role createRole(RoleIdentifier id, @Nullable String description, @Nullable Set<String> permissions) {
+        if (getRole(id) != null) {
+            throw new RoleExistsException(id.getGroup(), id.getName());
+        }
+        Role role = new Role(id.getGroup(), id.getName(), description);
+        _rolesById.put(id, role);
+        if (permissions != null && !permissions.isEmpty()) {
+            _permissionManager.updatePermissions(PermissionIDs.forRole(id), new PermissionUpdateRequest().permit(permissions));
+        }
+        return role;
+    }
+
+    @Override
+    public void updateRole(RoleIdentifier id, RoleUpdateRequest request) {
+        Role role = getRole(id);
+        if (role == null) {
+            throw new RoleNotFoundException(id.getGroup(), id.getName());
+        }
+        if (request.isDescriptionPresent()) {
+            role.setDescription(request.getDescription());
+        }
+        if (request.getPermissionUpdate() != null) {
+            _permissionManager.updatePermissions(PermissionIDs.forRole(id), request.getPermissionUpdate());
+        }
+    }
+
+    @Override
+    public void deleteRole(RoleIdentifier id) {
+        _permissionManager.revokePermissions(PermissionIDs.forRole(id));
+        _rolesById.remove(id);
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/Role.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/Role.java
@@ -1,0 +1,76 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * POJO representation of a role.  Note that permissions are not included in this object since the attributes of a role
+ * are orthogonal to management of permissions associated with that role.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Role {
+
+    private final String _group;
+    private final String _name;
+    private String _description;
+
+    @JsonCreator
+    public Role(@Nullable @JsonProperty("group") String group,
+                @JsonProperty("name") String name,
+                @Nullable @JsonProperty("description") String description) {
+        _group = group;
+        _name = checkNotNull(name, "name");
+        _description = description;
+    }
+
+    @JsonIgnore
+    public RoleIdentifier getId() {
+        return new RoleIdentifier(_group, _name);
+    }
+    
+    @Nullable
+    public String getGroup() {
+        return _group;
+    }
+
+    public String getName() {
+        return _name;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return _description;
+    }
+
+    public void setDescription(String description) {
+        _description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Role)) {
+            return false;
+        }
+
+        Role that = (Role) o;
+
+        return _name.equals(that._name) &&
+                Objects.equals(_group, that._group) &&
+                Objects.equals(_description, that._description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_group, _name);
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/Role.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/Role.java
@@ -18,21 +18,24 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class Role {
 
     private final String _group;
-    private final String _name;
+    private final String _id;
+    private String _name;
     private String _description;
 
     @JsonCreator
     public Role(@Nullable @JsonProperty("group") String group,
-                @JsonProperty("name") String name,
+                @JsonProperty("id") String id,
+                @Nullable @JsonProperty("name") String name,
                 @Nullable @JsonProperty("description") String description) {
         _group = group;
-        _name = checkNotNull(name, "name");
+        _id = checkNotNull(id, "id");
+        _name = name;
         _description = description;
     }
 
     @JsonIgnore
-    public RoleIdentifier getId() {
-        return new RoleIdentifier(_group, _name);
+    public RoleIdentifier getRoleIdentifier() {
+        return new RoleIdentifier(_group, _id);
     }
     
     @Nullable
@@ -40,6 +43,11 @@ public class Role {
         return _group;
     }
 
+    public String getId() {
+        return _id;
+    }
+    
+    @Nullable
     public String getName() {
         return _name;
     }
@@ -64,13 +72,14 @@ public class Role {
 
         Role that = (Role) o;
 
-        return _name.equals(that._name) &&
+        return _id.equals(that._id) &&
+                _name.equals(that._name) &&
                 Objects.equals(_group, that._group) &&
                 Objects.equals(_description, that._description);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_group, _name);
+        return Objects.hash(_group, _id);
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/Role.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/Role.java
@@ -52,6 +52,10 @@ public class Role {
         return _name;
     }
 
+    public void setName(String name) {
+        _name = name;
+    }
+
     @Nullable
     public String getDescription() {
         return _description;

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleExistsException.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleExistsException.java
@@ -8,19 +8,19 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties({"cause", "localizedMessage", "stackTrace"})
 public class RoleExistsException extends RuntimeException {
     private final String _group;
-    private final String _name;
+    private final String _id;
 
-    public RoleExistsException(String group, String name) {
+    public RoleExistsException(String group, String id) {
         super("Role not found");
         _group = group;
-        _name = name;
+        _id = id;
     }
     
     public String getGroup() {
         return _group;
     }
 
-    public String getName() {
-        return _name;
+    public String getId() {
+        return _id;
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleExistsException.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleExistsException.java
@@ -1,0 +1,26 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Exception thrown when attempting to create a role which already exists.
+ */
+@JsonIgnoreProperties({"cause", "localizedMessage", "stackTrace"})
+public class RoleExistsException extends RuntimeException {
+    private final String _group;
+    private final String _name;
+
+    public RoleExistsException(String group, String name) {
+        super("Role not found");
+        _group = group;
+        _name = name;
+    }
+    
+    public String getGroup() {
+        return _group;
+    }
+
+    public String getName() {
+        return _name;
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleIdentifier.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleIdentifier.java
@@ -49,10 +49,10 @@ public class RoleIdentifier {
     @Override
     public String toString() {
         if (_group == null) {
-            // When a role has no group the string representation is just the name.
+            // When a role has no group the string representation is just the id.
             return _id;
         }
-        // Since "/" isn't a valid character in group or role names it can be used as a separator without
+        // Since "/" isn't a valid character in groups or ids it can be used as a separator without
         // needing to encode either component.
         return _group + "/" + _id;
     }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleIdentifier.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleIdentifier.java
@@ -1,0 +1,78 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.shiro.authz.AuthorizationInfo;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Object implementation for the unique identifier for a role.  This ID consists of the role's group and name.
+ *
+ * Note this this identifier is only used in the context of managing roles.  Shiro represents roles as Strings,
+ * as demonstrated by {@link AuthorizationInfo#getRoles()}, so in all authentication and authorization interfaces
+ * the string representation as returned by {@link #toString()} is used to identify roles.
+ */
+public class RoleIdentifier {
+    private final String _group;
+    private final String _name;
+
+    @JsonCreator
+    public static RoleIdentifier fromString(String idStr) {
+        int s = idStr.indexOf('/');
+        if (s == -1) {
+            // Role has no group
+            return new RoleIdentifier(null, idStr);
+        }
+        // Split by group and role
+        return new RoleIdentifier(idStr.substring(0, s), idStr.substring(s+1));
+    }
+
+    public RoleIdentifier(@Nullable String group, String name) {
+        _group = group;
+        _name = checkNotNull(name, "name");
+    }
+
+    @Nullable
+    public String getGroup() {
+        return _group;
+    }
+
+    public String getName() {
+        return _name;
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        if (_group == null) {
+            // When a role has no group the string representation is just the name.
+            return _name;
+        }
+        // Since "/" isn't a valid character in group or role names it can be used as a separator without
+        // needing to encode either component.
+        return _group + "/" + _name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof RoleIdentifier)) {
+            return false;
+        }
+
+        RoleIdentifier that = (RoleIdentifier) o;
+
+        return _name.equals(that._name) && Objects.equals(_group, that._group);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_group, _name);
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleIdentifier.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleIdentifier.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Object implementation for the unique identifier for a role.  This ID consists of the role's group and name.
+ * Object implementation for the unique identifier for a role.  This ID consists of the role's group and id.
  *
  * Note this this identifier is only used in the context of managing roles.  Shiro represents roles as Strings,
  * as demonstrated by {@link AuthorizationInfo#getRoles()}, so in all authentication and authorization interfaces
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class RoleIdentifier {
     private final String _group;
-    private final String _name;
+    private final String _id;
 
     @JsonCreator
     public static RoleIdentifier fromString(String idStr) {
@@ -31,9 +31,9 @@ public class RoleIdentifier {
         return new RoleIdentifier(idStr.substring(0, s), idStr.substring(s+1));
     }
 
-    public RoleIdentifier(@Nullable String group, String name) {
+    public RoleIdentifier(@Nullable String group, String id) {
         _group = group;
-        _name = checkNotNull(name, "name");
+        _id = checkNotNull(id, "id");
     }
 
     @Nullable
@@ -41,8 +41,8 @@ public class RoleIdentifier {
         return _group;
     }
 
-    public String getName() {
-        return _name;
+    public String getId() {
+        return _id;
     }
 
     @JsonValue
@@ -50,11 +50,11 @@ public class RoleIdentifier {
     public String toString() {
         if (_group == null) {
             // When a role has no group the string representation is just the name.
-            return _name;
+            return _id;
         }
         // Since "/" isn't a valid character in group or role names it can be used as a separator without
         // needing to encode either component.
-        return _group + "/" + _name;
+        return _group + "/" + _id;
     }
 
     @Override
@@ -68,11 +68,11 @@ public class RoleIdentifier {
 
         RoleIdentifier that = (RoleIdentifier) o;
 
-        return _name.equals(that._name) && Objects.equals(_group, that._group);
+        return _id.equals(that._id) && Objects.equals(_group, that._group);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_group, _name);
+        return Objects.hash(_group, _id);
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleManager.java
@@ -35,14 +35,14 @@ public interface RoleManager {
     Set<String> getPermissionsForRole(RoleIdentifier id);
 
     /**
-     * Creates a role.  The method optionally accepts a list of initial permissions to associate with the role.
+     * Creates a role.
      * @return The role
      * @throws RoleExistsException Another role with the same ID exists
      */
-    Role createRole(RoleIdentifier id, @Nullable String description, @Nullable Set<String> permissions);
+    Role createRole(RoleIdentifier id, RoleUpdateRequest request);
 
     /**
-     * Updates a role.  This method can be used to update the role's description and/or permissions.
+     * Updates a role.  This method can be used to update the role's metadata and/or permissions.
      * @throws RoleNotFoundException No role with the ID exists
      */
     void updateRole(RoleIdentifier id, RoleUpdateRequest request);

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleManager.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleManager.java
@@ -1,0 +1,54 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Interface for managing roles and the permissions associated with those roles.
+ */
+public interface RoleManager {
+
+    /**
+     * Gets a role by ID.
+     * @return The role, or null of no role with the ID exists
+     */
+    Role getRole(RoleIdentifier id);
+
+    /**
+     * Gets all roles associated with a group.
+     * @return The roles for the group, or an empty list if no roles exist for the group
+     */
+    List<Role> getRolesByGroup(@Nullable String group);
+
+    /**
+     * Gets all roles defined.
+     * @return A role iterator.  If no roles exist the iterator will be empty
+     */
+    Iterator<Role> getAll();
+
+    /**
+     * Gets all permissions associated with a role.
+     * @return The permissions.  If the role does not exist returns an empty set
+     */
+    Set<String> getPermissionsForRole(RoleIdentifier id);
+
+    /**
+     * Creates a role.  The method optionally accepts a list of initial permissions to associate with the role.
+     * @return The role
+     * @throws RoleExistsException Another role with the same ID exists
+     */
+    Role createRole(RoleIdentifier id, @Nullable String description, @Nullable Set<String> permissions);
+
+    /**
+     * Updates a role.  This method can be used to update the role's description and/or permissions.
+     * @throws RoleNotFoundException No role with the ID exists
+     */
+    void updateRole(RoleIdentifier id, RoleUpdateRequest request);
+
+    /**
+     * Deletes a role.  If the role does not exist no action is performed.
+     */
+    void deleteRole(RoleIdentifier id);
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleNotFoundException.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleNotFoundException.java
@@ -8,19 +8,19 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties({"cause", "localizedMessage", "stackTrace"})
 public class RoleNotFoundException extends RuntimeException {
     private final String _group;
-    private final String _name;
+    private final String _id;
 
-    public RoleNotFoundException(String group, String name) {
+    public RoleNotFoundException(String group, String id) {
         super("Role not found");
         _group = group;
-        _name = name;
+        _id = id;
     }
 
     public String getGroup() {
         return _group;
     }
 
-    public String getName() {
-        return _name;
+    public String getId() {
+        return _id;
     }
 }

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleNotFoundException.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleNotFoundException.java
@@ -1,0 +1,26 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Exception thrown when attempting to utilize a role which does not exist.
+ */
+@JsonIgnoreProperties({"cause", "localizedMessage", "stackTrace"})
+public class RoleNotFoundException extends RuntimeException {
+    private final String _group;
+    private final String _name;
+
+    public RoleNotFoundException(String group, String name) {
+        super("Role not found");
+        _group = group;
+        _name = name;
+    }
+
+    public String getGroup() {
+        return _group;
+    }
+
+    public String getName() {
+        return _name;
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleUpdateRequest.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleUpdateRequest.java
@@ -3,7 +3,8 @@ package com.bazaarvoice.emodb.auth.role;
 import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
 
 /**
- * Request parameter for updating a role using {@link RoleManager#updateRole(RoleIdentifier, RoleUpdateRequest)}.
+ * Request parameter for updating a role using {@link RoleManager#createRole(RoleIdentifier, RoleUpdateRequest)}
+ * or {@link RoleManager#updateRole(RoleIdentifier, RoleUpdateRequest)}.
  */
 public class RoleUpdateRequest {
 

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleUpdateRequest.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleUpdateRequest.java
@@ -1,0 +1,36 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+
+/**
+ * Request parameter for updating a role using {@link RoleManager#updateRole(RoleIdentifier, RoleUpdateRequest)}.
+ */
+public class RoleUpdateRequest {
+
+    private String _description;
+    private boolean _descriptionPresent = false;
+    private PermissionUpdateRequest _permissionUpdate;
+
+    public RoleUpdateRequest withDescription(String description) {
+        _description = description;
+        _descriptionPresent = true;
+        return this;
+    }
+
+    public RoleUpdateRequest withPermissionUpdate(PermissionUpdateRequest permissionUpdate) {
+        _permissionUpdate = permissionUpdate;
+        return this;
+    }
+
+    public String getDescription() {
+        return _description;
+    }
+
+    public boolean isDescriptionPresent() {
+        return _descriptionPresent;
+    }
+
+    public PermissionUpdateRequest getPermissionUpdate() {
+        return _permissionUpdate;
+    }
+}

--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleUpdateRequest.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/role/RoleUpdateRequest.java
@@ -7,9 +7,17 @@ import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
  */
 public class RoleUpdateRequest {
 
+    private String _name;
+    private boolean _namePresent = false;
     private String _description;
     private boolean _descriptionPresent = false;
     private PermissionUpdateRequest _permissionUpdate;
+
+    public RoleUpdateRequest withName(String name) {
+        _name = name;
+        _namePresent = true;
+        return this;
+    }
 
     public RoleUpdateRequest withDescription(String description) {
         _description = description;
@@ -20,6 +28,14 @@ public class RoleUpdateRequest {
     public RoleUpdateRequest withPermissionUpdate(PermissionUpdateRequest permissionUpdate) {
         _permissionUpdate = permissionUpdate;
         return this;
+    }
+
+    public String getName() {
+        return _name;
+    }
+
+    public boolean isNamePresent() {
+        return _namePresent;
     }
 
     public String getDescription() {

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/TableAuthIdentityManagerDAO.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/TableAuthIdentityManagerDAO.java
@@ -35,7 +35,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * With circular logic more deadly to a robot than saying "this statement is false" the application must have
  * permission to perform operations on the table in order to use this manager.
  */
-public class TableAuthIdentityManager<T extends AuthIdentity> implements AuthIdentityManager<T> {
+public class TableAuthIdentityManagerDAO<T extends AuthIdentity> implements AuthIdentityManager<T> {
 
     private final static String ID = "id";
     private final static String INTERNAL_ID = "internalId";
@@ -50,13 +50,13 @@ public class TableAuthIdentityManager<T extends AuthIdentity> implements AuthIde
     private final HashFunction _hash;
     private volatile boolean _tablesValidated;
 
-    public TableAuthIdentityManager(Class<T> authIdentityClass, DataStore dataStore, String identityTableName,
-                                    String internalIdIndexTableName, String placement) {
+    public TableAuthIdentityManagerDAO(Class<T> authIdentityClass, DataStore dataStore, String identityTableName,
+                                       String internalIdIndexTableName, String placement) {
         this(authIdentityClass, dataStore, identityTableName, internalIdIndexTableName, placement, null);
     }
 
-    public TableAuthIdentityManager(Class<T> authIdentityClass, DataStore dataStore, String identityTableName,
-                                    String internalIdIndexTableName, String placement, @Nullable HashFunction hash) {
+    public TableAuthIdentityManagerDAO(Class<T> authIdentityClass, DataStore dataStore, String identityTableName,
+                                       String internalIdIndexTableName, String placement, @Nullable HashFunction hash) {
         _authIdentityClass = checkNotNull(authIdentityClass, "authIdentityClass");
         _dataStore = checkNotNull(dataStore, "client");
         _identityTableName = checkNotNull(identityTableName, "identityTableName");

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/CacheManagingPermissionManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/CacheManagingPermissionManager.java
@@ -23,20 +23,20 @@ public class CacheManagingPermissionManager implements PermissionManager {
     }
 
     @Override
-    public Set<Permission> getAllForRole(String role) {
-        checkNotNull(role, "role");
-        return _manager.getAllForRole(role);
+    public Set<Permission> getPermissions(String id) {
+        checkNotNull(id, "id");
+        return _manager.getPermissions(id);
     }
 
     @Override
-    public void updateForRole(String role, PermissionUpdateRequest updates) {
-        _manager.updateForRole(role, updates);
+    public void updatePermissions(String id, PermissionUpdateRequest updates) {
+        _manager.updatePermissions(id, updates);
         _cacheManager.invalidateAll();
     }
 
     @Override
-    public void revokeAllForRole(String role) {
-        _manager.revokeAllForRole(role);
+    public void revokePermissions(String id) {
+        _manager.revokePermissions(id);
         _cacheManager.invalidateAll();
     }
 

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/DeferringPermissionManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/DeferringPermissionManager.java
@@ -18,39 +18,39 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class DeferringPermissionManager implements PermissionManager {
 
     private final PermissionManager _manager;
-    private final Map<String, Set<Permission>> _rolePermissions;
+    private final Map<String, Set<Permission>> _permissions;
 
-    public DeferringPermissionManager(PermissionManager manager, @Nullable Map<String, Set<Permission>> rolePermissions) {
+    public DeferringPermissionManager(PermissionManager manager, @Nullable Map<String, Set<Permission>> permissions) {
         _manager = checkNotNull(manager, "manager");
-        _rolePermissions = rolePermissions != null ? ImmutableMap.copyOf(rolePermissions) : ImmutableMap.<String, Set<Permission>>of();
+        _permissions = permissions != null ? ImmutableMap.copyOf(permissions) : ImmutableMap.<String, Set<Permission>>of();
     }
 
     @Override
-    public Set<Permission> getAllForRole(String role) {
-        checkNotNull(role, "role");
-        Set<Permission> permissions = _rolePermissions.get(role);
+    public Set<Permission> getPermissions(String id) {
+        checkNotNull(id, "id");
+        Set<Permission> permissions = _permissions.get(id);
         if (permissions == null) {
-            permissions = _manager.getAllForRole(role);
+            permissions = _manager.getPermissions(id);
         }
         return permissions;
     }
 
     @Override
-    public void updateForRole(String role, PermissionUpdateRequest updates) {
-        checkArgument(!_rolePermissions.containsKey(role), "Cannot update permissions for static role: %s", role);
-        _manager.updateForRole(role, updates);
+    public void updatePermissions(String id, PermissionUpdateRequest updates) {
+        checkArgument(!_permissions.containsKey(id), "Cannot update permissions for static id: %s", id);
+        _manager.updatePermissions(id, updates);
     }
 
     @Override
-    public void revokeAllForRole(String role) {
-        checkArgument(!_rolePermissions.containsKey(role), "Cannot revoke all permissions for static role: %s", role);
-        _manager.revokeAllForRole(role);
+    public void revokePermissions(String id) {
+        checkArgument(!_permissions.containsKey(id), "Cannot revoke permissions for static id: %s", id);
+        _manager.revokePermissions(id);
     }
 
     @Override
     public Iterable<Map.Entry<String, Set<Permission>>> getAll() {
         return Iterables.concat(
-                _rolePermissions.entrySet(),
+                _permissions.entrySet(),
                 _manager.getAll());
     }
 

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/TablePermissionManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/TablePermissionManager.java
@@ -17,6 +17,7 @@ import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.permission.InvalidPermissionStringException;
 import org.apache.shiro.authz.permission.PermissionResolver;
 
+import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -73,29 +74,48 @@ public class TablePermissionManager implements PermissionManager {
         checkNotNull(request, "request");
         validateTable();
 
+        Delta delta = createDelta(request);
+        if (delta == null) {
+            // Request did not change the permissions at all.  Take no action.
+            return;
+        }
+
         _dataStore.update(
                 _tableName,
                 id,
                 TimeUUIDs.newUUID(),
-                createDelta(request),
+                delta,
                 new AuditBuilder().setLocalHost().setComment("update permissions").build(),
                 WriteConsistency.GLOBAL);
     }
 
+    /**
+     * Returns a delta constructed from this request, or null if the request contained no changes.
+     */
+    @Nullable
     private Delta createDelta(PermissionUpdateRequest request) {
         MapDeltaBuilder builder = Deltas.mapBuilder();
+        boolean modified = false;
 
         for (String permissionString : request.getPermitted()) {
             builder.put("perm_" + validated(permissionString), 1);
+            modified = true;
         }
         for (String permissionString : request.getRevoked()) {
             builder.remove("perm_" + validated(permissionString));
+            modified = true;
         }
         if (request.isRevokeRest()) {
             builder.removeRest();
+            modified = true;
         }
 
-        return builder.build();
+        if (modified) {
+            return builder.build();
+        }
+
+        // Request contained no changes
+        return null;
     }
 
     /**

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/TablePermissionManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/TablePermissionManager.java
@@ -87,7 +87,7 @@ public class TablePermissionManager implements PermissionManager {
                 TimeUUIDs.newUUID(),
                 createDelta(request),
                 new AuditBuilder().setLocalHost().setComment("update permissions").build(),
-                WriteConsistency.STRONG);
+                WriteConsistency.GLOBAL);
     }
 
     private Delta createDelta(PermissionUpdateRequest request) {
@@ -126,7 +126,7 @@ public class TablePermissionManager implements PermissionManager {
                 TimeUUIDs.newUUID(),
                 Deltas.delete(),
                 new AuditBuilder().setLocalHost().setComment("delete permissions").build(),
-                WriteConsistency.STRONG);
+                WriteConsistency.GLOBAL);
 
     }
 

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/TablePermissionManagerDAO.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/TablePermissionManagerDAO.java
@@ -32,7 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * With a level of irony not seen since Alanis Morissette the application must have permission to perform operations
  * on the table in order to use this manager.
  */
-public class TablePermissionManager implements PermissionManager {
+public class TablePermissionManagerDAO implements PermissionManager {
 
     private final PermissionResolver _permissionResolver;
     private final DataStore _dataStore;
@@ -40,8 +40,8 @@ public class TablePermissionManager implements PermissionManager {
     private final String _placement;
     private volatile boolean _tableValidated;
 
-    public TablePermissionManager(PermissionResolver permissionResolver, DataStore dataStore,
-                                  String tableName, String placement) {
+    public TablePermissionManagerDAO(PermissionResolver permissionResolver, DataStore dataStore,
+                                     String tableName, String placement) {
         _permissionResolver = checkNotNull(permissionResolver, "permissionResolver");
         _dataStore = checkNotNull(dataStore, "dataStore");
         _tableName = checkNotNull(tableName, "tableName");

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/DataCenterSynchronizedRoleManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/DataCenterSynchronizedRoleManager.java
@@ -1,0 +1,105 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import com.google.common.base.Throwables;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Role manager implementation which synchronizes mutative role updates in the current data center to prevent possible
+ * inconsistencies caused by concurrent updates.  To do this it uses the ZooKeeper {@link InterProcessMutex} recipe.
+ * Note that other protections are required to prevent global concurrent updates across all data centers.
+ */
+public class DataCenterSynchronizedRoleManager implements RoleManager {
+
+    private final static String LOCK_PATH = "/lock/roles";
+
+    private final RoleManager _delegate;
+    private final InterProcessMutex _mutex;
+
+    public DataCenterSynchronizedRoleManager(RoleManager delegate, CuratorFramework curator) {
+        _delegate = checkNotNull(delegate, "delegate");
+        _mutex = new InterProcessMutex(checkNotNull(curator, "curator"), LOCK_PATH);
+    }
+
+    @Override
+    public Role getRole(RoleIdentifier id) {
+        return _delegate.getRole(id);
+    }
+
+    @Override
+    public List<Role> getRolesByGroup(@Nullable String group) {
+        return _delegate.getRolesByGroup(group);
+    }
+
+    @Override
+    public Iterator<Role> getAll() {
+        return _delegate.getAll();
+    }
+
+    @Override
+    public Set<String> getPermissionsForRole(RoleIdentifier id) {
+        return _delegate.getPermissionsForRole(id);
+    }
+
+    @Override
+    public Role createRole(RoleIdentifier id, @Nullable String description, @Nullable Set<String> permissions) {
+        return inMutex(() -> _delegate.createRole(id, description, permissions));
+    }
+
+    @Override
+    public void updateRole(RoleIdentifier id, RoleUpdateRequest request) {
+        inMutex(() -> _delegate.updateRole(id, request));
+    }
+
+    @Override
+    public void deleteRole(RoleIdentifier id) {
+        inMutex(() -> _delegate.deleteRole(id));
+    }
+
+    private <T> T inMutex(Runnable runnable) {
+        return inMutex(() -> { runnable.run(); return null; });
+    }
+
+    private <T> T inMutex(Callable<T> callable) {
+        try {
+            if (!_mutex.acquire(100, TimeUnit.MILLISECONDS)) {
+                throw new TimeoutException();
+            }
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+
+        Exception exception = null;
+        T result = null;
+        try {
+            result = callable.call();
+        } catch (Exception e) {
+            exception = e;
+        } finally {
+            try {
+                _mutex.release();
+            } catch (Exception e) {
+                // If the callable raised an exception too prefer raising that one.
+                if (exception == null) {
+                    exception = e;
+                }
+            }
+        }
+
+        if (exception != null) {
+            throw Throwables.propagate(exception);
+        }
+
+        return result;
+    }
+}

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/DataCenterSynchronizedRoleManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/DataCenterSynchronizedRoleManager.java
@@ -52,8 +52,8 @@ public class DataCenterSynchronizedRoleManager implements RoleManager {
     }
 
     @Override
-    public Role createRole(RoleIdentifier id, @Nullable String description, @Nullable Set<String> permissions) {
-        return inMutex(() -> _delegate.createRole(id, description, permissions));
+    public Role createRole(RoleIdentifier id, RoleUpdateRequest request) {
+        return inMutex(() -> _delegate.createRole(id, request));
     }
 
     @Override

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/DeferringRoleManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/DeferringRoleManager.java
@@ -1,0 +1,89 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * RoleManager implementation which allows the caller to provide a static, immutable set of roles and a delegate
+ * RoleManager.  This provides the ability to have a set of reserved roles which are not persisted by the delegate.
+ */
+public class DeferringRoleManager implements RoleManager {
+
+    private final RoleManager _delegate;
+    private final Map<RoleIdentifier, Role> _rolesById;
+
+    public DeferringRoleManager(RoleManager delegate, Collection<Role> roles) {
+        _delegate = delegate;
+        _rolesById = Maps.uniqueIndex(roles, role -> new RoleIdentifier(role.getGroup(), role.getName()));
+    }
+
+    @Override
+    public Role getRole(RoleIdentifier id) {
+        checkNotNull(id, "id");
+        Role role = _rolesById.get(id);
+        if (role == null) {
+            role = _delegate.getRole(id);
+        }
+        return role;
+    }
+
+    @Override
+    public List<Role> getRolesByGroup(@Nullable String group) {
+        final List<Role> roles = Lists.newArrayList();
+        _rolesById.values().stream()
+                .filter(role -> Objects.equals(role.getGroup(), group))
+                .forEach(roles::add);
+        roles.addAll(_delegate.getRolesByGroup(group));
+        return roles;
+    }
+
+    @Override
+    public Iterator<Role> getAll() {
+        return Iterators.concat(_rolesById.values().iterator(), _delegate.getAll());
+    }
+
+    /**
+     * Although this implementation overrides specific roles the permissions associated with them are
+     * still managed by the permission manager, so always defer to the delegate to read permissions.
+     */
+    @Override
+    public Set<String> getPermissionsForRole(RoleIdentifier id) {
+        checkNotNull(id, "id");
+        return _delegate.getPermissionsForRole(id);
+    }
+
+    @Override
+    public Role createRole(RoleIdentifier id, @Nullable String description, @Nullable Set<String> permissions) {
+        checkNotNull(id, "id");
+        if (_rolesById.containsKey(id)) {
+            throw new RoleExistsException(id.getGroup(), id.getName());
+        }
+        return _delegate.createRole(id, description, permissions);
+    }
+
+    @Override
+    public void updateRole(RoleIdentifier id, RoleUpdateRequest request) {
+        checkNotNull(id, "id");
+        checkArgument(!_rolesById.containsKey(id), "Cannot update role %s", id);
+        _delegate.updateRole(id, request);
+    }
+
+    @Override
+    public void deleteRole(RoleIdentifier id) {
+        checkNotNull(id, "id");
+        checkArgument(!_rolesById.containsKey(id), "Cannot delete role %s", id);
+        _delegate.deleteRole(id);
+    }
+}

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/DeferringRoleManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/DeferringRoleManager.java
@@ -65,12 +65,12 @@ public class DeferringRoleManager implements RoleManager {
     }
 
     @Override
-    public Role createRole(RoleIdentifier id, @Nullable String description, @Nullable Set<String> permissions) {
+    public Role createRole(RoleIdentifier id, RoleUpdateRequest request) {
         checkNotNull(id, "id");
         if (_rolesById.containsKey(id)) {
-            throw new RoleExistsException(id.getGroup(), id.getName());
+            throw new RoleExistsException(id.getGroup(), id.getId());
         }
-        return _delegate.createRole(id, description, permissions);
+        return _delegate.createRole(id, request);
     }
 
     @Override

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/TableRoleManager.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/TableRoleManager.java
@@ -1,0 +1,269 @@
+package com.bazaarvoice.emodb.auth.role;
+
+import com.bazaarvoice.emodb.auth.permissions.PermissionIDs;
+import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.Coordinate;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.api.ReadConsistency;
+import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
+
+import javax.annotation.Nullable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Spliterators;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static com.bazaarvoice.emodb.common.api.Names.isLegalRoleName;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * RoleManager implementation which persists roles using tables in a {@link DataStore}.
+ */
+public class TableRoleManager implements RoleManager {
+
+    // Even roles with no group belong to a group, the catch-all "no group".  The name for this group is reserved
+    // and cannot be explicitly used by the API.
+    private static final String NO_GROUP_NAME = "_";
+
+    private final static String DESCRIPTION_ATTR = "description";
+    private final static String NAMES_ATTR = "names";
+
+    private final DataStore _dataStore;
+    // DataStore table which maps role IDs to roles
+    private final String _roleTableName;
+    // DataStore table which maps groups to role names.  Basically serves as an index to read all roles by group.
+    private final String _groupTableName;
+    private final String _placement;
+    private final PermissionManager _permissionManager;
+    private volatile boolean _tablesValidated;
+
+    public TableRoleManager(DataStore dataStore, String roleTableName, String groupTableName, String placement,
+                            PermissionManager permissionManager) {
+        _dataStore = checkNotNull(dataStore, "dataStore");
+        _roleTableName = checkNotNull(roleTableName, "roleTableName");
+        _groupTableName = checkNotNull(groupTableName, "groupTableName");
+        checkArgument(!roleTableName.equals(groupTableName), "Role and group tables must be unique");
+        _placement = checkNotNull(placement, "placement");
+        _permissionManager = checkNotNull(permissionManager, "permissionManager");
+    }
+
+    private String checkGroup(@Nullable String group) {
+        // Role groups follow the same naming conventions as role names
+        checkArgument(group == null || isLegalRoleName(group), "Group cannot be named %s", group);
+        // Since legal role names cannot begin with a "_" if the previous check passed then there cannot be a conflict
+        return group == null ? NO_GROUP_NAME : group;
+    }
+
+    @Override
+    public Role getRole(RoleIdentifier id) {
+        checkNotNull(id, "id");
+        checkGroup(id.getGroup());
+        validateTables();
+
+        Map<String, Object> record = _dataStore.get(_roleTableName, id.toString(), ReadConsistency.STRONG);
+        return convertRecordToRole(record);
+    }
+
+    private Role convertRecordToRole(Map<String, Object> record) {
+        if (Intrinsic.isDeleted(record)) {
+            return null;
+        }
+        RoleIdentifier id = RoleIdentifier.fromString(Intrinsic.getId(record));
+        return new Role(id.getGroup(), id.getName(), (String) record.get(DESCRIPTION_ATTR));
+    }
+
+    @Override
+    public List<Role> getRolesByGroup(@Nullable String group) {
+        String groupKey = checkGroup(group);
+        List<Role> roles = null;
+        validateTables();
+
+        Map<String, Object> record = _dataStore.get(_groupTableName, groupKey);
+        if (!Intrinsic.isDeleted(record)) {
+            //noinspection unchecked
+            List<String> names = (List<String>) record.get(NAMES_ATTR);
+            if (names != null && !names.isEmpty()) {
+                List<Coordinate> coordinates = names.stream()
+                        .map(name -> Coordinate.of(_roleTableName, new RoleIdentifier(group, name).toString()))
+                        .collect(Collectors.toList());
+
+                Iterator<Map<String, Object>> records = _dataStore.multiGet(coordinates, ReadConsistency.STRONG);
+
+                roles = StreamSupport.stream(Spliterators.spliteratorUnknownSize(records, 0), false)
+                        .map(this::convertRecordToRole)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+            }
+        }
+
+        return roles != null ? roles : ImmutableList.of();
+    }
+
+    @Override
+    public Iterator<Role> getAll() {
+        validateTables();
+
+        Iterator<Map<String, Object>> records = _dataStore.scan(_roleTableName, null, Integer.MAX_VALUE, ReadConsistency.STRONG);
+
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(records, 0), false)
+                .map(this::convertRecordToRole)
+                .iterator();
+    }
+
+    @Override
+    public Set<String> getPermissionsForRole(RoleIdentifier id) {
+        checkNotNull(id, "id");
+        return ImmutableSortedSet.copyOf(
+                _permissionManager.getPermissions(PermissionIDs.forRole(id))
+                        .stream()
+                        .map(Objects::toString)
+                        .iterator());
+    }
+
+    @Override
+    public Role createRole(RoleIdentifier id, @Nullable String description, @Nullable Set<String> permissions) {
+        checkNotNull(id, "id");
+        checkArgument(isLegalRoleName(id.getName()), "Role cannot be named %s", id.getName());
+        String groupKey = checkGroup(id.getGroup());
+
+        // First ensure that there is no conflicting role with the same name and group.
+        Role existingRole = getRole(id);
+        if (existingRole != null) {
+            throw new RoleExistsException(id.getGroup(), id.getName());
+        }
+        
+        // Without transactions it is not possible to ensure the role, group, and permissions are written without
+        // failing independently.  Write the group entry first followed by the role.  This way if there is a failure
+        // there won't be a dangling role with no group and the logic for role groups can tolerate missing references,
+        // although actual cleanup of the missing reference would need to be performed manually.  Persist
+        // permissions lastly since a failure at that point is most easily recoverable though other API calls.
+
+        UUID changeId = TimeUUIDs.newUUID();
+
+        _dataStore.update(_groupTableName, groupKey, changeId,
+                Deltas.mapBuilder()
+                        .update(NAMES_ATTR, Deltas.setBuilder()
+                                .add(id.getName())
+                                .build())
+                        .build(),
+                new AuditBuilder().setLocalHost().setComment("Create role " + id).build(),
+                WriteConsistency.GLOBAL);
+
+        _dataStore.update(_roleTableName, id.toString(), changeId,
+                Deltas.mapBuilder()
+                        .put(DESCRIPTION_ATTR, description)
+                        .build(),
+                new AuditBuilder().setLocalHost().setComment("Create role " + id).build(),
+                WriteConsistency.GLOBAL);
+
+        if (permissions != null && !permissions.isEmpty()) {
+            _permissionManager.updatePermissions(PermissionIDs.forRole(id),
+                    new PermissionUpdateRequest().permit(permissions));
+        }
+
+        return new Role(id.getGroup(), id.getName(), description);
+    }
+
+    @Override
+    public void updateRole(RoleIdentifier id, RoleUpdateRequest request) {
+        // First, verify the role exists
+        Role role = getRole(id);
+        if (role == null) {
+            throw new RoleNotFoundException(id.getGroup(), id.getName());
+        }
+
+        // As with creating a role, updating role metadata and permissions cannot be performed atomically.  Update
+        // role metadata first since a failure at that point poses the least security risk.
+        
+        if (request.isDescriptionPresent()) {
+            _dataStore.update(_roleTableName, id.toString(), TimeUUIDs.newUUID(),
+                    Deltas.mapBuilder()
+                            .put(DESCRIPTION_ATTR, request.getDescription())
+                            .build(),
+                    new AuditBuilder().setLocalHost().setComment("Update role " + id).build(),
+                    WriteConsistency.GLOBAL);
+        }
+
+        if (request.getPermissionUpdate() != null) {
+            _permissionManager.updatePermissions(PermissionIDs.forRole(id), request.getPermissionUpdate());
+        }
+    }
+
+    @Override
+    public void deleteRole(RoleIdentifier id) {
+        // First, verify the role exists
+        Role role = getRole(id);
+        if (role == null) {
+            // Role doesn't exist.  Don't raise an exception, just return now since there is no work to be done.
+            return;
+        }
+
+        // Start by revoking all permissions.  Even if the subsequent steps fail any users with this role won't have
+        // any permissions from it once this step completes.
+        _permissionManager.revokePermissions(PermissionIDs.forRole(id));
+
+        // As the inverse for creating roles the role is deleted before the group.
+        UUID changeId = TimeUUIDs.newUUID();
+        String groupKey = checkGroup(role.getGroup());
+        
+        _dataStore.update(_roleTableName, id.toString(), changeId,
+                Deltas.delete(),
+                new AuditBuilder().setLocalHost().setComment("Delete role " + id).build(),
+                WriteConsistency.GLOBAL);
+
+        _dataStore.update(_groupTableName, groupKey, changeId,
+                Deltas.mapBuilder()
+                        .update(NAMES_ATTR, Deltas.setBuilder()
+                                .remove(role.getName())
+                                .deleteIfEmpty()
+                                .build())
+                        .deleteIfEmpty()
+                        .build(),
+                new AuditBuilder().setLocalHost().setComment("Delete role " + id).build(),
+                WriteConsistency.GLOBAL);
+    }
+
+    /**
+     * Lazy initial verification to ensure the role and group tables exist.
+     */
+    private void validateTables() {
+        if (_tablesValidated) {
+            return;
+        }
+
+        synchronized(this) {
+            if (!_dataStore.getTableExists(_roleTableName)) {
+                _dataStore.createTable(
+                        _roleTableName,
+                        new TableOptionsBuilder().setPlacement(_placement).build(),
+                        ImmutableMap.<String, Object>of(),
+                        new AuditBuilder().setLocalHost().setComment("create role table").build());
+            }
+
+            if (!_dataStore.getTableExists(_groupTableName)) {
+                _dataStore.createTable(
+                        _groupTableName,
+                        new TableOptionsBuilder().setPlacement(_placement).build(),
+                        ImmutableMap.<String, Object>of(),
+                        new AuditBuilder().setLocalHost().setComment("create role group table").build());
+            }
+
+            _tablesValidated = true;
+        }
+    }
+}

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/TableRoleManagerDAO.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/TableRoleManagerDAO.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static com.bazaarvoice.emodb.common.api.Names.isLegalRoleGroupName;
 import static com.bazaarvoice.emodb.common.api.Names.isLegalRoleName;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -35,7 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * RoleManager implementation which persists roles using tables in a {@link DataStore}.
  */
-public class TableRoleManager implements RoleManager {
+public class TableRoleManagerDAO implements RoleManager {
 
     // Even roles with no group belong to a group, the catch-all "no group".  The name for this group is reserved
     // and cannot be explicitly used by the API.
@@ -54,8 +55,8 @@ public class TableRoleManager implements RoleManager {
     private final PermissionManager _permissionManager;
     private volatile boolean _tablesValidated;
 
-    public TableRoleManager(DataStore dataStore, String roleTableName, String groupTableName, String placement,
-                            PermissionManager permissionManager) {
+    public TableRoleManagerDAO(DataStore dataStore, String roleTableName, String groupTableName, String placement,
+                               PermissionManager permissionManager) {
         _dataStore = checkNotNull(dataStore, "dataStore");
         _roleTableName = checkNotNull(roleTableName, "roleTableName");
         _groupTableName = checkNotNull(groupTableName, "groupTableName");
@@ -66,8 +67,8 @@ public class TableRoleManager implements RoleManager {
 
     private String checkGroup(@Nullable String group) {
         // Role groups follow the same naming conventions as role names
-        checkArgument(group == null || isLegalRoleName(group), "Group cannot be named %s", group);
-        // Since legal role names cannot begin with a "_" if the previous check passed then there cannot be a conflict
+        checkArgument(group == null || isLegalRoleGroupName(group), "Group cannot be named %s", group);
+        // Since legal role names cannot equal "_" if the previous check passed then there cannot be a conflict
         return group == null ? NO_GROUP_NAME : group;
     }
 

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/TableRoleManagerDAO.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/TableRoleManagerDAO.java
@@ -68,7 +68,7 @@ public class TableRoleManagerDAO implements RoleManager {
     private String checkGroup(@Nullable String group) {
         // Role groups follow the same naming conventions as role names
         checkArgument(group == null || isLegalRoleGroupName(group), "Group cannot be named %s", group);
-        // Since legal role names cannot equal "_" if the previous check passed then there cannot be a conflict
+        // Since legal role group names cannot equal "_" if the previous check passed then there cannot be a conflict
         return group == null ? NO_GROUP_NAME : group;
     }
 

--- a/auth/auth-test/src/test/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyRealmTest.java
+++ b/auth/auth-test/src/test/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyRealmTest.java
@@ -4,6 +4,7 @@ import com.bazaarvoice.emodb.auth.identity.AuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.CacheManagingAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.MatchingPermissionResolver;
+import com.bazaarvoice.emodb.auth.permissions.PermissionIDs;
 import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
 import com.bazaarvoice.emodb.auth.shiro.GuavaCacheManager;
 import com.bazaarvoice.emodb.auth.shiro.InvalidatableCacheManager;
@@ -62,23 +63,23 @@ public class ApiKeyRealmTest {
                 _cacheManager, _authIdentityManager, _permissionManager, null);
         LifecycleUtils.init(_underTest);
 
-//        _permissionCaching.updateForRole("othertestrole", new PermissionUpdateRequest().permit("city|get|Austin", "country|get|USA"));
+//        _permissionCaching.updatePermissions("othertestrole", new PermissionUpdateRequest().permit("city|get|Austin", "country|get|USA"));
 
     }
 
 //    @Test
 //    public void simpleNull() {
 //        assertNotNull(_underTest.getAvailableRolesCache(), "precondition: there is a cache");
-//        when(_permissionManager.getAllForRole("role")).thenReturn(null);
-//        Collection<Permission> resultPerms = _underTest.getPermissions("role");
+//        when(_permissionReader.getPermissions(PermissionIDs.forRole("role"))).thenReturn(null);
+//        Collection<Permission> resultPerms = _underTest.getRolePermissions("role");
 //        assertNull(resultPerms, "should be no permissions yet");
 //    }
 //
     @Test
     public void simpleEmpty() {
         assertNotNull(_underTest.getAvailableRolesCache(), "precondition: there is a cache");
-        when(_permissionManager.getAllForRole("role")).thenReturn(Sets.<Permission>newHashSet());
-        Collection<Permission> resultPerms = _underTest.getPermissions("role");
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role"))).thenReturn(Sets.<Permission>newHashSet());
+        Collection<Permission> resultPerms = _underTest.getRolePermissions("role");
         assertTrue(resultPerms.isEmpty(), "should be no permissions yet");
     }
 
@@ -87,8 +88,8 @@ public class ApiKeyRealmTest {
         Cache<String, RolePermissionSet> cache = _underTest.getAvailableRolesCache();
         assertEquals(cache.size(), 0, "precondition: cache is empty");
         Permission p1 = mock(Permission.class);
-        when(_permissionManager.getAllForRole("role")).thenReturn(Sets.newHashSet(p1));
-        Collection<Permission> resultPerms = _underTest.getPermissions("role");
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role"))).thenReturn(Sets.newHashSet(p1));
+        Collection<Permission> resultPerms = _underTest.getRolePermissions("role");
         assertNotNull(resultPerms.iterator().next(), "should have a permission");
         assertEquals(cache.size(), 1, "side effect: cache has an element");
     }
@@ -99,18 +100,18 @@ public class ApiKeyRealmTest {
         assertEquals(cache.size(), 0, "precondition: cache is empty");
         Permission p1 = mock(Permission.class);
         when(p1.toString()).thenReturn("p1");
-        when(_permissionManager.getAllForRole("role")).thenReturn(Sets.newHashSet(p1));
-        Collection<Permission> resultPerms = _underTest.getPermissions("role");
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role"))).thenReturn(Sets.newHashSet(p1));
+        Collection<Permission> resultPerms = _underTest.getRolePermissions("role");
         assertEquals(resultPerms.iterator().next(), p1, "should have the first permission we added");
         assertEquals(cache.size(), 1, "side effect: cache has one element");
         Permission p2 = mock(Permission.class);
         when(p2.toString()).thenReturn("p2");
-        when(_permissionManager.getAllForRole("role")).thenReturn(Sets.newHashSet(p2));
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role"))).thenReturn(Sets.newHashSet(p2));
         cache.clear();
-        Collection<Permission> resultPerms2 = _underTest.getPermissions("role");
+        Collection<Permission> resultPerms2 = _underTest.getRolePermissions("role");
         assertEquals(resultPerms2.iterator().next(), p2, "should have the second permission we added");
         assertEquals(cache.size(), 1, "side effect: cache still has one element");
-        resultPerms2 = _underTest.getPermissions("role");
+        resultPerms2 = _underTest.getRolePermissions("role");
         assertEquals(resultPerms2.iterator().next(), p2, "should still have the second permission we added");
         assertEquals(cache.size(), 1, "side effect: cache still has one element");
     }
@@ -121,13 +122,13 @@ public class ApiKeyRealmTest {
 //        assertEquals(cache.size(), 0, "precondition: cache is empty");
 //        Permission p1 = mock(Permission.class);
 //        when(p1.toString()).thenReturn("p1");
-//        when(_permissionManager.getAllForRole("role")).thenReturn(Sets.<Permission>newHashSet(p1));
-//        Collection<Permission> resultPerms = _underTest.getPermissions("role");
+//        when(_permissionReader.getRolePermissions("role")).thenReturn(Sets.<Permission>newHashSet(p1));
+//        Collection<Permission> resultPerms = _underTest.getRolePermissions("role");
 //        assertEquals(resultPerms.iterator().next(), p1, "should have the first permission we added");
 //        assertEquals(cache.size(), 1, "side effect: cache has one element");
-//        when(_permissionManager.getAllForRole("role")).thenReturn(null);
+//        when(_permissionReader.getRolePermissions("role")).thenReturn(null);
 //        cache.clear();
-//        resultPerms = _underTest.getPermissions("role");
+//        resultPerms = _underTest.getRolePermissions("role");
 //        assertNull(resultPerms, "now should have null");
 //        assertEquals(cache.size(), 0, "side effect: cache has nothing");
 //    }
@@ -138,13 +139,13 @@ public class ApiKeyRealmTest {
         assertEquals(cache.size(), 0, "precondition: cache is empty");
         Permission p1 = mock(Permission.class);
         when(p1.toString()).thenReturn("p1");
-        when(_permissionManager.getAllForRole("role")).thenReturn(Sets.newHashSet(p1));
-        Collection<Permission> resultPerms = _underTest.getPermissions("role");
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role"))).thenReturn(Sets.newHashSet(p1));
+        Collection<Permission> resultPerms = _underTest.getRolePermissions("role");
         assertEquals(resultPerms.iterator().next(), p1, "should have the first permission we added");
         assertEquals(cache.size(), 1, "side effect: cache has one element");
-        when(_permissionManager.getAllForRole("role")).thenReturn(Sets.<Permission>newHashSet());
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role"))).thenReturn(Sets.<Permission>newHashSet());
         cache.clear();
-        resultPerms = _underTest.getPermissions("role");
+        resultPerms = _underTest.getRolePermissions("role");
         assertTrue(resultPerms.isEmpty(), "now should have empty");
         assertEquals(cache.size(), 1, "side effect: cache has empty permission");
     }
@@ -157,11 +158,11 @@ public class ApiKeyRealmTest {
         when(p1.toString()).thenReturn("p1");
         Permission p2 = mock(Permission.class);
         when(p2.toString()).thenReturn("p2");
-        when(_permissionManager.getAllForRole("role")).thenReturn(Sets.newHashSet(p1), Sets.newHashSet(p2));
-        Collection<Permission> resultPerms = _underTest.getPermissions("role");
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role"))).thenReturn(Sets.newHashSet(p1), Sets.newHashSet(p2));
+        Collection<Permission> resultPerms = _underTest.getRolePermissions("role");
         assertEquals(resultPerms.iterator().next(), p1, "should have the first permission we added");
         assertEquals(cache.size(), 1, "side effect: cache has one element");
-        resultPerms = _underTest.getPermissions("role");
+        resultPerms = _underTest.getRolePermissions("role");
         assertEquals(resultPerms.iterator().next(), p2, "should have the last permission we added");
         assertEquals(cache.size(), 1, "side effect: cache has one element");
     }
@@ -174,14 +175,14 @@ public class ApiKeyRealmTest {
         when(p1.toString()).thenReturn("p1");
         Permission p2 = mock(Permission.class);
         when(p2.toString()).thenReturn("p2");
-        when(_permissionManager.getAllForRole("role"))
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role")))
                 .thenReturn(Sets.newHashSet(p1))
                 .thenReturn(Sets.newHashSet(p2));
-        Collection<Permission> resultPerms = _underTest.getPermissions("role");
+        Collection<Permission> resultPerms = _underTest.getRolePermissions("role");
         assertEquals(resultPerms.iterator().next(), p1, "should have the last permission we added");
         assertEquals(cache.size(), 1, "side effect: cache has one element");
         cache.clear();
-        resultPerms = _underTest.getPermissions("role");
+        resultPerms = _underTest.getRolePermissions("role");
         assertEquals(resultPerms.iterator().next(), p2, "should again have the last permission we added");
         assertEquals(cache.size(), 1, "side effect: cache again has one element");
     }
@@ -194,7 +195,7 @@ public class ApiKeyRealmTest {
         when(p1.toString()).thenReturn("p1");
         final Permission p2 = mock(Permission.class);
         when(p2.toString()).thenReturn("p2");
-        when(_permissionManager.getAllForRole("role"))
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role")))
                 .thenReturn(Sets.newHashSet(p1))
                 .thenAnswer(new Answer<Set<Permission>>() {
                     @Override
@@ -204,11 +205,11 @@ public class ApiKeyRealmTest {
                     }
                 })
                 .thenReturn(Sets.newHashSet(p2));
-        Permission resultPerm = _underTest.getPermissions("role").iterator().next();
+        Permission resultPerm = _underTest.getRolePermissions("role").iterator().next();
         assertEquals(resultPerm, p1, "should have permission p1");
-        resultPerm = _underTest.getPermissions("role").iterator().next();
+        resultPerm = _underTest.getRolePermissions("role").iterator().next();
         assertEquals(resultPerm, p2, "should have permission p2");
-        resultPerm = _underTest.getPermissions("role").iterator().next();
+        resultPerm = _underTest.getRolePermissions("role").iterator().next();
         assertEquals(resultPerm, p2, "should have permission p2");
         assertNotNull(cache.get("role"), "Cached value for role should have been present");
         assertEquals(cache.get("role").permissions(), ImmutableSet.of(p2), "Cached values incorrect");
@@ -223,7 +224,7 @@ public class ApiKeyRealmTest {
         Permission negativePermission = mock(Permission.class);
         when(rolePermission.implies(positivePermission)).thenReturn(true);
         when(rolePermission.implies(not(eq(positivePermission)))).thenReturn(false);
-        when(_permissionManager.getAllForRole("role0")).thenReturn(ImmutableSet.of(rolePermission));
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role0"))).thenReturn(ImmutableSet.of(rolePermission));
 
         // Verify the internal ID is not cached
         assertNull(_underTest.getInternalAuthorizationCache().get("id0"));
@@ -249,7 +250,7 @@ public class ApiKeyRealmTest {
         Permission positivePermission = mock(Permission.class);
         when(rolePermission.implies(positivePermission)).thenReturn(true);
         when(rolePermission.implies(not(eq(positivePermission)))).thenReturn(false);
-        when(_permissionManager.getAllForRole("role0")).thenReturn(ImmutableSet.of(rolePermission));
+        when(_permissionManager.getPermissions(PermissionIDs.forRole("role0"))).thenReturn(ImmutableSet.of(rolePermission));
 
         // Verify permission is granted using the API key
         PrincipalCollection principals = _underTest.getAuthenticationInfo(new ApiKeyAuthenticationToken("apikey0")).getPrincipals();

--- a/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
@@ -14,6 +14,14 @@ public abstract class Names {
                     .or(CharMatcher.anyOf("-.:_"))
                     .precomputed();
 
+    // Exclude whitespace, control chars, non-ascii, most punctuation.
+    private static final CharMatcher ROLE_NAME_ALLOWED =
+            CharMatcher.inRange('a', 'z')
+                    .or(CharMatcher.inRange('A', 'Z'))
+                    .or(CharMatcher.inRange('0', '9'))
+                    .or(CharMatcher.anyOf("-.:_"))
+                    .precomputed();
+
     /**
      * Table names must be lowercase ASCII strings. between 1 and 255 characters in length.  Whitespace, ISO control
      * characters and certain punctuation characters that aren't generally allowed in file names or in elasticsearch
@@ -27,5 +35,17 @@ public abstract class Names {
                 !(table.charAt(0) == '_' && !table.startsWith("__")) &&
                 !(table.charAt(0) == '.' && (".".equals(table) || "..".equals(table))) &&
                 TABLE_NAME_ALLOWED.matchesAllOf(table);
+    }
+
+    /**
+     * Role names mostly follow the same conventions as table names except, since they are only used internally, are
+     * slightly more permissive, such as allowing capital letters.  Although "_" is a valid part of a role name it
+     * can't be used as the first character.
+     */
+    public static boolean isLegalRoleName(String role) {
+        return role != null &&
+                role.length() > 0 && role.length() <= 255 &&
+                !role.startsWith("_") &&
+                ROLE_NAME_ALLOWED.matchesAllOf(role);
     }
 }

--- a/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
@@ -39,13 +39,20 @@ public abstract class Names {
 
     /**
      * Role names mostly follow the same conventions as table names except, since they are only used internally, are
-     * slightly more permissive, such as allowing capital letters.  Although "_" is a valid part of a role name it
-     * can't be used as the first character.
+     * slightly more permissive, such as allowing capital letters.
      */
     public static boolean isLegalRoleName(String role) {
         return role != null &&
                 role.length() > 0 && role.length() <= 255 &&
-                !role.startsWith("_") &&
                 ROLE_NAME_ALLOWED.matchesAllOf(role);
+    }
+
+    /**
+     * Role group names mostly follow the same conventions as role names.  The only difference is that the role group
+     * "_" is a reserved null-substitution for the absence of a group.
+     */
+    public static boolean isLegalRoleGroupName(String group) {
+        return isLegalRoleName(group) &&
+                !"_".equals(group);
     }
 }

--- a/quality/integration/src/test/java/com/bazaarvoice/emodb/test/ResourceTest.java
+++ b/quality/integration/src/test/java/com/bazaarvoice/emodb/test/ResourceTest.java
@@ -6,9 +6,11 @@ import com.bazaarvoice.emodb.auth.identity.AuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
 import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
 import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
 import com.bazaarvoice.emodb.auth.role.RoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleUpdateRequest;
 import com.bazaarvoice.emodb.auth.test.ResourceTestAuthUtil;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.sor.api.DataStore;
@@ -25,9 +27,11 @@ import com.sun.jersey.spi.container.ResourceFilterFactory;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import test.integration.databus.DatabusJerseyTest;
 
+import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Set;
 import java.util.TimeZone;
 
 import static org.mockito.Mockito.mock;
@@ -49,7 +53,7 @@ public abstract class ResourceTest {
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         RoleManager roleManager = new InMemoryRoleManager(permissionManager);
 
-        roleManager.createRole(new RoleIdentifier(null,typeName + "-role"), null, ImmutableSet.of(typeName + "|*|*"));
+        createRole(roleManager, null,typeName + "-role", ImmutableSet.of(typeName + "|*|*"));
 
         return setupResourceTestRule(resourceList, filters, authIdentityManager, permissionManager);
     }
@@ -110,5 +114,15 @@ public abstract class ResourceTest {
         resourceTestRule.getObjectMapper().setDateFormat(fmt);
 
         return resourceTestRule;
+    }
+
+    /**
+     * Convenience method to create a role with permissions.  It only delegates to a single method call, but that call
+     * is complex enough and creating roles is done with sufficient frequency that this method is beneficial to
+     * maintain readability.
+     */
+    protected static void createRole(RoleManager roleManager, @Nullable String group, String id,Set<String> permissions) {
+        roleManager.createRole(new RoleIdentifier(group, id),
+                new RoleUpdateRequest().withPermissionUpdate(new PermissionUpdateRequest().permit(permissions)));
     }
 }

--- a/quality/integration/src/test/java/com/bazaarvoice/emodb/test/ResourceTest.java
+++ b/quality/integration/src/test/java/com/bazaarvoice/emodb/test/ResourceTest.java
@@ -53,7 +53,7 @@ public abstract class ResourceTest {
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         RoleManager roleManager = new InMemoryRoleManager(permissionManager);
 
-        createRole(roleManager, null,typeName + "-role", ImmutableSet.of(typeName + "|*|*"));
+        createRole(roleManager, null, typeName + "-role", ImmutableSet.of(typeName + "|*|*"));
 
         return setupResourceTestRule(resourceList, filters, authIdentityManager, permissionManager);
     }

--- a/quality/integration/src/test/java/test/integration/auth/ApiKeyAdminTaskTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/ApiKeyAdminTaskTest.java
@@ -7,6 +7,8 @@ import com.bazaarvoice.emodb.auth.apikey.ApiKeySecurityManager;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
 import com.bazaarvoice.emodb.sor.api.DataStore;
@@ -35,17 +37,18 @@ public class ApiKeyAdminTaskTest {
 
     private ApiKeyAdminTask _task;
     private InMemoryAuthIdentityManager<ApiKey> _authIdentityManager;
-    private InMemoryPermissionManager _permissionManager;
 
     @BeforeMethod
     public void setUp() {
         _authIdentityManager = new InMemoryAuthIdentityManager<>();
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(mock(DataStore.class), mock(BlobStore.class));
-        _permissionManager = new InMemoryPermissionManager(permissionResolver);
+        InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
+        InMemoryRoleManager roleManager = new InMemoryRoleManager(permissionManager);
 
-        _permissionManager.updateForRole(DefaultRoles.admin.toString(), new PermissionUpdateRequest().permit(Permissions.manageApiKeys()));
+        roleManager.createRole(new RoleIdentifier(null, DefaultRoles.admin.toString()), null, ImmutableSet.of(Permissions.manageApiKeys()));
+
         ApiKeySecurityManager securityManager = new ApiKeySecurityManager(
-                new ApiKeyRealm("test", new MemoryConstrainedCacheManager(), _authIdentityManager, _permissionManager,
+                new ApiKeyRealm("test", new MemoryConstrainedCacheManager(), _authIdentityManager, permissionManager,
                         null));
 
         _task = new ApiKeyAdminTask(securityManager, mock(TaskRegistry.class), _authIdentityManager,

--- a/quality/integration/src/test/java/test/integration/auth/ApiKeyAdminTaskTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/ApiKeyAdminTaskTest.java
@@ -9,6 +9,7 @@ import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
 import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
 import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+import com.bazaarvoice.emodb.auth.role.RoleUpdateRequest;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
 import com.bazaarvoice.emodb.sor.api.DataStore;
@@ -45,7 +46,8 @@ public class ApiKeyAdminTaskTest {
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         InMemoryRoleManager roleManager = new InMemoryRoleManager(permissionManager);
 
-        roleManager.createRole(new RoleIdentifier(null, DefaultRoles.admin.toString()), null, ImmutableSet.of(Permissions.manageApiKeys()));
+        roleManager.createRole(new RoleIdentifier(null, DefaultRoles.admin.toString()),
+                new RoleUpdateRequest().withPermissionUpdate(new PermissionUpdateRequest().permit(ImmutableSet.of(Permissions.manageApiKeys()))));
 
         ApiKeySecurityManager securityManager = new ApiKeySecurityManager(
                 new ApiKeyRealm("test", new MemoryConstrainedCacheManager(), _authIdentityManager, permissionManager,

--- a/quality/integration/src/test/java/test/integration/auth/RebuildMissingRolesTaskTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/RebuildMissingRolesTaskTest.java
@@ -1,0 +1,58 @@
+package test.integration.auth;
+
+import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+import com.bazaarvoice.emodb.auth.role.RoleManager;
+import com.bazaarvoice.emodb.blob.api.BlobStore;
+import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
+import com.bazaarvoice.emodb.web.auth.RebuildMissingRolesTask;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.shiro.authz.permission.PermissionResolver;
+import org.testng.annotations.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+public class RebuildMissingRolesTaskTest {
+
+    @Test
+    public void testTask() throws Exception {
+        PermissionResolver permissionResolver = new EmoPermissionResolver(mock(DataStore.class), mock(BlobStore.class));
+        PermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
+        RoleManager roleManager = new InMemoryRoleManager(permissionManager);
+
+        RebuildMissingRolesTask task = new RebuildMissingRolesTask(permissionManager, roleManager, mock(TaskRegistry.class));
+
+        // Create pre-existing permissions for two roles, one with a group and one without
+        permissionManager.updatePermissions("role:role1", new PermissionUpdateRequest().permit("role1|*"));
+        permissionManager.updatePermissions("role:group2/role2", new PermissionUpdateRequest().permit("role2|*"));
+
+        // Create a role complete with permissions which should be untouched by the task
+        roleManager.createRole(new RoleIdentifier(null, "role3"), null, ImmutableSet.of("role3|*"));
+
+        // Run the task
+        StringWriter out = new StringWriter();
+        task.execute(ImmutableMultimap.of(), new PrintWriter(out));
+
+        // Verify all three roles exist with the correct permissions
+        assertEquals(roleManager.getRole(new RoleIdentifier(null, "role1")).getName(), "role1");
+        assertEquals(roleManager.getPermissionsForRole(new RoleIdentifier(null, "role1")), ImmutableSet.of("role1|*"));
+        assertEquals(roleManager.getRole(new RoleIdentifier("group2", "role2")).getName(), "role2");
+        assertEquals(roleManager.getPermissionsForRole(new RoleIdentifier("group2", "role2")), ImmutableSet.of("role2|*"));
+        assertEquals(roleManager.getRole(new RoleIdentifier(null, "role3")).getName(), "role3");
+        assertEquals(roleManager.getPermissionsForRole(new RoleIdentifier(null, "role3")), ImmutableSet.of("role3|*"));
+
+        Set<String> lines = ImmutableSet.copyOf(out.toString().split("\n"));
+        assertEquals(lines, ImmutableSet.of("Created missing role: role1", "Created missing role: group2/role2"));
+    }
+}

--- a/quality/integration/src/test/java/test/integration/auth/RebuildMissingRolesTaskTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/RebuildMissingRolesTaskTest.java
@@ -6,6 +6,7 @@ import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
 import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
 import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
 import com.bazaarvoice.emodb.auth.role.RoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleUpdateRequest;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
 import com.bazaarvoice.emodb.sor.api.DataStore;
@@ -38,7 +39,10 @@ public class RebuildMissingRolesTaskTest {
         permissionManager.updatePermissions("role:group2/role2", new PermissionUpdateRequest().permit("role2|*"));
 
         // Create a role complete with permissions which should be untouched by the task
-        roleManager.createRole(new RoleIdentifier(null, "role3"), null, ImmutableSet.of("role3|*"));
+        roleManager.createRole(new RoleIdentifier(null, "role3"),
+                new RoleUpdateRequest()
+                        .withName("role3")
+                        .withPermissionUpdate(new PermissionUpdateRequest().permit(ImmutableSet.of("role3|*"))));
 
         // Run the task
         StringWriter out = new StringWriter();

--- a/quality/integration/src/test/java/test/integration/auth/RoleAdminTaskTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/RoleAdminTaskTest.java
@@ -6,8 +6,10 @@ import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeySecurityManager;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
 import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
 import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+import com.bazaarvoice.emodb.auth.role.RoleUpdateRequest;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
 import com.bazaarvoice.emodb.sor.api.DataStore;
@@ -53,7 +55,8 @@ public class RoleAdminTaskTest {
         _roleManager = new InMemoryRoleManager(permissionManager);
 
         RoleIdentifier adminId = new RoleIdentifier(null, DefaultRoles.admin.toString());
-        _roleManager.createRole(adminId, null, ImmutableSet.of(Permissions.manageRoles()));
+        _roleManager.createRole(adminId, new RoleUpdateRequest()
+                .withPermissionUpdate(new PermissionUpdateRequest().permit(ImmutableSet.of(Permissions.manageRoles()))));
         ApiKeySecurityManager securityManager = new ApiKeySecurityManager(
                 new ApiKeyRealm("test", new MemoryConstrainedCacheManager(), _authIdentityManager, permissionManager,
                         null));
@@ -83,8 +86,9 @@ public class RoleAdminTaskTest {
     @Test
     public void testViewRole()
             throws Exception {
-        _roleManager.createRole(new RoleIdentifier(null, "view-role"), null,
-                ImmutableSet.of("queue|post|foo", "queue|poll|foo", "sor|update|test:*", "blob|update|test:*"));
+        _roleManager.createRole(new RoleIdentifier(null, "view-role"), new RoleUpdateRequest()
+                .withPermissionUpdate(new PermissionUpdateRequest().permit(
+                        ImmutableSet.of("queue|post|foo", "queue|poll|foo", "sor|update|test:*", "blob|update|test:*"))));
 
         StringWriter out = new StringWriter();
 
@@ -108,7 +112,7 @@ public class RoleAdminTaskTest {
             throws Exception {
         _task.execute(ImmutableMultimap.of(
                 ApiKeyRequest.AUTHENTICATION_PARAM, "test-admin",
-                "action", "create",
+                "action", "update",
                 "role", "new-role",
                 "permit", "sor|update|if({..,\"foo\":\"bar\"})",
                 "permit", "queue|post|*"),
@@ -127,8 +131,9 @@ public class RoleAdminTaskTest {
     @Test
     public void testUpdateRole()
             throws Exception {
-        _roleManager.createRole(new RoleIdentifier(null, "existing-role"), null,
-                ImmutableSet.of("queue|post|foo", "queue|post|bar"));
+        _roleManager.createRole(new RoleIdentifier(null, "existing-role"), new RoleUpdateRequest()
+                .withPermissionUpdate(new PermissionUpdateRequest().permit(
+                        ImmutableSet.of("queue|post|foo", "queue|post|bar"))));
 
         _task.execute(ImmutableMultimap.of(
                         ApiKeyRequest.AUTHENTICATION_PARAM, "test-admin",
@@ -148,8 +153,9 @@ public class RoleAdminTaskTest {
     @Test
     public void testDeleteRole()
             throws Exception {
-        _roleManager.createRole(new RoleIdentifier(null, "delete-role"), null,
-                ImmutableSet.of("queue|post|foo", "queue|post|bar"));
+        _roleManager.createRole(new RoleIdentifier(null, "delete-role"), new RoleUpdateRequest()
+                .withPermissionUpdate(new PermissionUpdateRequest().permit(
+                        ImmutableSet.of("queue|post|foo", "queue|post|bar"))));
 
         _task.execute(ImmutableMultimap.of(
                         ApiKeyRequest.AUTHENTICATION_PARAM, "test-admin",
@@ -193,9 +199,9 @@ public class RoleAdminTaskTest {
     @Test
     public void testCheckRole()
             throws Exception {
-
-        _roleManager.createRole(new RoleIdentifier("check-group", "check-role"), null,
-                ImmutableSet.of("sor|update|c*", "sor|update|ch*"));
+        _roleManager.createRole(new RoleIdentifier("check-group", "check-role"), new RoleUpdateRequest()
+                .withPermissionUpdate(new PermissionUpdateRequest().permit(
+                        ImmutableSet.of("sor|update|c*", "sor|update|ch*"))));
 
         Map<String, List<String>> expected = ImmutableMap.<String, List<String>> of(
                 "sor|update|check", ImmutableList.of("- sor|update|c*", "- sor|update|ch*"),

--- a/quality/integration/src/test/java/test/integration/auth/RoleAdminTaskTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/RoleAdminTaskTest.java
@@ -6,7 +6,8 @@ import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeySecurityManager;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
-import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
 import com.bazaarvoice.emodb.sor.api.DataStore;
@@ -22,7 +23,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
-import org.apache.shiro.authz.Permission;
 import org.apache.shiro.cache.MemoryConstrainedCacheManager;
 import org.apache.shiro.util.ThreadContext;
 import org.testng.annotations.AfterMethod;
@@ -37,25 +37,28 @@ import java.util.Set;
 
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.fail;
 
 public class RoleAdminTaskTest {
     private RoleAdminTask _task;
     private InMemoryAuthIdentityManager<ApiKey> _authIdentityManager;
-    private InMemoryPermissionManager _permissionManager;
+    private InMemoryRoleManager _roleManager;
 
     @BeforeMethod
     public void setUp() {
         _authIdentityManager = new InMemoryAuthIdentityManager<>();
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(mock(DataStore.class), mock(BlobStore.class));
-        _permissionManager = new InMemoryPermissionManager(permissionResolver);
+        InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
+        _roleManager = new InMemoryRoleManager(permissionManager);
 
-        _permissionManager.updateForRole(DefaultRoles.admin.toString(), new PermissionUpdateRequest().permit(Permissions.manageRoles()));
+        RoleIdentifier adminId = new RoleIdentifier(null, DefaultRoles.admin.toString());
+        _roleManager.createRole(adminId, null, ImmutableSet.of(Permissions.manageRoles()));
         ApiKeySecurityManager securityManager = new ApiKeySecurityManager(
-                new ApiKeyRealm("test", new MemoryConstrainedCacheManager(), _authIdentityManager, _permissionManager,
+                new ApiKeyRealm("test", new MemoryConstrainedCacheManager(), _authIdentityManager, permissionManager,
                         null));
 
-        _task = new RoleAdminTask(securityManager, _permissionManager, mock(TaskRegistry.class));
+        _task = new RoleAdminTask(securityManager, _roleManager, permissionManager.getPermissionResolver(), mock(TaskRegistry.class));
         _authIdentityManager.updateIdentity(new ApiKey("test-admin", "id_admin", ImmutableSet.of(DefaultRoles.admin.toString())));
     }
 
@@ -80,9 +83,8 @@ public class RoleAdminTaskTest {
     @Test
     public void testViewRole()
             throws Exception {
-        _permissionManager.updateForRole("view-role",
-                new PermissionUpdateRequest()
-                        .permit("queue|post|foo", "queue|poll|foo", "sor|update|test:*", "blob|update|test:*"));
+        _roleManager.createRole(new RoleIdentifier(null, "view-role"), null,
+                ImmutableSet.of("queue|post|foo", "queue|poll|foo", "sor|update|test:*", "blob|update|test:*"));
 
         StringWriter out = new StringWriter();
 
@@ -106,28 +108,27 @@ public class RoleAdminTaskTest {
             throws Exception {
         _task.execute(ImmutableMultimap.of(
                 ApiKeyRequest.AUTHENTICATION_PARAM, "test-admin",
-                "action", "update",
+                "action", "create",
                 "role", "new-role",
                 "permit", "sor|update|if({..,\"foo\":\"bar\"})",
                 "permit", "queue|post|*"),
                 new PrintWriter(ByteStreams.nullOutputStream()));
 
-        Set<Permission> permissions = _permissionManager.getAllForRole("new-role");
-        Set<Permission> expected = toPermissionSet(ImmutableList.of(
+        Set<String> permissions = _roleManager.getPermissionsForRole(new RoleIdentifier(null, "new-role"));
+        Set<String> expected = ImmutableSet.of(
                 Permissions.updateSorTable(
                         new ConditionResource(Conditions.mapBuilder()
                                 .contains("foo", "bar")
                                 .build())),
-                Permissions.postQueue(Permissions.ALL)));
+                Permissions.postQueue(Permissions.ALL));
         assertEquals(permissions, expected);
     }
 
     @Test
     public void testUpdateRole()
             throws Exception {
-        _permissionManager.updateForRole("existing-role",
-                new PermissionUpdateRequest()
-                        .permit("queue|post|foo", "queue|post|bar"));
+        _roleManager.createRole(new RoleIdentifier(null, "existing-role"), null,
+                ImmutableSet.of("queue|post|foo", "queue|post|bar"));
 
         _task.execute(ImmutableMultimap.of(
                         ApiKeyRequest.AUTHENTICATION_PARAM, "test-admin",
@@ -137,19 +138,18 @@ public class RoleAdminTaskTest {
                         "revoke", "queue|post|bar"),
                 new PrintWriter(ByteStreams.nullOutputStream()));
 
-        Set<Permission> permissions = _permissionManager.getAllForRole("existing-role");
-        Set<Permission> expected = toPermissionSet(ImmutableList.of(
+        Set<String> permissions = _roleManager.getPermissionsForRole(new RoleIdentifier(null, "existing-role"));
+        Set<String> expected = ImmutableSet.of(
                 Permissions.postQueue(new NamedResource("foo")),
-                Permissions.postQueue(new NamedResource("baz"))));
+                Permissions.postQueue(new NamedResource("baz")));
         assertEquals(permissions, expected);
     }
 
     @Test
     public void testDeleteRole()
             throws Exception {
-        _permissionManager.updateForRole("delete-role",
-                new PermissionUpdateRequest()
-                        .permit("queue|post|foo", "queue|post|bar"));
+        _roleManager.createRole(new RoleIdentifier(null, "delete-role"), null,
+                ImmutableSet.of("queue|post|foo", "queue|post|bar"));
 
         _task.execute(ImmutableMultimap.of(
                         ApiKeyRequest.AUTHENTICATION_PARAM, "test-admin",
@@ -157,8 +157,7 @@ public class RoleAdminTaskTest {
                         "role", "delete-role"),
                 new PrintWriter(ByteStreams.nullOutputStream()));
 
-        Set<Permission> permissions = _permissionManager.getAllForRole("delete-role");
-        assertEquals(permissions, ImmutableList.<Permission>of());
+        assertNull(_roleManager.getRole(new RoleIdentifier(null, "delete-role")));
     }
 
     @Test
@@ -195,9 +194,8 @@ public class RoleAdminTaskTest {
     public void testCheckRole()
             throws Exception {
 
-        _permissionManager.updateForRole("check-role",
-                new PermissionUpdateRequest()
-                        .permit("sor|update|c*", "sor|update|ch*"));
+        _roleManager.createRole(new RoleIdentifier("check-group", "check-role"), null,
+                ImmutableSet.of("sor|update|c*", "sor|update|ch*"));
 
         Map<String, List<String>> expected = ImmutableMap.<String, List<String>> of(
                 "sor|update|check", ImmutableList.of("- sor|update|c*", "- sor|update|ch*"),
@@ -211,6 +209,7 @@ public class RoleAdminTaskTest {
                             ApiKeyRequest.AUTHENTICATION_PARAM, "test-admin",
                             "action", "check",
                             "role", "check-role",
+                            "group", "check-group",
                             "permission", entry.getKey()),
                     new PrintWriter(out));
 
@@ -219,13 +218,5 @@ public class RoleAdminTaskTest {
             // The first line is a header; skip it and check the remaining lines
             assertEquals(actual.subList(1, actual.size()), entry.getValue());
         }
-    }
-
-    private Set<Permission> toPermissionSet(Iterable<String> permissionStrings) {
-        ImmutableSet.Builder<Permission> builder = ImmutableSet.builder();
-        for (String permissionString : permissionStrings) {
-            builder.add(_permissionManager.getPermissionResolver().resolvePermission(permissionString));
-        }
-        return builder.build();
     }
 }

--- a/quality/integration/src/test/java/test/integration/auth/TableRoleManagerDAOTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/TableRoleManagerDAOTest.java
@@ -8,7 +8,7 @@ import com.bazaarvoice.emodb.auth.role.RoleExistsException;
 import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
 import com.bazaarvoice.emodb.auth.role.RoleNotFoundException;
 import com.bazaarvoice.emodb.auth.role.RoleUpdateRequest;
-import com.bazaarvoice.emodb.auth.role.TableRoleManager;
+import com.bazaarvoice.emodb.auth.role.TableRoleManagerDAO;
 import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.api.Intrinsic;
@@ -19,7 +19,6 @@ import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
 import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -45,7 +44,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-public class TableRoleManagerTest {
+public class TableRoleManagerDAOTest {
 
     private final static String ROLE_TABLE = "roles";
     private final static String GROUP_TABLE = "groups";
@@ -56,7 +55,7 @@ public class TableRoleManagerTest {
     private PermissionResolver _permissionResolver;
     private PermissionManager _backendPermissionManager;
     private PermissionManager _permissionManager;
-    private TableRoleManager _roleManager;
+    private TableRoleManagerDAO _roleManager;
 
     @BeforeMethod
     public void setUp() {
@@ -66,7 +65,7 @@ public class TableRoleManagerTest {
         _permissionResolver = new EmoPermissionResolver(null, null);
         _backendPermissionManager = new InMemoryPermissionManager(_permissionResolver);
         _permissionManager = spy(_backendPermissionManager);
-        _roleManager = new TableRoleManager(_dataStore, ROLE_TABLE, GROUP_TABLE, PLACEMENT, _permissionManager);
+        _roleManager = new TableRoleManagerDAO(_dataStore, ROLE_TABLE, GROUP_TABLE, PLACEMENT, _permissionManager);
     }
     
     @Test

--- a/quality/integration/src/test/java/test/integration/auth/TableRoleManagerTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/TableRoleManagerTest.java
@@ -1,0 +1,282 @@
+package test.integration.auth;
+
+import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.Role;
+import com.bazaarvoice.emodb.auth.role.RoleExistsException;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+import com.bazaarvoice.emodb.auth.role.RoleNotFoundException;
+import com.bazaarvoice.emodb.auth.role.RoleUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.TableRoleManager;
+import com.bazaarvoice.emodb.sor.api.Audit;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.api.ReadConsistency;
+import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.shiro.authz.permission.PermissionResolver;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TableRoleManagerTest {
+
+    private final static String ROLE_TABLE = "roles";
+    private final static String GROUP_TABLE = "groups";
+    private final static String PLACEMENT = "system";
+
+    private DataStore _backendDataStore;
+    private DataStore _dataStore;
+    private PermissionResolver _permissionResolver;
+    private PermissionManager _backendPermissionManager;
+    private PermissionManager _permissionManager;
+    private TableRoleManager _roleManager;
+
+    @BeforeMethod
+    public void setUp() {
+        // DataStore and PermissionManager are fairly heavy to fully mock.  Use spies on in-memory implementations instead
+        _backendDataStore = new InMemoryDataStore(new MetricRegistry());
+        _dataStore = spy(_backendDataStore);
+        _permissionResolver = new EmoPermissionResolver(null, null);
+        _backendPermissionManager = new InMemoryPermissionManager(_permissionResolver);
+        _permissionManager = spy(_backendPermissionManager);
+        _roleManager = new TableRoleManager(_dataStore, ROLE_TABLE, GROUP_TABLE, PLACEMENT, _permissionManager);
+    }
+    
+    @Test
+    public void testCreatesTables() throws Exception {
+        // For this test make a call to read a single role.  The actual role returned is irrelevant, this test verifies
+        // that on the first call only the role and group tables are checked and created when necessary.
+
+        RoleIdentifier id = new RoleIdentifier("g1", "r1");
+
+        for (int i=0; i < 3; i++) {
+            _roleManager.getRole(id);
+        }
+
+        verify(_dataStore, times(3)).get(ROLE_TABLE, "g1/r1", ReadConsistency.STRONG);
+        
+        // Each table is checked and created once
+        verify(_dataStore).getTableExists(ROLE_TABLE);
+        verify(_dataStore).createTable(
+                eq(ROLE_TABLE), eq(new TableOptionsBuilder().setPlacement(PLACEMENT).build()), eq(ImmutableMap.of()), any(Audit.class));
+        verify(_dataStore).getTableExists(GROUP_TABLE);
+        verify(_dataStore).createTable(
+                eq(GROUP_TABLE), eq(new TableOptionsBuilder().setPlacement(PLACEMENT).build()), eq(ImmutableMap.of()), any(Audit.class));
+    }
+
+    @Test
+    public void testCreateRole() throws Exception {
+        RoleIdentifier id = new RoleIdentifier("g1", "r1");
+        _roleManager.createRole(id, "d1", ImmutableSet.of("p1", "p2"));
+
+        Map<String, Object> roleMap = _backendDataStore.get(ROLE_TABLE, "g1/r1", ReadConsistency.STRONG);
+        assertEquals(Intrinsic.getId(roleMap), "g1/r1");
+        assertEquals(roleMap.get("description"), "d1");
+
+        Map<String, Object> groupMap = _backendDataStore.get(GROUP_TABLE, "g1", ReadConsistency.STRONG);
+        assertEquals(Intrinsic.getId(groupMap), "g1");
+        assertEquals(groupMap.get("names"), ImmutableList.of("r1"));
+
+        assertEquals(_backendPermissionManager.getPermissions("role:g1/r1"),
+                ImmutableSet.of(_permissionResolver.resolvePermission("p1"), _permissionResolver.resolvePermission("p2")));
+    }
+
+    @Test
+    public void testCreateRoleWitNoGroup() throws Exception {
+        RoleIdentifier id = new RoleIdentifier(null, "r1");
+        _roleManager.createRole(id, "d1", ImmutableSet.of("p1", "p2"));
+
+        Map<String, Object> roleMap = _backendDataStore.get(ROLE_TABLE, "r1", ReadConsistency.STRONG);
+        assertEquals(Intrinsic.getId(roleMap), "r1");
+        assertEquals(roleMap.get("description"), "d1");
+
+        Map<String, Object> groupMap = _backendDataStore.get(GROUP_TABLE, "_", ReadConsistency.STRONG);
+        assertEquals(Intrinsic.getId(groupMap), "_");
+        assertEquals(groupMap.get("names"), ImmutableList.of("r1"));
+
+        assertEquals(_backendPermissionManager.getPermissions("role:r1"),
+                ImmutableSet.of(_permissionResolver.resolvePermission("p1"), _permissionResolver.resolvePermission("p2")));
+    }
+
+    @Test
+    public void testAddRoleToExistingGroup() throws Exception {
+        RoleIdentifier id1 = new RoleIdentifier("g1", "r1");
+        _roleManager.createRole(id1, null, null);
+        RoleIdentifier id2 = new RoleIdentifier("g1", "r2");
+        _roleManager.createRole(id2, null, null);
+
+        Map<String, Object> groupMap = _backendDataStore.get(GROUP_TABLE, "g1", ReadConsistency.STRONG);
+        assertEquals(Intrinsic.getId(groupMap), "g1");
+        assertEquals(groupMap.get("names"), ImmutableList.of("r1", "r2"));
+    }
+
+    @Test
+    public void testCreateExistingRoleFails() throws Exception {
+        // Create a role once
+        RoleIdentifier id = new RoleIdentifier("g1", "r1");
+        _roleManager.createRole(id, null, null);
+        // Creating the same role again should fail
+        try {
+            _roleManager.createRole(id, null, null);
+            fail("RoleExistsException not thrown");
+        } catch (RoleExistsException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testCreateInvalidRoleName() throws Exception {
+        RoleIdentifier id = new RoleIdentifier("g1", "bad/role");
+        try {
+            _roleManager.createRole(id, null, null);
+            fail("IllegalArgumentException not thrown");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testCreateInvalidGroupName() throws Exception {
+        RoleIdentifier id = new RoleIdentifier("bad/group", "r1");
+        try {
+            _roleManager.createRole(id, null, null);
+            fail("IllegalArgumentException not thrown");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testUpdateRole() throws Exception {
+        RoleIdentifier id = new RoleIdentifier("g1", "r1");
+        _roleManager.createRole(id, "d1", ImmutableSet.of("p1", "p2"));
+
+        // Modify the role
+        _roleManager.updateRole(id, new RoleUpdateRequest()
+                .withDescription("new description")
+                .withPermissionUpdate(new PermissionUpdateRequest().revoke("p2").permit("p3")));
+
+        Map<String, Object> roleMap = _backendDataStore.get(ROLE_TABLE, "g1/r1", ReadConsistency.STRONG);
+        assertEquals(Intrinsic.getId(roleMap), "g1/r1");
+        assertEquals(roleMap.get("description"), "new description");
+
+        assertEquals(_backendPermissionManager.getPermissions("role:g1/r1"),
+                ImmutableSet.of(_permissionResolver.resolvePermission("p1"), _permissionResolver.resolvePermission("p3")));
+    }
+
+    @Test
+    public void testUpdateNonExistentRole() throws Exception {
+        try {
+            _roleManager.updateRole(new RoleIdentifier("g1", "r1"), new RoleUpdateRequest()
+                    .withDescription("new description"));
+            fail("RoleNotFoundException not thrown");
+        } catch (RoleNotFoundException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testGetPermissionsForRole() throws Exception {
+        RoleIdentifier id = new RoleIdentifier("g1", "r1");
+        _roleManager.createRole(id, "d1", ImmutableSet.of("p1", "p2"));
+
+        Set<String> permissions = _roleManager.getPermissionsForRole(id);
+        assertEquals(permissions, ImmutableSet.of("p1", "p2"));
+    }
+
+    @Test
+    public void testGetPermissionsForNonExistentRole() throws Exception {
+        RoleIdentifier id = new RoleIdentifier("g1", "no_such_role");
+        Set<String> permissions = _roleManager.getPermissionsForRole(id);
+        // Expected behavior is to return an empty set of permissions, not to raise an exception or return null
+        assertEquals(permissions, ImmutableSet.of());
+    }
+
+    @Test
+    public void testGetRolesByGroup() throws Exception {
+        _roleManager.createRole(new RoleIdentifier("g1", "r1"), null, null);
+        _roleManager.createRole(new RoleIdentifier("g1", "r2"), null, null);
+        _roleManager.createRole(new RoleIdentifier("g2", "r3"), null, null);
+        _roleManager.createRole(new RoleIdentifier(null, "r4"), null, null);
+
+        assertEquals(_roleManager.getRolesByGroup("g1").stream().map(Role::getName).collect(Collectors.toSet()),
+                ImmutableSet.of("r1", "r2"));
+        assertEquals(_roleManager.getRolesByGroup("g2").stream().map(Role::getName).collect(Collectors.toSet()),
+                ImmutableSet.of("r3"));
+        assertEquals(_roleManager.getRolesByGroup(null).stream().map(Role::getName).collect(Collectors.toSet()),
+                ImmutableSet.of("r4"));
+        assertEquals(_roleManager.getRolesByGroup("no_such_group"), ImmutableList.of());
+    }
+
+    @Test
+    public void testGetAll() throws Exception {
+        Set<RoleIdentifier> roleIds = ImmutableSet.of(
+                new RoleIdentifier("g1", "r1"),
+                new RoleIdentifier("g1", "r2"),
+                new RoleIdentifier("g2", "r3"),
+                new RoleIdentifier(null, "r4"));
+
+        for (RoleIdentifier id : roleIds) {
+            _roleManager.createRole(id, null, null);
+        }
+        List<Role> actual = ImmutableList.copyOf(_roleManager.getAll());
+
+        assertEquals(actual.stream().map(Role::getId).collect(Collectors.toSet()), roleIds);
+    }
+
+    @Test
+    public void testDeleteRole() throws Exception {
+        RoleIdentifier id = new RoleIdentifier("g1", "r1");
+        _roleManager.createRole(id, "d1", ImmutableSet.of("p1", "p2"));
+
+        // Verify role exists
+        assertNotNull(_roleManager.getRole(id));
+        assertFalse(_roleManager.getPermissionsForRole(id).isEmpty());
+
+        _roleManager.deleteRole(id);
+
+        // Test the interfaces
+        assertNull(_roleManager.getRole(id));
+        assertTrue(_roleManager.getPermissionsForRole(id).isEmpty());
+
+        // Verify the expected API calls to the delegates were made
+        verify(_dataStore).update(eq(ROLE_TABLE), eq("g1/r1"), any(UUID.class), eq(Deltas.delete()),
+                any(Audit.class), eq(WriteConsistency.GLOBAL));
+        verify(_dataStore).update(eq(GROUP_TABLE), eq("g1"), any(UUID.class),
+                eq(Deltas.mapBuilder()
+                        .update("names", Deltas.setBuilder()
+                                .remove("r1")
+                                .deleteIfEmpty()
+                                .build())
+                        .deleteIfEmpty()
+                        .build()),
+                any(Audit.class), eq(WriteConsistency.GLOBAL));
+        verify(_permissionManager).revokePermissions("role:g1/r1");
+    }
+}

--- a/quality/integration/src/test/java/test/integration/auth/TableRoleManagerTest.java
+++ b/quality/integration/src/test/java/test/integration/auth/TableRoleManagerTest.java
@@ -286,10 +286,14 @@ public class TableRoleManagerTest {
     }
 
     private void createRole(RoleIdentifier id, String name, String description, Set<String> permissions) {
-        _roleManager.createRole(id, new RoleUpdateRequest()
+        RoleUpdateRequest request = new RoleUpdateRequest()
                 .withName(name)
-                .withDescription(description)
-                .withPermissionUpdate(new PermissionUpdateRequest()
-                        .permit(Objects.firstNonNull(permissions, ImmutableList.of()))));
+                .withDescription(description);
+
+        if (permissions != null) {
+            request = request.withPermissionUpdate(new PermissionUpdateRequest().permit(permissions));
+        }
+
+        _roleManager.createRole(id, request);
     }
 }

--- a/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
@@ -3,7 +3,9 @@ package test.integration.blob;
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
-import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+import com.bazaarvoice.emodb.auth.role.RoleManager;
 import com.bazaarvoice.emodb.blob.api.Blob;
 import com.bazaarvoice.emodb.blob.api.BlobMetadata;
 import com.bazaarvoice.emodb.blob.api.BlobNotFoundException;
@@ -110,9 +112,11 @@ public class BlobStoreJerseyTest extends ResourceTest {
 
         final EmoPermissionResolver permissionResolver = new EmoPermissionResolver(mock(DataStore.class), _server);
         final InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
-        permissionManager.updateForRole("blob-role", new PermissionUpdateRequest().permit("blob|*|*"));
-        permissionManager.updateForRole("blob-role-a", new PermissionUpdateRequest().permit("blob|read|a*"));
-        permissionManager.updateForRole("blob-role-b", new PermissionUpdateRequest().permit("blob|read|b*"));
+        final RoleManager roleManager = new InMemoryRoleManager(permissionManager);
+
+        roleManager.createRole(new RoleIdentifier(null, "blob-role"), null, ImmutableSet.of("blob|*|*"));
+        roleManager.createRole(new RoleIdentifier(null, "blob-role-a"), null, ImmutableSet.of("blob|read|a*"));
+        roleManager.createRole(new RoleIdentifier(null, "blob-role-b"), null, ImmutableSet.of("blob|read|b*"));
 
         return setupResourceTestRule(
             Collections.<Object>singletonList(new BlobStoreResource1(_server, _dataCenters, _approvedContentTypes)),

--- a/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
@@ -4,7 +4,6 @@ import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
-import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
 import com.bazaarvoice.emodb.auth.role.RoleManager;
 import com.bazaarvoice.emodb.blob.api.Blob;
 import com.bazaarvoice.emodb.blob.api.BlobMetadata;
@@ -114,9 +113,9 @@ public class BlobStoreJerseyTest extends ResourceTest {
         final InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         final RoleManager roleManager = new InMemoryRoleManager(permissionManager);
 
-        roleManager.createRole(new RoleIdentifier(null, "blob-role"), null, ImmutableSet.of("blob|*|*"));
-        roleManager.createRole(new RoleIdentifier(null, "blob-role-a"), null, ImmutableSet.of("blob|read|a*"));
-        roleManager.createRole(new RoleIdentifier(null, "blob-role-b"), null, ImmutableSet.of("blob|read|b*"));
+        createRole(roleManager, null, "blob-role", ImmutableSet.of("blob|*|*"));
+        createRole(roleManager, null, "blob-role-a", ImmutableSet.of("blob|read|a*"));
+        createRole(roleManager, null, "blob-role-b", ImmutableSet.of("blob|read|b*"));
 
         return setupResourceTestRule(
             Collections.<Object>singletonList(new BlobStoreResource1(_server, _dataCenters, _approvedContentTypes)),

--- a/quality/integration/src/test/java/test/integration/databus/ReplicationJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/ReplicationJerseyTest.java
@@ -52,7 +52,7 @@ public class ReplicationJerseyTest extends ResourceTest {
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         RoleManager roleManager = new InMemoryRoleManager(permissionManager);
 
-        roleManager.createRole(new RoleIdentifier(null, "replication-role"), null, DefaultRoles.replication.getPermissions());
+        createRole(roleManager, null, "replication-role", DefaultRoles.replication.getPermissions());
 
         return setupResourceTestRule(resourceList, authIdentityManager, permissionManager);
     }

--- a/quality/integration/src/test/java/test/integration/databus/ReplicationJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/ReplicationJerseyTest.java
@@ -3,7 +3,9 @@ package test.integration.databus;
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
-import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+import com.bazaarvoice.emodb.auth.role.RoleManager;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.databus.repl.ReplicationClient;
 import com.bazaarvoice.emodb.databus.repl.ReplicationSource;
@@ -48,8 +50,9 @@ public class ReplicationJerseyTest extends ResourceTest {
 
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(mock(DataStore.class), mock(BlobStore.class));
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
-        permissionManager.updateForRole(
-               "replication-role", new PermissionUpdateRequest().permit(DefaultRoles.replication.getPermissions()));
+        RoleManager roleManager = new InMemoryRoleManager(permissionManager);
+
+        roleManager.createRole(new RoleIdentifier(null, "replication-role"), null, DefaultRoles.replication.getPermissions());
 
         return setupResourceTestRule(resourceList, authIdentityManager, permissionManager);
     }

--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -6,7 +6,6 @@ import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
 import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
-import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
 import com.bazaarvoice.emodb.auth.role.RoleManager;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
@@ -132,13 +131,13 @@ public class DataStoreJerseyTest extends ResourceTest {
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         RoleManager roleManager = new InMemoryRoleManager(permissionManager);
 
-        roleManager.createRole(new RoleIdentifier(null, "table-role"), null, ImmutableSet.of("sor|*|*"));
-        roleManager.createRole(new RoleIdentifier(null, "tables-a-role"), null, ImmutableSet.of("sor|read|a*"));
-        roleManager.createRole(new RoleIdentifier(null, "tables-b-role"), null, ImmutableSet.of("sor|read|b*"));
-        roleManager.createRole(new RoleIdentifier(null, "facade-role"), null, ImmutableSet.of("facade|*|*"));
-        roleManager.createRole(new RoleIdentifier(null, "reviews-only-role"), null, ImmutableSet.of("sor|*|if({..,\"type\":\"review\"})"));
-        roleManager.createRole(new RoleIdentifier(null, "standard"), null, DefaultRoles.standard.getPermissions());
-        roleManager.createRole(new RoleIdentifier(null, "update-with-events"), null, ImmutableSet.of("sor|update|*"));
+        createRole(roleManager, null, "table-role", ImmutableSet.of("sor|*|*"));
+        createRole(roleManager, null, "tables-a-role", ImmutableSet.of("sor|read|a*"));
+        createRole(roleManager, null, "tables-b-role", ImmutableSet.of("sor|read|b*"));
+        createRole(roleManager, null, "facade-role", ImmutableSet.of("facade|*|*"));
+        createRole(roleManager, null, "reviews-only-role", ImmutableSet.of("sor|*|if({..,\"type\":\"review\"})"));
+        createRole(roleManager, null, "standard", DefaultRoles.standard.getPermissions());
+        createRole(roleManager, null, "update-with-events", ImmutableSet.of("sor|update|*"));
 
         return setupResourceTestRule(Collections.<Object>singletonList(new DataStoreResource1(_server, mock(DataStoreAsync.class))), authIdentityManager, permissionManager);
     }

--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -5,7 +5,9 @@ import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
-import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+import com.bazaarvoice.emodb.auth.role.RoleManager;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
 import com.bazaarvoice.emodb.common.jersey.dropwizard.JerseyEmoClient;
@@ -128,17 +130,15 @@ public class DataStoreJerseyTest extends ResourceTest {
 
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(_server, mock(BlobStore.class));
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
-        permissionManager.updateForRole("table-role", new PermissionUpdateRequest().permit("sor|*|*"));
-        permissionManager.updateForRole("tables-a-role", new PermissionUpdateRequest().permit("sor|read|a*"));
-        permissionManager.updateForRole("tables-b-role", new PermissionUpdateRequest().permit("sor|read|b*"));
-        permissionManager.updateForRole(
-                "facade-role", new PermissionUpdateRequest().permit("facade|*|*"));
-        permissionManager.updateForRole(
-                "reviews-only-role", new PermissionUpdateRequest().permit("sor|*|if({..,\"type\":\"review\"})"));
-        permissionManager.updateForRole(
-                "standard", new PermissionUpdateRequest().permit(DefaultRoles.standard.getPermissions()));
-        permissionManager.updateForRole(
-                "update-with-events", new PermissionUpdateRequest().permit("sor|update|*"));
+        RoleManager roleManager = new InMemoryRoleManager(permissionManager);
+
+        roleManager.createRole(new RoleIdentifier(null, "table-role"), null, ImmutableSet.of("sor|*|*"));
+        roleManager.createRole(new RoleIdentifier(null, "tables-a-role"), null, ImmutableSet.of("sor|read|a*"));
+        roleManager.createRole(new RoleIdentifier(null, "tables-b-role"), null, ImmutableSet.of("sor|read|b*"));
+        roleManager.createRole(new RoleIdentifier(null, "facade-role"), null, ImmutableSet.of("facade|*|*"));
+        roleManager.createRole(new RoleIdentifier(null, "reviews-only-role"), null, ImmutableSet.of("sor|*|if({..,\"type\":\"review\"})"));
+        roleManager.createRole(new RoleIdentifier(null, "standard"), null, DefaultRoles.standard.getPermissions());
+        roleManager.createRole(new RoleIdentifier(null, "update-with-events"), null, ImmutableSet.of("sor|update|*"));
 
         return setupResourceTestRule(Collections.<Object>singletonList(new DataStoreResource1(_server, mock(DataStoreAsync.class))), authIdentityManager, permissionManager);
     }

--- a/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
@@ -3,7 +3,8 @@ package test.integration.throttle;
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
-import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.client.EmoClientException;
 import com.bazaarvoice.emodb.common.jersey.dropwizard.JerseyEmoClient;
@@ -29,6 +30,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.reflect.AbstractInvocationHandler;
@@ -103,8 +105,9 @@ public class AdHocThrottleTest extends ResourceTest {
         authIdentityManager.updateIdentity(new ApiKey(API_KEY, "id", ImmutableList.of("all-sor-role")));
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(_dataStore, mock(BlobStore.class));
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
-        permissionManager.updateForRole(
-                "all-sor-role", new PermissionUpdateRequest().permit("sor|*|*"));
+        InMemoryRoleManager roleManager = new InMemoryRoleManager(permissionManager);
+
+        roleManager.createRole(new RoleIdentifier(null, "all-sor-role"), null, ImmutableSet.of("sor|*|*"));
 
         return setupResourceTestRule(
                 Collections.<Object>singletonList(new DataStoreResource1(_dataStore, new DefaultDataStoreAsync(_dataStore, mock(JobService.class), mock(JobHandlerRegistry.class)))),

--- a/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
@@ -107,7 +107,7 @@ public class AdHocThrottleTest extends ResourceTest {
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         InMemoryRoleManager roleManager = new InMemoryRoleManager(permissionManager);
 
-        roleManager.createRole(new RoleIdentifier(null, "all-sor-role"), null, ImmutableSet.of("sor|*|*"));
+        createRole(roleManager,null, "all-sor-role", ImmutableSet.of("sor|*|*"));
 
         return setupResourceTestRule(
                 Collections.<Object>singletonList(new DataStoreResource1(_dataStore, new DefaultDataStoreAsync(_dataStore, mock(JobService.class), mock(JobHandlerRegistry.class)))),

--- a/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
@@ -107,7 +107,7 @@ public class AdHocThrottleTest extends ResourceTest {
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
         InMemoryRoleManager roleManager = new InMemoryRoleManager(permissionManager);
 
-        createRole(roleManager,null, "all-sor-role", ImmutableSet.of("sor|*|*"));
+        createRole(roleManager, null, "all-sor-role", ImmutableSet.of("sor|*|*"));
 
         return setupResourceTestRule(
                 Collections.<Object>singletonList(new DataStoreResource1(_dataStore, new DefaultDataStoreAsync(_dataStore, mock(JobService.class), mock(JobHandlerRegistry.class)))),

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.web;
 
 import com.bazaarvoice.curator.dropwizard.ZooKeeperConfiguration;
 import com.bazaarvoice.emodb.auth.AuthCacheRegistry;
+import com.bazaarvoice.emodb.auth.AuthZooKeeper;
 import com.bazaarvoice.emodb.blob.BlobStoreConfiguration;
 import com.bazaarvoice.emodb.blob.BlobStoreModule;
 import com.bazaarvoice.emodb.blob.BlobStoreZooKeeper;
@@ -554,6 +555,11 @@ public class EmoModule extends AbstractModule {
         @Provides @Singleton @AuthCacheRegistry
         CacheRegistry provideCacheRegistry(CacheRegistry cacheRegistry) {
             return cacheRegistry.withNamespace("auth");
+        }
+
+        @Provides @Singleton @AuthZooKeeper
+        CuratorFramework provideAuthZooKeeperConnection(@Global CuratorFramework curator) {
+            return withComponentNamespace(curator, "auth");
         }
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
@@ -10,6 +10,8 @@ public class AuthorizationConfiguration {
     private final static String DEFAULT_IDENTITY_TABLE = "__auth:keys";
     private final static String DEFAULT_INTERNAL_ID_INDEX_TABLE = "__auth:internal_ids";
     private final static String DEFAULT_PERMISSION_TABLE = "__auth:permissions";
+    private final static String DEFAULT_ROLE_TABLE = "__auth:roles";
+    private final static String DEFAULT_ROLE_GROUP_TABLE = "__auth:role_groups";
 
     // Table for storing API keys
     @NotNull
@@ -20,6 +22,12 @@ public class AuthorizationConfiguration {
     // Table for storing permissions
     @NotNull
     private String _permissionsTable = DEFAULT_PERMISSION_TABLE;
+    // Table for storing roles
+    @NotNull
+    private String _roleTable = DEFAULT_ROLE_TABLE;
+    // Table for storing mappings of role groups to roles
+    @NotNull
+    private String _roleGroupTable = DEFAULT_ROLE_GROUP_TABLE;
     // Placement for preceding tables
     @NotNull
     private String _tablePlacement;
@@ -56,6 +64,24 @@ public class AuthorizationConfiguration {
 
     public AuthorizationConfiguration setPermissionsTable(String permissionsTable) {
         _permissionsTable = permissionsTable;
+        return this;
+    }
+
+    public String getRoleTable() {
+        return _roleTable;
+    }
+
+    public AuthorizationConfiguration setRoleTable(String roleTable) {
+        _roleTable = roleTable;
+        return this;
+    }
+
+    public String getRoleGroupTable() {
+        return _roleGroupTable;
+    }
+
+    public AuthorizationConfiguration setRoleGroupTable(String roleGroupTable) {
+        _roleGroupTable = roleGroupTable;
         return this;
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.web.auth;
 
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.web.auth.resource.ConditionResource;
 import com.google.common.collect.ImmutableSet;
@@ -152,12 +153,14 @@ public enum DefaultRoles {
         return _permissions;
     }
 
-    public static boolean isDefaultRole(String role) {
-        if (role == null) {
+    public static boolean isDefaultRole(RoleIdentifier id) {
+        // Default roles exist with no group, so if the ID has a group it's not a default role.
+        if (id == null || id.getGroup() != null) {
             return false;
         }
+        String name = id.getName();
         for (DefaultRoles defaultRole : DefaultRoles.values()) {
-            if (defaultRole.name().equals(role)) {
+            if (defaultRole.name().equals(name)) {
                 return true;
             }
         }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
@@ -158,9 +158,9 @@ public enum DefaultRoles {
         if (id == null || id.getGroup() != null) {
             return false;
         }
-        String name = id.getName();
+        String checkId = id.getId();
         for (DefaultRoles defaultRole : DefaultRoles.values()) {
-            if (defaultRole.name().equals(name)) {
+            if (defaultRole.name().equals(checkId)) {
                 return true;
             }
         }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/RebuildMissingRolesTask.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/RebuildMissingRolesTask.java
@@ -1,0 +1,69 @@
+package com.bazaarvoice.emodb.web.auth;
+
+import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
+import com.bazaarvoice.emodb.auth.role.Role;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+import com.bazaarvoice.emodb.auth.role.RoleManager;
+import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.inject.Inject;
+import io.dropwizard.servlets.tasks.Task;
+import org.apache.shiro.authz.Permission;
+
+import java.io.PrintWriter;
+import java.util.Map;
+import java.util.Set;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Task for populating role tables with missing roles.  This is accomplished by scanning for all permissions associated
+ * with roles and then creating the role if it does not exist.
+ *
+ * Use for this task should be infrequent.  It was introduced to handle the upgrade case prior to the introduction of
+ * roles as first-order objects.  Prior to that roles only existed as the keys for identifying permissions.  In this
+ * case this task would be run once after the upgrade to ensure that all pre-existing roles have records in the role
+ * related tables.
+ *
+ * Example:
+ *
+ * <code>
+ *     $ curl -XPOST "localhost:8081/tasks/rebuild-missing-roles"
+ * </code>
+ */
+public class RebuildMissingRolesTask extends Task {
+
+    private final PermissionManager _permissionManager;
+    private final RoleManager _roleManager;
+
+    @Inject
+    public RebuildMissingRolesTask(PermissionManager permissionManager, RoleManager roleManager, TaskRegistry taskRegistry) {
+        super("rebuild-missing-roles");
+        _permissionManager = permissionManager;
+        _roleManager = roleManager;
+
+        taskRegistry.addTask(this);
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> params, PrintWriter out) throws Exception {
+        Set<RoleIdentifier> existingRoles = StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(_roleManager.getAll(), 0), false)
+                .map(Role::getId)
+                .collect(Collectors.toSet());
+
+        for (Map.Entry<String, Set<Permission>> entry : _permissionManager.getAll()) {
+            String key = entry.getKey();
+            if (key.startsWith("role:")) {
+                RoleIdentifier id = RoleIdentifier.fromString(key.substring(5));
+                if (!existingRoles.contains(id)) {
+                    // Permission exists for a role which does not exist.  Create the role now with reasonable defaults.
+                    Set<String> initialPermissions = entry.getValue().stream().map(Object::toString).collect(Collectors.toSet());
+                    _roleManager.createRole(id, null, initialPermissions);
+                    out.println("Created missing role: " + id);
+                }
+            }
+        }
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/RoleAdminTask.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/RoleAdminTask.java
@@ -9,6 +9,7 @@ import com.bazaarvoice.emodb.auth.role.RoleManager;
 import com.bazaarvoice.emodb.auth.role.RoleUpdateRequest;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
@@ -28,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -156,6 +158,12 @@ public class RoleAdminTask extends Task {
         } catch (AuthenticationException | AuthorizationException e) {
             _log.warn("Unauthorized attempt to access role management task");
             output.println("Not authorized");
+        } catch (Exception e) {
+            if (Throwables.getRootCause(e) instanceof TimeoutException) {
+                output.println("Timed out, try again later");
+            } else {
+                throw Throwables.propagate(e);
+            }
         } finally {
             subject.logout();
         }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/RoleAdminTask.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/RoleAdminTask.java
@@ -2,36 +2,33 @@ package com.bazaarvoice.emodb.web.auth;
 
 import com.bazaarvoice.emodb.auth.apikey.ApiKeyAuthenticationToken;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
-import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionUpdateRequest;
+import com.bazaarvoice.emodb.auth.role.RoleExistsException;
+import com.bazaarvoice.emodb.auth.role.RoleIdentifier;
+import com.bazaarvoice.emodb.auth.role.RoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleNotFoundException;
+import com.bazaarvoice.emodb.auth.role.RoleUpdateRequest;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import io.dropwizard.servlets.tasks.Task;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authz.AuthorizationException;
 import org.apache.shiro.authz.Permission;
+import org.apache.shiro.authz.permission.PermissionResolver;
 import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.subject.Subject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.io.PrintWriter;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -46,10 +43,6 @@ import static java.lang.String.format;
  *
  * Create or update role
  * =====================
- *
- * EmoDB does not distinguish between creating a new role and updating an existing role.  An API key can be associated with
- * any role name, even one that has not been created.  However, until an administrator explicitly assigns permissions
- * to the role it will only be able to perform actions with implicit permissions, such as reading from a SoR table.
  *
  * The following example adds databus poll permissions for subscriptions starting with "foo_" and removes poll permissions
  * for subscriptions starting with "bar_" for role "sample-role":
@@ -103,6 +96,7 @@ public class RoleAdminTask extends Task {
 
     private enum Action {
         VIEW,
+        CREATE,
         UPDATE,
         DELETE,
         CHECK,
@@ -110,13 +104,16 @@ public class RoleAdminTask extends Task {
     }
 
     private final SecurityManager _securityManager;
-    private final PermissionManager _permissionManager;
+    private final RoleManager _roleManager;
+    private final PermissionResolver _permissionResolver;
 
     @Inject
-    public RoleAdminTask(SecurityManager securityManager, PermissionManager permissionManager, TaskRegistry taskRegistry) {
+    public RoleAdminTask(SecurityManager securityManager, RoleManager roleManager, PermissionResolver permissionResolver,
+                         TaskRegistry taskRegistry) {
         super("role");
         _securityManager = checkNotNull(securityManager, "securityManager");
-        _permissionManager = checkNotNull(permissionManager, "permissionManager");
+        _roleManager = checkNotNull(roleManager, "roleManager");
+        _permissionResolver = checkNotNull(permissionResolver, "permissionResolver");
 
         taskRegistry.addTask(this);
     }
@@ -140,8 +137,11 @@ public class RoleAdminTask extends Task {
                 case VIEW:
                     viewRole(getRole(parameters), output);
                     break;
+                case CREATE:
+                    createOrUpdateRole(getRole(parameters), parameters, output, true);
+                    break;
                 case UPDATE:
-                    updateRole(getRole(parameters), parameters, output);
+                    createOrUpdateRole(getRole(parameters), parameters, output, false);
                     break;
                 case DELETE:
                     deleteRole(getRole(parameters), output);
@@ -160,23 +160,23 @@ public class RoleAdminTask extends Task {
         }
     }
 
-    private String getRole(ImmutableMultimap<String, String> parameters) {
-        return getValueFromParams("role", parameters);
+    private RoleIdentifier getRole(ImmutableMultimap<String, String> parameters) {
+        String name = getValueFromParams("role", parameters);
+        String group = parameters.get("group").stream().findFirst().orElse(null);
+        return new RoleIdentifier(group, name);
     }
 
-    private void viewRole(String role, PrintWriter output) {
-        List<String> permissions = FluentIterable.from(_permissionManager.getAllForRole(role))
-                .transform(Functions.toStringFunction())
-                .toSortedList(Ordering.natural());
-
-        output.println(String.format("%s has %d permissions", role, permissions.size()));
+    private void viewRole(RoleIdentifier id, PrintWriter output) {
+        Set<String> permissions = _roleManager.getPermissionsForRole(id);
+        output.println(String.format("%s has %d permissions", id, permissions.size()));
         for (String permission : permissions) {
             output.println("- " + permission);
         }
     }
 
-    private void updateRole(String role, ImmutableMultimap<String, String> parameters, PrintWriter output) {
-        checkArgument(!DefaultRoles.isDefaultRole(role), "Cannot update default role: %s", role);
+    private void createOrUpdateRole(RoleIdentifier id, ImmutableMultimap<String, String> parameters, PrintWriter output,
+                                    boolean isCreate) {
+        checkArgument(!DefaultRoles.isDefaultRole(id), "Cannot update default role: %s", id);
 
         Set<String> permitSet = ImmutableSet.copyOf(parameters.get("permit"));
         Set<String> revokeSet = ImmutableSet.copyOf(parameters.get("revoke"));
@@ -189,7 +189,7 @@ public class RoleAdminTask extends Task {
         boolean allAssignable = true;
         for (String permit : permitSet) {
             // All permissions returned are EmoPermission instances.
-            EmoPermission resolved = (EmoPermission) _permissionManager.getPermissionResolver().resolvePermission(permit);
+            EmoPermission resolved = (EmoPermission) _permissionResolver.resolvePermission(permit);
             if (!resolved.isAssignable()) {
                 if (allAssignable) {
                     output.println("The following permission(s) cannot be assigned to a role:");
@@ -204,100 +204,76 @@ public class RoleAdminTask extends Task {
             return;
         }
 
-        _permissionManager.updateForRole(role,
-                new PermissionUpdateRequest()
-                        .permit(permitSet)
-                        .revoke(revokeSet));
-
-        output.println("Role updated.");
-        viewRole(role, output);
-    }
-
-    private void deleteRole(String role, PrintWriter output) {
-        // A role technically cannot be deleted.  What this method does is revoke all permissions associated with
-        // the role.
-
-        checkArgument(!DefaultRoles.isDefaultRole(role), "Cannot delete default role: %s", role);
-
-        Set<Permission> permissions = _permissionManager.getAllForRole(role);
-
-        // Bound the number of times we'll try to revoke all permissions.
-        for (int attempt = 0; !permissions.isEmpty() && attempt < 10; attempt++) {
-            _permissionManager.updateForRole(role,
-                    new PermissionUpdateRequest()
-                            .revoke(FluentIterable.from(permissions)
-                                    .transform(Functions.toStringFunction())));
-
-            permissions = _permissionManager.getAllForRole(role);
-        }
-
-        if (permissions.isEmpty()) {
-            output.println("Role deleted");
+        if (isCreate) {
+            try {
+                _roleManager.createRole(id, null, permitSet);
+                output.println("Role created.");
+                viewRole(id, output);
+            } catch (RoleExistsException e) {
+                output.write("Role already exists");
+            }
         } else {
-            output.println(String.format("WARNING:  Role still had %d permissions after 10 delete attempts", permissions.size()));
+            try {
+                _roleManager.updateRole(id, new RoleUpdateRequest()
+                        .withPermissionUpdate(new PermissionUpdateRequest()
+                                .permit(permitSet)
+                                .revoke(revokeSet)));
+
+                output.println("Role updated.");
+                viewRole(id, output);
+            } catch (RoleNotFoundException e) {
+                output.write("Role not found");
+            }
         }
     }
 
-    private void checkPermission(String role, ImmutableMultimap<String, String> parameters, PrintWriter output) {
-        String permissionStr = getValueFromParams("permission", parameters);
-        final Permission permission = _permissionManager.getPermissionResolver().resolvePermission(permissionStr);
+    private void deleteRole(RoleIdentifier id, PrintWriter output) {
+        checkArgument(!DefaultRoles.isDefaultRole(id), "Cannot delete default role: %s", id);
+        _roleManager.deleteRole(id);
+        output.println("Role deleted");
+    }
 
-        List<String> matchingPermissions = FluentIterable.from(_permissionManager.getAllForRole(role))
-                .filter(
-                        new Predicate<Permission>() {
-                                @Override
-                                public boolean apply(Permission grantedPermission) {
-                                    return grantedPermission.implies(permission);
-                                }
-                        })
-                .transform(Functions.toStringFunction())
-                .toSortedList(Ordering.natural());
+    private void checkPermission(RoleIdentifier id, ImmutableMultimap<String, String> parameters, PrintWriter output) {
+        String permissionStr = getValueFromParams("permission", parameters);
+        final Permission permission = _permissionResolver.resolvePermission(permissionStr);
+
+        List<String> matchingPermissions = _roleManager.getPermissionsForRole(id)
+                .stream()
+                .filter(p -> _permissionResolver.resolvePermission(p).implies(permission))
+                .sorted()
+                .collect(Collectors.toList());
 
         if (!matchingPermissions.isEmpty()) {
-            output.println(String.format("%s is permitted %s by the following:", role, permissionStr));
+            output.println(String.format("%s is permitted %s by the following:", id, permissionStr));
             for (String matchingPermission : matchingPermissions) {
                 output.println("- " + matchingPermission);
             }
         } else {
-            output.println(String.format("%s is not permitted %s", role, permissionStr));
+            output.println(String.format("%s is not permitted %s", id, permissionStr));
         }
     }
 
     private void findDeprecatedPermissions(PrintWriter output) {
-        Iterator<Map.Entry<String, Set<Permission>>> deprecatedPermissionsByRole =
-                FluentIterable.from(_permissionManager.getAll())
-                        .transform(new Function<Map.Entry<String, Set<Permission>>, Map.Entry<String, Set<Permission>>>() {
-                            @Nullable
-                            @Override
-                            public Map.Entry<String, Set<Permission>> apply(Map.Entry<String, Set<Permission>> rolePermissions) {
-                                Set<Permission> deprecatedPermissions = Sets.newLinkedHashSet();
-                                for (Permission permission : rolePermissions.getValue()) {
-                                    if (!((EmoPermission) permission).isAssignable()) {
-                                        deprecatedPermissions.add(permission);
-                                    }
-                                }
+        final AtomicBoolean anyDeprecated = new AtomicBoolean(false);
+        
+        _roleManager.getAll().forEachRemaining(role -> {
+            List<Permission> deprecatedPermissions = _roleManager.getPermissionsForRole(role.getId())
+                    .stream()
+                    .map(p -> (EmoPermission) _permissionResolver.resolvePermission(p))
+                    .filter(p -> !p.isAssignable())
+                    .collect(Collectors.toList());
 
-                                if (deprecatedPermissions.isEmpty()) {
-                                    return null;
-                                }
-
-                                return Maps.immutableEntry(rolePermissions.getKey(), deprecatedPermissions);
-                            }
-                        })
-                        .filter(Predicates.notNull())
-                        .iterator();
-
-        if (!deprecatedPermissionsByRole.hasNext()) {
-            output.println("There are no roles with deprecated permissions.");
-        } else {
-            output.println("The following roles have deprecated permissions:\n");
-            while (deprecatedPermissionsByRole.hasNext()) {
-                Map.Entry<String, Set<Permission>> entry = deprecatedPermissionsByRole.next();
-                output.println(entry.getKey());
-                for (Permission permission : entry.getValue()) {
-                    output.println("- " + permission);
+            if (!deprecatedPermissions.isEmpty()) {
+                if (anyDeprecated.compareAndSet(false, true)) {
+                    output.println("The following roles have deprecated permissions:\n");
                 }
+                output.println(role.getId());
+                deprecatedPermissions.forEach(p -> output.println("- " + p));
             }
+        });
+
+        if (!anyDeprecated.get()) {
+            output.println("There are no roles with deprecated permissions.");
         }
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
@@ -267,7 +267,8 @@ public class SecurityModule extends PrivateModule {
     RoleManager provideRoleManagerWithDefaultRoles(@Named("dao") RoleManager delegate) {
         List<Role> defaultRoles = Lists.newArrayList();
         for (DefaultRoles defaultRole : DefaultRoles.values()) {
-            defaultRoles.add(new Role(null, defaultRole.name(), "Reserved role"));
+            // Use the default role's name as both the role's identifier and name attribute
+            defaultRoles.add(new Role(null, defaultRole.name(), defaultRole.name(),"Reserved role"));
         }
         return new DeferringRoleManager(delegate, defaultRoles);
     }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
@@ -11,18 +11,18 @@ import com.bazaarvoice.emodb.auth.identity.AuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.AuthIdentityReader;
 import com.bazaarvoice.emodb.auth.identity.CacheManagingAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.DeferringAuthIdentityManager;
-import com.bazaarvoice.emodb.auth.identity.TableAuthIdentityManager;
+import com.bazaarvoice.emodb.auth.identity.TableAuthIdentityManagerDAO;
 import com.bazaarvoice.emodb.auth.permissions.CacheManagingPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.DeferringPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionIDs;
 import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.PermissionReader;
-import com.bazaarvoice.emodb.auth.permissions.TablePermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.TablePermissionManagerDAO;
 import com.bazaarvoice.emodb.auth.role.DataCenterSynchronizedRoleManager;
 import com.bazaarvoice.emodb.auth.role.DeferringRoleManager;
 import com.bazaarvoice.emodb.auth.role.Role;
 import com.bazaarvoice.emodb.auth.role.RoleManager;
-import com.bazaarvoice.emodb.auth.role.TableRoleManager;
+import com.bazaarvoice.emodb.auth.role.TableRoleManagerDAO;
 import com.bazaarvoice.emodb.auth.shiro.GuavaCacheManager;
 import com.bazaarvoice.emodb.auth.shiro.InvalidatableCacheManager;
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
@@ -187,7 +187,7 @@ public class SecurityModule extends PrivateModule {
     @Named("dao")
     AuthIdentityManager<ApiKey> provideAuthIdentityManagerDAO(
             AuthorizationConfiguration config, DataStore dataStore, @ApiKeyHashFunction HashFunction hash) {
-        return new TableAuthIdentityManager<>(ApiKey.class, dataStore, config.getIdentityTable(),
+        return new TableAuthIdentityManagerDAO<>(ApiKey.class, dataStore, config.getIdentityTable(),
                 config.getInternalIdIndexTable(), config.getTablePlacement(), hash);
     }
 
@@ -219,7 +219,7 @@ public class SecurityModule extends PrivateModule {
     @Named("dao")
     PermissionManager providePermissionManagerDAO(
             AuthorizationConfiguration config, PermissionResolver permissionResolver, DataStore dataStore) {
-        return new TablePermissionManager(
+        return new TablePermissionManagerDAO(
                 permissionResolver, dataStore, config.getPermissionsTable(), config.getTablePlacement());
     }
 
@@ -257,7 +257,7 @@ public class SecurityModule extends PrivateModule {
     @Named("dao")
     RoleManager provideRoleManagerDAO(AuthorizationConfiguration config, DataStore dataStore,
                                       PermissionManager permissionManager) {
-        return new TableRoleManager(dataStore, config.getRoleTable(), config.getRoleGroupTable(),
+        return new TableRoleManagerDAO(dataStore, config.getRoleTable(), config.getRoleGroupTable(),
                 config.getTablePlacement(), permissionManager);
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
@@ -1,31 +1,39 @@
 package com.bazaarvoice.emodb.web.auth;
 
 import com.bazaarvoice.emodb.auth.AuthCacheRegistry;
+import com.bazaarvoice.emodb.auth.AuthZooKeeper;
 import com.bazaarvoice.emodb.auth.EmoSecurityManager;
 import com.bazaarvoice.emodb.auth.InternalAuthorizer;
 import com.bazaarvoice.emodb.auth.SecurityManagerBuilder;
 import com.bazaarvoice.emodb.auth.apikey.ApiKey;
 import com.bazaarvoice.emodb.auth.dropwizard.DropwizardAuthConfigurator;
 import com.bazaarvoice.emodb.auth.identity.AuthIdentityManager;
+import com.bazaarvoice.emodb.auth.identity.AuthIdentityReader;
 import com.bazaarvoice.emodb.auth.identity.CacheManagingAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.DeferringAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.identity.TableAuthIdentityManager;
 import com.bazaarvoice.emodb.auth.permissions.CacheManagingPermissionManager;
 import com.bazaarvoice.emodb.auth.permissions.DeferringPermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionIDs;
 import com.bazaarvoice.emodb.auth.permissions.PermissionManager;
+import com.bazaarvoice.emodb.auth.permissions.PermissionReader;
 import com.bazaarvoice.emodb.auth.permissions.TablePermissionManager;
+import com.bazaarvoice.emodb.auth.role.DataCenterSynchronizedRoleManager;
+import com.bazaarvoice.emodb.auth.role.DeferringRoleManager;
+import com.bazaarvoice.emodb.auth.role.Role;
+import com.bazaarvoice.emodb.auth.role.RoleManager;
+import com.bazaarvoice.emodb.auth.role.TableRoleManager;
 import com.bazaarvoice.emodb.auth.shiro.GuavaCacheManager;
 import com.bazaarvoice.emodb.auth.shiro.InvalidatableCacheManager;
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
 import com.bazaarvoice.emodb.databus.ReplicationKey;
 import com.bazaarvoice.emodb.databus.SystemInternalId;
 import com.bazaarvoice.emodb.sor.api.DataStore;
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.inject.Exposed;
@@ -36,12 +44,15 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
+import org.apache.curator.framework.CuratorFramework;
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.permission.PermissionResolver;
 import org.apache.shiro.mgt.SecurityManager;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Guice module which configures security on the local server.
@@ -53,6 +64,7 @@ import java.util.Set;
  * <li> {@link com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry}
  * <li> @{@link com.bazaarvoice.emodb.common.dropwizard.guice.SelfHostAndPort} HostAndPort
  * <li> @{@link com.bazaarvoice.emodb.common.dropwizard.guice.ServerCluster} String
+ * <li> @{@link com.bazaarvoice.emodb.auth.AuthZooKeeper} {@link CuratorFramework}
  * </ul>
  * Exports the following:
  * <ul>
@@ -82,7 +94,8 @@ public class SecurityModule extends PrivateModule {
         bind(ApiKeyEncryption.class).asEagerSingleton();
         bind(ApiKeyAdminTask.class).asEagerSingleton();
         bind(RoleAdminTask.class).asEagerSingleton();
-
+        bind(RebuildMissingRolesTask.class).asEagerSingleton();
+        
         bind(new TypeLiteral<Set<String>>() {})
                 .annotatedWith(ReservedRoles.class)
                 .toInstance(ImmutableSet.of(
@@ -92,6 +105,8 @@ public class SecurityModule extends PrivateModule {
         bind(PermissionResolver.class).to(EmoPermissionResolver.class).asEagerSingleton();
         bind(SecurityManager.class).to(EmoSecurityManager.class);
         bind(InternalAuthorizer.class).to(EmoSecurityManager.class);
+        bind(new TypeLiteral<AuthIdentityReader<ApiKey>>() {}).to(new TypeLiteral<AuthIdentityManager<ApiKey>>() {});
+        bind(PermissionReader.class).to(PermissionManager.class);
 
         bind(String.class).annotatedWith(SystemInternalId.class).toInstance(SYSTEM_INTERNAL_ID);
 
@@ -106,15 +121,15 @@ public class SecurityModule extends PrivateModule {
     @Singleton
     @Inject
     EmoSecurityManager provideSecurityManager(
-            AuthIdentityManager<ApiKey> authIdentityManager,
-            PermissionManager permissionManager,
+            AuthIdentityReader<ApiKey> authIdentityReader,
+            PermissionReader permissionReader,
             InvalidatableCacheManager cacheManager,
             @Named("AnonymousKey") Optional<String> anonymousKey) {
 
         return SecurityManagerBuilder.create()
                 .withRealmName(REALM_NAME)
-                .withAuthIdentityManager(authIdentityManager)
-                .withPermissionManager(permissionManager)
+                .withAuthIdentityReader(authIdentityReader)
+                .withPermissionReader(permissionReader)
                 .withAnonymousAccessAs(anonymousKey.orNull())
                 .withCacheManager(cacheManager)
                 .build();
@@ -223,23 +238,43 @@ public class SecurityModule extends PrivateModule {
                                                final PermissionResolver permissionResolver) {
         ImmutableMap.Builder<String, Set<Permission>> defaultRolePermissions = ImmutableMap.builder();
 
-        Function<String, Permission> toPermission = new Function<String, Permission>() {
-            @Override
-            public Permission apply(String permissionString) {
-                return permissionResolver.resolvePermission(permissionString);
-            }
-        };
-
         for (DefaultRoles defaultRole : DefaultRoles.values()) {
-            Set<Permission> rolePermissions = FluentIterable.from(defaultRole.getPermissions())
-                    .transform(toPermission)
-                    .toSet();
+            Set<Permission> rolePermissions = defaultRole.getPermissions()
+                    .stream()
+                    .map(permissionResolver::resolvePermission)
+                    .collect(Collectors.toSet());
 
-            defaultRolePermissions.put(defaultRole.toString(), rolePermissions);
+            defaultRolePermissions.put(PermissionIDs.forRole(defaultRole.toString()), rolePermissions);
         }
 
         PermissionManager deferring = new DeferringPermissionManager(permissionManager, defaultRolePermissions.build());
 
         return new CacheManagingPermissionManager(deferring, cacheManager);
+    }
+
+    @Provides
+    @Singleton
+    @Named("dao")
+    RoleManager provideRoleManagerDAO(AuthorizationConfiguration config, DataStore dataStore,
+                                      PermissionManager permissionManager) {
+        return new TableRoleManager(dataStore, config.getRoleTable(), config.getRoleGroupTable(),
+                config.getTablePlacement(), permissionManager);
+    }
+
+    @Provides
+    @Singleton
+    @Named("withDefaults")
+    RoleManager provideRoleManagerWithDefaultRoles(@Named("dao") RoleManager delegate) {
+        List<Role> defaultRoles = Lists.newArrayList();
+        for (DefaultRoles defaultRole : DefaultRoles.values()) {
+            defaultRoles.add(new Role(null, defaultRole.name(), "Reserved role"));
+        }
+        return new DeferringRoleManager(delegate, defaultRoles);
+    }
+
+    @Provides
+    @Singleton
+    RoleManager provideRoleManager(@Named("withDefaults") RoleManager delegate, @AuthZooKeeper CuratorFramework curator) {
+        return new DataCenterSynchronizedRoleManager(delegate, curator);
     }
 }


### PR DESCRIPTION
## Github Issue #

[93](https://github.com/bazaarvoice/emodb/issues/93)

## What Are We Doing Here?

As described in the corresponding issue, Emo is moving towards a system of delegated API key management.  To fully get there is a four step process:

1. Create the ability to restrict an API key from creating a role with permissions wider than the API key's current permissions (https://github.com/bazaarvoice/emodb/issues/63)
1. Add the ability to group roles together by namespace (https://github.com/bazaarvoice/emodb/issues/93)
1. Refactor role and API key management permissions to restrict role management and assignment by group
1. Expose role and API key management as a public REST interface (https://github.com/bazaarvoice/emodb/issues/50)

This PR addresses the second step in this process.  The major changes in this PR are:

1. Created first-order `Role` object and the associated management interface and implementations.  Each role belongs to exactly one group, including the implicit `null` group.
1. Split `AuthIdentityManager` and `PermissionManager` interfaces to inherit from more restrictive read-only `AuthIdentityReader` and `PermissionReader` interfaces, respectively.  This allows authenticators such as `ApiKeyRealm` to use the reader interfaces without risk of exposing the ability to update users, roles, or permissions.  This is not strictly necessary for this PR but with the added interfaces for manipulating security artifacts introduced in this PR it was a good time to close this potential gap.
1. Refactored `PermissionManager` to be more agnostic about the permissions it manages.  This was done to provide a clean separation of role and permission management since roles are now first-order objects.

Although this PR updates many files it's changes 2 and 3 above which account for a good share of those, due to the class and method name changes percolating through the system.

**Design Decisions**

It's possible that roles could have been modeled as belonging to multiple groups, not one exclusively.  However, this was not done for the following reasons:

- There is no use case for it.
- It complicates the goal of grouping roles for the purpose of managing permissions to use those roles.  If a role belongs to multiple groups the permissions associated with that role become much less clear.  For example, if a role belongs to "group1" and "group2" and a user has update permission for roles in "group1" but not "group2" then should he be able to update the role?
- If a role can belong to more than one group then the role needs a unique identifier which is separate from the role ID or group, such as a random UUID.  While this itself is not a bad thing it requires a complicated dereferencing system and upgrade path with no recognizable benefit.

The unique identifier for a role is derived from the group and a user-provided ID.  This means that if a role is deleted and then re-created with the same group and ID then any API keys who had been assigned the role prior to its deletion will still be assigned the role after it is re-created, assuming the role was not explicitly removed from the API key at any time during this process.  This is an intentional decision for the following reasons:

- It avoids potential confusion given that the (group, ID) is effectively a natural key since the role's creator provides both.
- It allows for the assignment of roles to be completely separated from the management of roles.  For example, deleting a role does not require scanning every API key and removing the role from that key if present.
- It simplifies role management by requiring neither maintaining multiple states for a role nor creating non-natural unique identifiers for new roles upon creation.  Both of these solutions add significant complexity for a small benefit which is arguably not the desired behavior.

Note that in addition to (group, ID) the role creator can also set a "name" and "description" attribute.  Both of these are informational only and there is no uniqueness guarantee on either of these fields, although it likely benefits the creator to assign unique names to roles within her group.

**Upgrade path**

The naming convention for roles is as follows:

- If the role has no group (group == `null`) then the role's persistence ID is just the role ID.
- If the role has a group then the role's persistence ID is "group/ID".

For this reason, prior to upgrading there must be no roles whose name includes the "/" character.  Any such roles should be migrated to new roles with no "/" prior to upgrading.

Once this is done all existing roles are implicitly grandfathered into the `null` group of roles.  All existing API keys and permissions are already persisted in a forward-compatible format.  Upgraded Emo servers can be deployed along with the existing ones with no down time or interruption of normal service.  The only restriction is that roles should not be modified while the upgrade is taking place.

While the current users, roles, and permissions are forward-compatible the ability to manage existing roles is not.  The `RebuildMissingRolesTask` must be run once per environment after the upgrade to populate the new role persistence tables.  Until this is done the administrator will not be able to modify any existing roles.

## How to Test and Verify

1. Check out this PR
2. Use the `RoleAdminTask` and `ApiKeyAdminTask` to create and assign multiple roles, both with and without a group.  Verify all works as expected.

## Risk

The greatest risk is an error which causes roles to become unstable, since this could lead to users being unable to access parts of Emo for which they should have permission.

### Level 

`Medium` While this seems like a large scale PR most of the changes are centered around the management of roles.  Permission management is intentionally unaffected to minimize the risk of any changes impacting the existing permissions system.

### Required Testing

`Manual`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
