### PR TITLE
Fix inefficiency in databus poll due to unclaiming events

### DIFF
--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/AuthDatabus.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/AuthDatabus.java
@@ -8,7 +8,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Authenticating interface to {@link Databus}.  This method should exactly mirror Databus except with added credentials
@@ -54,7 +53,7 @@ public interface AuthDatabus {
      * Note that there is no API for paging through all events.  The {@code limit} argument is limited by the amount
      * of memory required to hold the event data on the server and, in practice, should be no more than a few hundred.
      */
-    List<Event> peek(@Credential String apiKey, String subscription, int limit);
+    Iterator<Event> peek(@Credential String apiKey, String subscription, int limit);
 
     /**
      * Claim events for the specified subscription and return it.  The caller must call {@link #acknowledge} with the

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Databus.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Databus.java
@@ -7,7 +7,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 
 public interface Databus {
 
@@ -62,7 +61,7 @@ public interface Databus {
      * Note that there is no API for paging through all events.  The {@code limit} argument is limited by the amount
      * of memory required to hold the event data on the server and, in practice, should be no more than a few hundred.
      */
-    List<Event> peek(String subscription, int limit);
+    Iterator<Event> peek(String subscription, int limit);
 
     /**
      * Claim events for the specified subscription and return it.  The caller must call {@link #acknowledge} with the

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/PollResult.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/PollResult.java
@@ -1,15 +1,20 @@
 package com.bazaarvoice.emodb.databus.api;
 
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import org.joda.time.Duration;
 
+import java.util.Iterator;
 import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Result returned from {@link Databus#poll(String, Duration, int)}.  The result contains to attributes:
  *
  * <ol>
  *     <li>
- *         The list of {@link Event} instances returned from the poll.
+ *         The an iterator of {@link Event} instances returned from the poll, returned by {@link #getEventStream()}.
  *     </li>
  *     <li>
  *         A boolean indicator for whether there are more events and the caller would benefit from immediately re-polling
@@ -19,18 +24,39 @@ import java.util.List;
  *         contain no events yet still indicate that there are more events.
  *     </li>
  * </ol>
+ *
+ * As a convenience the result has a {@link #getEvents()} method which returns all of the events from the stream in a
+ * list.  This is present primarily to support older non-streaming implementations and may be removed in a future
+ * release.
  */
 public class PollResult {
 
+    private final Iterator<Event> _eventIterator;
     private final List<Event> _events;
     private final boolean _moreEvents;
 
-    public PollResult(List<Event> events, boolean moreEvents) {
-        _events = events;
+    public PollResult(Iterator<Event> eventIterator, int approximateSize, boolean moreEvents) {
+        checkNotNull(eventIterator, "eventIterator");
+        _events = Lists.newArrayListWithCapacity(approximateSize);
         _moreEvents = moreEvents;
+
+        // Wrap the event iterator such that each event returned is appended to the event list
+        _eventIterator = Iterators.transform(eventIterator, event -> {
+            _events.add(event);
+            return event;
+        });
     }
 
+    public Iterator<Event> getEventStream() {
+        return _eventIterator;
+    }
+
+    @Deprecated
     public List<Event> getEvents() {
+        // Iterate over the entire iterator to ensure the event list is completely filled
+        while (_eventIterator.hasNext()) {
+            _eventIterator.next();
+        }
         return _events;
     }
 

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/PollResult.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/PollResult.java
@@ -14,7 +14,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * <ol>
  *     <li>
- *         The an iterator of {@link Event} instances returned from the poll, returned by {@link #getEventStream()}.
+ *         The an iterator of {@link Event} instances returned from the poll, returned by {@link #getEventIterator()}.
  *     </li>
  *     <li>
  *         A boolean indicator for whether there are more events and the caller would benefit from immediately re-polling
@@ -47,7 +47,7 @@ public class PollResult {
         });
     }
 
-    public Iterator<Event> getEventStream() {
+    public Iterator<Event> getEventIterator() {
         return _eventIterator;
     }
 

--- a/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusAuthenticatorProxy.java
+++ b/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusAuthenticatorProxy.java
@@ -16,7 +16,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Databus instance that takes an {@link AuthDatabus} and API key and proxies all calls using the API key.
@@ -90,7 +89,7 @@ class DatabusAuthenticatorProxy implements Databus {
     }
 
     @Override
-    public List<Event> peek(@PartitionKey String subscription, int limit) {
+    public Iterator<Event> peek(@PartitionKey String subscription, int limit) {
         return _authDatabus.peek(_apiKey, subscription, limit);
     }
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/Canary.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/Canary.java
@@ -114,7 +114,7 @@ public class Canary extends AbstractScheduledService {
         List<String> eventKeys = Lists.newArrayList();
         PollResult result = _databus.poll(_subscriptionName, CLAIM_TTL, EVENTS_LIMIT);
         // Get the keys for all events polled.  This also forces resolution of all events for timing metrics
-        Iterator<Event> events = result.getEventStream();
+        Iterator<Event> events = result.getEventIterator();
         while (events.hasNext()) {
             eventKeys.add(events.next().getEventKey());
         }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusFactory.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusFactory.java
@@ -15,7 +15,6 @@ import javax.inject.Inject;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -85,7 +84,7 @@ public class DatabusFactory {
             }
 
             @Override
-            public List<Event> peek(String subscription, int limit) {
+            public Iterator<Event> peek(String subscription, int limit) {
                 return _ownerAwareDatabus.peek(ownerId, subscription, limit);
             }
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -429,7 +429,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, Managed {
         checkSubscriptionOwner(ownerId, subscription);
 
         PollResult result = peekOrPoll(subscription, null, limit);
-        return result.getEventStream();
+        return result.getEventIterator();
     }
 
     @Override
@@ -573,7 +573,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, Managed {
                                         (coord, item) -> {
                                             // Unlike with the original batch the deferred batch's events are always
                                             // already de-duplicated by coordinate, so there is no need to maintain
-                                            // a coordiate-to-item uniqueness map.
+                                            // a coordinate-to-item uniqueness map.
                                             items.add(item);
                                         });
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OwnerAwareDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OwnerAwareDatabus.java
@@ -48,7 +48,7 @@ public interface OwnerAwareDatabus {
     long getClaimCount(String ownerId, String subscription)
         throws UnauthorizedSubscriptionException;
 
-    List<Event> peek(String ownerId, String subscription, int limit)
+    Iterator<Event> peek(String ownerId, String subscription, int limit)
         throws UnauthorizedSubscriptionException;
 
     PollResult poll(String ownerId, String subscription, Duration claimTtl, int limit)

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/TrustedDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/TrustedDatabus.java
@@ -16,7 +16,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -46,7 +45,7 @@ public class TrustedDatabus implements AuthDatabus {
         return _databus.moveAsync(from, to);
     }
 
-    public List<Event> peek(@Credential String apiKey, String subscription, int limit) {
+    public Iterator<Event> peek(@Credential String apiKey, String subscription, int limit) {
         return _databus.peek(subscription, limit);
     }
 

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
@@ -9,6 +9,7 @@ import com.bazaarvoice.emodb.table.db.ClusterInfo;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.joda.time.Duration;
 import org.mockito.ArgumentCaptor;
@@ -85,7 +86,7 @@ public class CanaryTest {
     @Test
     public void testIterationWithNoEvents() throws Exception {
         when(_databus.poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50))
-                .thenReturn(new PollResult(ImmutableList.of(), false));
+                .thenReturn(new PollResult(Iterators.emptyIterator(), 0, false));
 
         _iterationRunnable.run();
 
@@ -102,7 +103,7 @@ public class CanaryTest {
             eventIds.add(eventId);
         }
         when(_databus.poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50))
-                .thenReturn(new PollResult(events, false));
+                .thenReturn(new PollResult(events.iterator(), events.size(), false));
 
         _iterationRunnable.run();
 
@@ -129,9 +130,9 @@ public class CanaryTest {
         }
 
         when(_databus.poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50))
-                .thenReturn(new PollResult(events.get(0), true))
-                .thenReturn(new PollResult(events.get(1), true))
-                .thenReturn(new PollResult(events.get(2), false));
+                .thenReturn(new PollResult(events.get(0).iterator(), events.get(0).size(), true))
+                .thenReturn(new PollResult(events.get(1).iterator(), events.get(1).size(), true))
+                .thenReturn(new PollResult(events.get(2).iterator(), events.get(2).size(), false));
 
         _iterationRunnable.run();
 
@@ -144,9 +145,9 @@ public class CanaryTest {
     @Test
     public void testIterationWithDiscardedEvents() throws Exception {
         when(_databus.poll("__system_bus:canary-cluster", Duration.standardSeconds(30), 50))
-                .thenReturn(new PollResult(ImmutableList.of(), true))
-                .thenReturn(new PollResult(ImmutableList.of(), true))
-                .thenReturn(new PollResult(ImmutableList.of(), false));
+                .thenReturn(new PollResult(Iterators.emptyIterator(), 0, true))
+                .thenReturn(new PollResult(Iterators.emptyIterator(), 0, true))
+                .thenReturn(new PollResult(Iterators.emptyIterator(), 0, false));
 
         _iterationRunnable.run();
 

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
@@ -71,7 +71,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        List<Event> events = result.getEvents();
+        List<Event> events = ImmutableList.copyOf(result.getEventStream());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -102,7 +102,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        List<Event> events = result.getEvents();
+        List<Event> events = ImmutableList.copyOf(result.getEventStream());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -135,7 +135,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        List<Event> events = result.getEvents();
+        List<Event> events = ImmutableList.copyOf(result.getEventStream());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -179,7 +179,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        List<Event> events = result.getEvents();
+        List<Event> events = ImmutableList.copyOf(result.getEventStream());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -237,7 +237,7 @@ public class ConsolidationTest {
 
         // Use a limit of 2 to force multiple calls to the event store.
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 2);
-        List<Event> events = result.getEvents();
+        List<Event> events = ImmutableList.copyOf(result.getEventStream());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -278,7 +278,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(annotatedContent));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 2);
-        assertTrue(result.getEvents().isEmpty());
+        assertFalse(result.getEventStream().hasNext());
         assertFalse(result.hasMoreEvents());
 
         // Since all events came from the same batch from the underlying event store they should all be deleted in one call.
@@ -316,7 +316,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(annotatedContent));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        assertTrue(result.getEvents().isEmpty());
+        assertFalse(result.getEventStream().hasNext());
         assertFalse(result.hasMoreEvents());
 
         // Since each event came from a separate batch from the underlying event store they should each be deleted

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
@@ -71,7 +71,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        List<Event> events = ImmutableList.copyOf(result.getEventStream());
+        List<Event> events = ImmutableList.copyOf(result.getEventIterator());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -102,7 +102,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        List<Event> events = ImmutableList.copyOf(result.getEventStream());
+        List<Event> events = ImmutableList.copyOf(result.getEventIterator());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -135,7 +135,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        List<Event> events = ImmutableList.copyOf(result.getEventStream());
+        List<Event> events = ImmutableList.copyOf(result.getEventIterator());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -179,7 +179,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(content));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        List<Event> events = ImmutableList.copyOf(result.getEventStream());
+        List<Event> events = ImmutableList.copyOf(result.getEventIterator());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -237,7 +237,7 @@ public class ConsolidationTest {
 
         // Use a limit of 2 to force multiple calls to the event store.
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 2);
-        List<Event> events = ImmutableList.copyOf(result.getEventStream());
+        List<Event> events = ImmutableList.copyOf(result.getEventIterator());
 
         Event first = events.get(0);
         assertEquals(first.getContent(), content);
@@ -278,7 +278,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(annotatedContent));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 2);
-        assertFalse(result.getEventStream().hasNext());
+        assertFalse(result.getEventIterator().hasNext());
         assertFalse(result.hasMoreEvents());
 
         // Since all events came from the same batch from the underlying event store they should all be deleted in one call.
@@ -316,7 +316,7 @@ public class ConsolidationTest {
         OwnerAwareDatabus databus = newDatabus(eventStore, new TestDataProvider().add(annotatedContent));
 
         PollResult result = databus.poll("id", "test-subscription", Duration.standardSeconds(30), 1);
-        assertFalse(result.getEventStream().hasNext());
+        assertFalse(result.getEventIterator().hasNext());
         assertFalse(result.hasMoreEvents());
 
         // Since each event came from a separate batch from the underlying event store they should each be deleted

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultDatabusTest.java
@@ -282,7 +282,7 @@ public class DefaultDatabusTest {
         PollResult pollResult = testDatabus.poll("owner", "subscription", Duration.standardMinutes(1), 500);
         assertFalse(pollResult.hasMoreEvents());
 
-        Iterator<Event> events = pollResult.getEventStream();
+        Iterator<Event> events = pollResult.getEventIterator();
         Set<String> actualIds = Sets.newHashSet();
         // Read the entire event list
         while (events.hasNext()) {
@@ -360,7 +360,7 @@ public class DefaultDatabusTest {
         // Padded events will be unclaimed lazily upon iterating over the event list, so verify they haven't been unclaimed yet
         verify(eventStore, never()).renew(anyString(), anyCollectionOf(String.class), any(Duration.class), anyBoolean());
         
-        Iterator<Event> events = pollResult.getEventStream();
+        Iterator<Event> events = pollResult.getEventIterator();
         // Read the entire event list
         Set<String> actualIds = Sets.newHashSet();
         while (events.hasNext()) {

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/TestDataProvider.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/TestDataProvider.java
@@ -6,6 +6,7 @@ import com.bazaarvoice.emodb.sor.api.UnknownTableException;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.emodb.table.db.Table;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -13,6 +14,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -21,6 +24,7 @@ class TestDataProvider implements DataProvider {
     private final Map<String, Table> _cannedTables = Maps.newHashMap();
     private final Map<Coordinate, AnnotatedContent> _cannedContent = Maps.newHashMap();
     private final Map<Coordinate, UnknownTableException> _cannedExceptions = Maps.newHashMap();
+    private final List<List<Coordinate>> _executions = Lists.newArrayList();
 
     public TestDataProvider addTable(String table, Table response) {
         _cannedTables.put(table, response);
@@ -65,6 +69,7 @@ class TestDataProvider implements DataProvider {
 
             @Override
             public Iterator<AnnotatedContent> execute() {
+                _executions.add(_contents.stream().map(AnnotatedContent::getContent).map(Coordinate::fromJson).collect(Collectors.toList()));
                 Collections.shuffle(_contents);
                 return _contents.iterator();
             }
@@ -78,5 +83,9 @@ class TestDataProvider implements DataProvider {
             throw new UnknownTableException(table);
         }
         return response;
+    }
+
+    public List<List<Coordinate>> getExecutions() {
+        return _executions;
     }
 }

--- a/event/src/main/java/com/bazaarvoice/emodb/event/core/DefaultEventStore.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/core/DefaultEventStore.java
@@ -293,6 +293,15 @@ public class DefaultEventStore implements EventStore {
                 // that clients will abuse renew() compared to poll().
 
                 claims.renewAll(toClaimIds(eventIdObjects), claimTtl, extendOnly);
+
+                // If the claim TTL is zero then renewing these events effectively makes them available again immediately
+                if (claimTtl.getMillis() == 0) {
+                    // Mark the events as unread
+                    _readerDao.markUnread(channel, eventIdObjects);
+                    // Remove the channel from the empty cache, or no-op if it wasn't cached as empty
+                    _emptyCache.invalidate(channel);
+                }
+
                 return null;
             }
         });

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/EventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/EventReaderDAO.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.event.db;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 
@@ -30,4 +31,12 @@ public interface EventReaderDAO {
      * @return true if all events were definitely moved, false if some events might not have been moved.
      */
     boolean moveIfFast(String fromChannel, String toChannel);
+
+    /**
+     * Returns events previous read using one of the read operations to the unread state.  This hints to the reader that
+     * if it has cached these events as read then it can clear that cache.  There are no guarantees whether this will
+     * have any effect on the reader, and calling this method on an event that has been deleted via
+     * {@link EventWriterDAO#delete(String, Collection)} has no effect.  
+     */
+    void markUnread(String channel, Collection<EventId> events);
 }

--- a/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
@@ -497,7 +497,7 @@ public class DatabusJerseyTest extends ResourceTest {
             // This is the default poll behavior
             PollResult pollResult = databusClient().poll("queue-name", Duration.standardSeconds(15), 123);
             assertFalse(pollResult.hasMoreEvents());
-            actual = ImmutableList.copyOf(pollResult.getEventStream());
+            actual = ImmutableList.copyOf(pollResult.getEventIterator());
             expected = pollResults;
         } else {
             // Tags won't be returned
@@ -750,7 +750,7 @@ public class DatabusJerseyTest extends ResourceTest {
 
         PollResult actual = databusClient(true).poll("queue-name", Duration.standardSeconds(15), 123);
 
-        assertEquals(ImmutableList.copyOf(actual.getEventStream()), expected);
+        assertEquals(ImmutableList.copyOf(actual.getEventIterator()), expected);
         assertTrue(actual.hasMoreEvents());
         verify(_local).poll(isSubject(), eq("queue-name"), eq(Duration.standardSeconds(15)), eq(123));
         verifyNoMoreInteractions(_local);

--- a/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
@@ -438,7 +438,7 @@ public class DatabusJerseyTest extends ResourceTest {
         List<Event> peekResults = ImmutableList.of(
                 new Event("id-1", ImmutableMap.of("key-1", "value-1"), ImmutableList.<List<String>>of(ImmutableList.<String>of("tag-1"))),
                 new Event("id-2", ImmutableMap.of("key-2", "value-2"), ImmutableList.<List<String>>of(ImmutableList.<String>of("tag-2"))));
-        when(_client.peek(isSubject(), eq("queue-name"), eq(123))).thenReturn(peekResults);
+        when(_client.peek(isSubject(), eq("queue-name"), eq(123))).thenReturn(peekResults.iterator());
 
         List<Event> expected;
         List<Event> actual;
@@ -446,7 +446,7 @@ public class DatabusJerseyTest extends ResourceTest {
         if (includeTags) {
             // This is the default peek behavior
             expected = peekResults;
-            actual = databusClient().peek("queue-name", 123);
+            actual = ImmutableList.copyOf(databusClient().peek("queue-name", 123));
         } else {
             // Tags won't be returned
             expected = ImmutableList.of(
@@ -488,7 +488,7 @@ public class DatabusJerseyTest extends ResourceTest {
                 new Event("id-1", ImmutableMap.of("key-1", "value-1"), ImmutableList.<List<String>>of(ImmutableList.<String>of("tag-1"))),
                 new Event("id-2", ImmutableMap.of("key-2", "value-2"), ImmutableList.<List<String>>of(ImmutableList.<String>of("tag-2"))));
         when(_client.poll(isSubject(), eq("queue-name"), eq(Duration.standardSeconds(15)), eq(123)))
-                .thenReturn(new PollResult(pollResults, false));
+                .thenReturn(new PollResult(pollResults.iterator(), 2, false));
 
         List<Event> expected;
         List<Event> actual;
@@ -497,7 +497,7 @@ public class DatabusJerseyTest extends ResourceTest {
             // This is the default poll behavior
             PollResult pollResult = databusClient().poll("queue-name", Duration.standardSeconds(15), 123);
             assertFalse(pollResult.hasMoreEvents());
-            actual = pollResult.getEvents();
+            actual = ImmutableList.copyOf(pollResult.getEventStream());
             expected = pollResults;
         } else {
             // Tags won't be returned
@@ -542,13 +542,13 @@ public class DatabusJerseyTest extends ResourceTest {
                     Optional.of(new LongPollingExecutorServices(pollService, keepAliveService)), new MetricRegistry());
 
             SubjectDatabus databus = mock(SubjectDatabus.class);
-            List<Event> emptyList = ImmutableList.of();
             List<Event> pollResults = ImmutableList.of(
                     new Event("id-1", ImmutableMap.of("key-1", "value-1"), ImmutableList.<List<String>>of(ImmutableList.<String>of("tag-1"))),
                     new Event("id-2", ImmutableMap.of("key-2", "value-2"), ImmutableList.<List<String>>of(ImmutableList.<String>of("tag-2"))));
             //noinspection unchecked
             when(databus.poll(isSubject(), eq("queue-name"), eq(Duration.standardSeconds(10)), eq(100)))
-                    .thenReturn(new PollResult(emptyList, false), new PollResult(pollResults, true));
+                    .thenReturn(new PollResult(Iterators.emptyIterator(), 0, false))
+                    .thenReturn(new PollResult(pollResults.iterator(), 2, true));
 
             List<Event> expected;
             Class<? extends EventViews.ContentOnly> view;
@@ -646,7 +646,7 @@ public class DatabusJerseyTest extends ResourceTest {
 
             SubjectDatabus databus = mock(SubjectDatabus.class);
             when(databus.poll(isSubject(), eq("queue-name"), eq(Duration.standardSeconds(10)), eq(100)))
-                    .thenReturn(new PollResult(ImmutableList.of(), false))
+                    .thenReturn(new PollResult(Iterators.emptyIterator(), 0, false))
                     .thenThrow(new RuntimeException("Simulated read failure from Cassandra"));
 
             final StringWriter out = new StringWriter();
@@ -746,11 +746,11 @@ public class DatabusJerseyTest extends ResourceTest {
                 new Event("id-1", ImmutableMap.of("key-1", "value-1"), ImmutableList.<List<String>>of()),
                 new Event("id-2", ImmutableMap.of("key-2", "value-2"), ImmutableList.<List<String>>of()));
         when(_local.poll(isSubject(), eq("queue-name"), eq(Duration.standardSeconds(15)), eq(123)))
-                .thenReturn(new PollResult(expected, true));
+                .thenReturn(new PollResult(expected.iterator(), 2, true));
 
         PollResult actual = databusClient(true).poll("queue-name", Duration.standardSeconds(15), 123);
 
-        assertEquals(actual.getEvents(), expected);
+        assertEquals(ImmutableList.copyOf(actual.getEventStream()), expected);
         assertTrue(actual.hasMoreEvents());
         verify(_local).poll(isSubject(), eq("queue-name"), eq(Duration.standardSeconds(15)), eq(123));
         verifyNoMoreInteractions(_local);

--- a/quality/integration/src/test/java/test/integration/sor/SorStressTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/SorStressTest.java
@@ -119,14 +119,14 @@ public class SorStressTest  {
         loop(new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
-                List<Event> events = _databus.poll(SUBSCRIPTION, Duration.standardSeconds(30), 10).getEvents();
-                if (events.isEmpty()) {
+                Iterator<Event> events = _databus.poll(SUBSCRIPTION, Duration.standardSeconds(30), 10).getEventStream();
+                if (!events.hasNext()) {
                     _numIdle.incrementAndGet();
                     return false;  // idle
                 }
                 List<String> eventKeys = Lists.newArrayList();
-                for (Event event : events) {
-                    eventKeys.add(event.getEventKey());
+                while (events.hasNext()) {
+                    eventKeys.add(events.next().getEventKey());
                 }
                 _databus.acknowledge(SUBSCRIPTION, eventKeys);
                 _numReads.addAndGet(eventKeys.size());

--- a/quality/integration/src/test/java/test/integration/sor/SorStressTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/SorStressTest.java
@@ -119,7 +119,7 @@ public class SorStressTest  {
         loop(new Callable<Boolean>() {
             @Override
             public Boolean call() throws Exception {
-                Iterator<Event> events = _databus.poll(SUBSCRIPTION, Duration.standardSeconds(30), 10).getEventStream();
+                Iterator<Event> events = _databus.poll(SUBSCRIPTION, Duration.standardSeconds(30), 10).getEventIterator();
                 if (!events.hasNext()) {
                     _numIdle.incrementAndGet();
                     return false;  // idle

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/ApiKeyAdminTask.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/ApiKeyAdminTask.java
@@ -358,14 +358,16 @@ public class ApiKeyAdminTask extends Task {
 
         String key = getValueFromParams("key", parameters);
         ApiKey apiKey = _authIdentityManager.getIdentity(key);
-        checkArgument(apiKey != null, "Unknown API key");
 
-        // Does the caller have permission to revoke every role from the API key?
-        for (String role : apiKey.getRoles()) {
-            subject.checkPermission(Permissions.grantRole(RoleIdentifier.fromString(role)));
+        if (apiKey != null) {
+            // Does the caller have permission to revoke every role from the API key?
+            for (String role : apiKey.getRoles()) {
+                subject.checkPermission(Permissions.grantRole(RoleIdentifier.fromString(role)));
+            }
+
+            _authIdentityManager.deleteIdentity(key);
         }
-        
-        _authIdentityManager.deleteIdentity(key);
+
         output.println("API key deleted");
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/AbstractSubjectDatabus.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/AbstractSubjectDatabus.java
@@ -16,7 +16,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Base implementation for {@link SubjectDatabus}.
@@ -68,7 +67,7 @@ public abstract class AbstractSubjectDatabus implements SubjectDatabus {
     }
 
     @Override
-    public List<Event> peek(Subject subject, @PartitionKey String subscription, int limit) {
+    public Iterator<Event> peek(Subject subject, @PartitionKey String subscription, int limit) {
         return databus(subject).peek(subscription, limit);
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResource1.java
@@ -203,7 +203,7 @@ public class DatabusResource1 {
         // For backwards compatibility with older clients only include tags if explicitly requested
         // (default is false).
         PeekOrPollResponseHelper helper = getPeekOrPollResponseHelper(includeTags.get());
-        List<Event> events = getClient(partitioned).peek(subject, subscription, limit.get());
+        Iterator<Event> events = getClient(partitioned).peek(subject, subscription, limit.get());
         return Response.ok().entity(helper.asEntity(events)).build();
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResourcePoller.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResourcePoller.java
@@ -1,8 +1,6 @@
 package com.bazaarvoice.emodb.web.resources.databus;
 
 import com.bazaarvoice.emodb.auth.jersey.Subject;
-import com.bazaarvoice.emodb.databus.api.Databus;
-import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.PollResult;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
@@ -11,7 +9,6 @@ import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.inject.Inject;
 import org.joda.time.DateTime;
@@ -24,7 +21,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -149,7 +145,7 @@ public class DatabusResourcePoller {
 
                     // Go ahead and output the response if we either 1.) find events to output, 2.) exceed our time
                     // limit, or 3.) received an exception during the last poll
-                    if (result.getEventStream().hasNext()
+                    if (result.getEventIterator().hasNext()
                             || (System.currentTimeMillis() + LONG_POLL_RETRY_TIME.getMillis()) >= _longPollStopTime
                             || pollFailed) {
                         // Lock the context before writing the response to ensure that the KeepAliveRunnable doesn't
@@ -250,7 +246,7 @@ public class DatabusResourcePoller {
 
     private static void populateResponse(PollResult result, HttpServletResponse response, PeekOrPollResponseHelper helper) {
         try {
-            helper.getJson().writeJson(response.getOutputStream(), result.getEventStream());
+            helper.getJson().writeJson(response.getOutputStream(), result.getEventIterator());
         } catch (IOException ex) {
             _log.error("Failed to write response to the client");
         }
@@ -281,12 +277,12 @@ public class DatabusResourcePoller {
             // response - however, since we use the server-side client we know that it will always execute synchronously
             // itself (no long-polling) and return in a reasonable period of time.
             PollResult result = databus.poll(subject, subscription, claimTtl, limit);
-            if (ignoreLongPoll || result.getEventStream().hasNext() || _keepAliveExecutorService == null || _pollingExecutorService == null) {
+            if (ignoreLongPoll || result.getEventIterator().hasNext() || _keepAliveExecutorService == null || _pollingExecutorService == null) {
                 // If ignoreLongPoll == true or we have no executor services to schedule long-polling on then always
                 // return a response, even if it's empty. Alternatively, if we have data to return - return it!
                 response = Response.ok()
                         .header(POLL_DATABUS_EMPTY_HEADER, String.valueOf(!result.hasMoreEvents()))
-                        .entity(helper.asEntity(result.getEventStream()))
+                        .entity(helper.asEntity(result.getEventIterator()))
                         .build();
             } else {
                 // If the response is empty then go into async-mode and start up the runnables for our long-polling.

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResourcePoller.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResourcePoller.java
@@ -12,6 +12,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
 import com.google.inject.Inject;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -142,13 +143,13 @@ public class DatabusResourcePoller {
                         // We're in an async context and have already returned a 200 response.  Since we can't
                         // retroactively change to 500 finish the request with an empty response and log the error.
                         _log.error("Failed to perform asynchronous poll on subscription {}", _subscription, e);
-                        result = new PollResult(ImmutableList.of(), false);
+                        result = new PollResult(Iterators.emptyIterator(), 0, false);
                         pollFailed = true;
                     }
 
                     // Go ahead and output the response if we either 1.) find events to output, 2.) exceed our time
                     // limit, or 3.) received an exception during the last poll
-                    if (result.getEvents().size() > 0
+                    if (result.getEventStream().hasNext()
                             || (System.currentTimeMillis() + LONG_POLL_RETRY_TIME.getMillis()) >= _longPollStopTime
                             || pollFailed) {
                         // Lock the context before writing the response to ensure that the KeepAliveRunnable doesn't
@@ -249,7 +250,7 @@ public class DatabusResourcePoller {
 
     private static void populateResponse(PollResult result, HttpServletResponse response, PeekOrPollResponseHelper helper) {
         try {
-            helper.getJson().writeJson(response.getOutputStream(), result.getEvents());
+            helper.getJson().writeJson(response.getOutputStream(), result.getEventStream());
         } catch (IOException ex) {
             _log.error("Failed to write response to the client");
         }
@@ -280,12 +281,12 @@ public class DatabusResourcePoller {
             // response - however, since we use the server-side client we know that it will always execute synchronously
             // itself (no long-polling) and return in a reasonable period of time.
             PollResult result = databus.poll(subject, subscription, claimTtl, limit);
-            if (ignoreLongPoll || !result.getEvents().isEmpty() || _keepAliveExecutorService == null || _pollingExecutorService == null) {
+            if (ignoreLongPoll || result.getEventStream().hasNext() || _keepAliveExecutorService == null || _pollingExecutorService == null) {
                 // If ignoreLongPoll == true or we have no executor services to schedule long-polling on then always
                 // return a response, even if it's empty. Alternatively, if we have data to return - return it!
                 response = Response.ok()
                         .header(POLL_DATABUS_EMPTY_HEADER, String.valueOf(!result.hasMoreEvents()))
-                        .entity(helper.asEntity(result.getEvents()))
+                        .entity(helper.asEntity(result.getEventStream()))
                         .build();
             } else {
                 // If the response is empty then go into async-mode and start up the runnables for our long-polling.

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/SubjectDatabus.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/SubjectDatabus.java
@@ -14,7 +14,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Interface for providing owner-aware access to {@link com.bazaarvoice.emodb.databus.api.Databus} using an authenticated
@@ -55,7 +54,7 @@ public interface SubjectDatabus {
 
     long getClaimCount(Subject subject, String subscription);
 
-    List<Event> peek(Subject subject, String subscription, int limit);
+    Iterator<Event> peek(Subject subject, String subscription, int limit);
 
     PollResult poll(Subject subject, String subscription, Duration claimTtl, int limit);
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

A change was introduced recently which does the following on a databus poll for _limit_ events:

- _limit_ events are polled from the event store
- The raw events are resolved in a loop in batches of 10
- If more than 100ms is spent resolving events any remaining events are unclaimed and the events resolved to that point are claimed.

After introducing this change we noticed frequent gatekeeper failures on polls. After investigation the root cause looks like it is in the way events are unclaimed.  An event is unclaimed by renewing it with a zero TTL.  However, there are two places where caching prevents unclaimed events from being immediately returned:

1. If the subscription was cached as empty then the poll will return empty for up to 1 second, even if an event was unclaimed and ready to be polled.
2. The slab cursor is cached at a point after the event in the event store.  This expires in 10 seconds, which means it could be up to 10 seconds before that unclaimed event will be returned by the event store again.

The first of the two commits in this PR addresses these issues by clearing those caches immediately when an event is renewed with a zero TTL.

The second commit in the PR is a larger change.  Instead of relying on the efficient unclaiming of events it reduces overall the need to unclaim events.  Effectively `DefaultDatabus` peek and poll operations have been changed to stream results back rather than return them as a List.  This helps with the goal of the original change, which was not to reduce the number of results returned by a poll but to reduce the time until the first poll result is made available to the API.

Since the databus peek and poll interfaces return a List and not a streaming interface the APIs were changed to return Iterators instead, although in the case of peek() a deprecated method to return List was included for backwards compatibility.  This accounts for most of the files changed, since this update affects numerous interfaces and unit tests.  

## How to Test and Verify

1. Check out this PR
2. Run through a typical battery of databus subscriptions and table updates
3. Ensure everything behaves as expected

## Risk

Because these changes affect databus polling the risk is higher than usual.  However, most of the changes in this PR involve reshuffling existing code to support streaming rather than changing any features of polling.

### Level 

`Medium

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
