### PR TITLE
Fixed broken markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,33 +20,33 @@ persistence and cross-data center replication.
 Documentation
 -------------
 
-[Release Notes] (markdowns/ReleaseNotes.md)
+[Release Notes](markdowns/ReleaseNotes.md)
 
-[System of Record API] (https://bazaarvoice.github.io/emodb/sor/)
+[System of Record API](https://bazaarvoice.github.io/emodb/sor/)
 
-[System of Record Deltas] (https://bazaarvoice.github.io/emodb/deltas/)
+[System of Record Deltas](https://bazaarvoice.github.io/emodb/deltas/)
 
-[Databus API] (https://bazaarvoice.github.io/emodb/databus/)
+[Databus API](https://bazaarvoice.github.io/emodb/databus/)
 
-[BlobStore API] (https://bazaarvoice.github.io/emodb/blobstore/)
+[BlobStore API](https://bazaarvoice.github.io/emodb/blobstore/)
 
-[Queue API] (https://bazaarvoice.github.io/emodb/queue/)
+[Queue API](https://bazaarvoice.github.io/emodb/queue/)
 
-[Stash API] (https://bazaarvoice.github.io/emodb/stash/)
+[Stash API](https://bazaarvoice.github.io/emodb/stash/)
 
-[Hadoop and Hive Support] (https://bazaarvoice.github.io/emodb/mapreduce/)
+[Hadoop and Hive Support](https://bazaarvoice.github.io/emodb/mapreduce/)
 
-[Operations] (markdowns/Operations.md)
+[Operations](markdowns/Operations.md)
 
-[EmoDB SDK] (https://bazaarvoice.github.io/emodb/maven/)
+[EmoDB SDK](https://bazaarvoice.github.io/emodb/maven/)
 
-[API Keys] (https://bazaarvoice.github.io/emodb/security/)
+[API Keys](https://bazaarvoice.github.io/emodb/security/)
 
-[API Key Management] (https://bazaarvoice.github.io/emodb/securityadmin/)
+[API Key Management](https://bazaarvoice.github.io/emodb/securityadmin/)
 
-[Legacy Java Client Support] (markdowns/LegacyJavaClients.md)
+[Legacy Java Client Support](markdowns/LegacyJavaClients.md)
 
 Quick Start
 -----------
 
-[Quick Start Guide] (https://bazaarvoice.github.io/emodb/quickstart/)
+[Quick Start Guide](https://bazaarvoice.github.io/emodb/quickstart/)


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

GitHub recently switched to a stricter markdown renderer, and now all of the links on the README page look terrible.  This PR removes the extra space in the links which was causing the problem.

## How to Test and Verify

1. Check out this PR
2. Just look at README.md
3. There is no step 3

## Risk

None, only the README is updated.

### Level 

`Low`

### Required Testing

`Smoke`

### Risk Summary

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
