### PR TITLE
EMO-6249: Introduced basic event tracing for replay and move databus operations

### DIFF
--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/AuthDatabus.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/AuthDatabus.java
@@ -79,19 +79,28 @@ public interface AuthDatabus {
     void acknowledge(@Credential String apiKey, String subscription, Collection<String> eventKeys);
 
     /**
-     * Replays events from the last two days for the given subscription.  This method returns immediately with
-     * a reference that can be used to query the progress of the replay.
+     * Replays events from the last two days for the given subscription.  Functionally equivalent to:
+     * <code>
+     *     replayAsync(apiKey, new ReplaySubscriptionRequest(subscription))
+     * </code>
      */
     String replayAsync(@Credential String apiKey, String subscription);
+
+    /**
+     * Replays events since a given timestamp within the last two days for the given subscription.  Functionally equivalent to:
+     * <code>
+     *     replayAsync(apiKey, new ReplaySubscriptionRequest(subscription).since(since))
+     * </code>
+     */
+    String replayAsyncSince(@Credential String apiKey, String subscription, Date since);
 
     /**
      * Replays events since a given timestamp within the last two days for the given subscription.
      * This method returns immediately with a reference that can be used to query the progress of the replay.
      * NOTE: This may replay some extra events that are before the 'since' timestamp (no more than 999 previous events),
      + but guarantees that any events on or after 'since' will be replayed.
-     * @param since Specifies timestamp since when the events will be replayed (inclusive)
      */
-    String replayAsyncSince(@Credential String apiKey, String subscription, Date since);
+    String replayAsync(@Credential String apiKey, ReplaySubscriptionRequest request);
 
     /**
      * Checks the status of a replay operation.  If the reference is unknown or the replay failed then this method will
@@ -100,13 +109,20 @@ public interface AuthDatabus {
     ReplaySubscriptionStatus getReplayStatus(@Credential String apiKey, String reference);
 
     /**
+     * Moves events from one subscription to another.  Functionally equivalent to:
+     * <code>
+     *     moveAsync(apiKey, new MoveSubscriptionReqeust(from, to))
+     * </code>
+     */
+    String moveAsync(@Credential String apiKey, String from, String to);
+
+    /**
      * Moves events from one subscription to another.  This moves all currently un-acked events and does not filter
      * by the destination subscription table filter.  Future events are not affected.  No guarantees are made
      * regarding event TTLs--an event about to expire may or may not have its TTL reset.
      * This method returns immediately with a reference that can be used to query the progress of the move.
      */
-    String moveAsync(@Credential String apiKey, String from, String to);
-
+    String moveAsync(@Credential String apiKey, MoveSubscriptionRequest request);
     /**
      * Checks the status of a move operation.  If the reference is unknown or the move failed then this method will throw an exception.
      */

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/BlobCSVEventTracerSpec.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/BlobCSVEventTracerSpec.java
@@ -1,0 +1,90 @@
+package com.bazaarvoice.emodb.databus.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import org.joda.time.Duration;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * {@link DatabusEventTracerSpec} implementation which writes the event trace to a CSV file, which is then persisted in
+ * the blob store.  By default documents are written gzipped with a 14-day TTL, although both of these can be
+ * overridden in the spec.
+ *
+ * Columns in the resulting CSV are, by position:
+ *
+ * <ol>
+ *     <li>Original document change ID</li>
+ *     <li>Document change timestamp</li>
+ *     <li>table</li>
+ *     <li>key</li>
+ *     <li>trace comment, typically debug information about how the change was included in the requested operation</li>
+ * </ol>
+ */
+@JsonTypeName("blob")
+public class BlobCSVEventTracerSpec implements DatabusEventTracerSpec {
+
+    private final String _table;
+    private final String _blobId;
+    private boolean _gzipped = true;
+    private Duration _ttl = Duration.standardDays(14);
+
+    @JsonCreator
+    public BlobCSVEventTracerSpec(@JsonProperty("table") String table, @JsonProperty("blobId") String blobId) {
+        _table = checkNotNull(table, "table");
+        _blobId = checkNotNull(blobId, "blobId");
+    }
+
+    public String getTable() {
+        return _table;
+    }
+
+    public String getBlobId() {
+        return _blobId;
+    }
+
+    public boolean isGzipped() {
+        return _gzipped;
+    }
+
+    @JsonProperty("gzipped")
+    public BlobCSVEventTracerSpec gzipped(boolean gzipped) {
+        _gzipped = gzipped;
+        return this;
+    }
+
+    public Duration getTtl() {
+        return _ttl;
+    }
+
+    @JsonProperty("ttl")
+    public BlobCSVEventTracerSpec ttl(Duration ttl) {
+        _ttl = ttl;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BlobCSVEventTracerSpec)) {
+            return false;
+        }
+
+        BlobCSVEventTracerSpec that = (BlobCSVEventTracerSpec) o;
+
+        return _gzipped == that.isGzipped() &&
+                _table.equals(that.getTable()) &&
+                _blobId.equals(that.getBlobId()) &&
+                Objects.equals(_ttl, that.getTtl());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_table, _blobId, _gzipped, _ttl);
+    }
+}

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Databus.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Databus.java
@@ -87,19 +87,28 @@ public interface Databus {
     void acknowledge(String subscription, Collection<String> eventKeys);
 
     /**
-     * Replays events from the last two days for the given subscription.  This method returns immediately with
-     * a reference that can be used to query the progress of the replay.
+     * Replays events from the last two days for the given subscription.    Functionally equivalent to:
+     * <code>
+     *     replayAsync(new ReplaySubscriptionRequest(subscription))
+     * </code>
      */
     String replayAsync(String subscription);
+
+    /**
+     * Replays events since the given timestamp within the last two days for the given subscription.  Functionally equivalent to:
+     * <code>
+     *     replayAsync(new ReplaySubscriptionRequest(subscription).since(since))
+     * </code>
+     */
+    String replayAsyncSince(String subscription, Date since);
 
     /**
      * Replays events since the given timestamp within the last two days for the given subscription.
      * This method returns immediately with a reference that can be used to query the progress of the replay.
      * NOTE: This may replay some extra events that are before the 'since' timestamp (no more than 999 previous events),
      * but guarantees that any events on or after 'since' will be replayed.
-     * @param since Specifies timestamp since when the events will be replayed (inclusive)
      */
-    String replayAsyncSince(String subscription, Date since);
+    String replayAsync(ReplaySubscriptionRequest request);
 
     /**
      * Checks the status of a replay operation.  If the reference is unknown or the replay failed then this method will
@@ -108,12 +117,20 @@ public interface Databus {
     ReplaySubscriptionStatus getReplayStatus(String reference);
 
     /**
+     * Moves events from one subscription to another.  Functionally equivalent to:
+     * <code>
+     *     moveAsync(new MoveSubscriptionReqeust(from, to))
+     * </code>
+     */
+    String moveAsync(String from, String to);
+
+    /**
      * Moves events from one subscription to another.  This moves all currently un-acked events and does not filter
      * by the destination subscription table filter.  Future events are not affected.  No guarantees are made
      * regarding event TTLs--an event about to expire may or may not have its TTL reset.
      * This method returns immediately with a reference that can be used to query the progress of the move.
      */
-    String moveAsync(String from, String to);
+    String moveAsync(MoveSubscriptionRequest request);
 
     /**
      * Checks the status of a move operation.  If the reference is unknown or the move failed then this method will throw an exception.

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DatabusEventTracerSpec.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DatabusEventTracerSpec.java
@@ -1,0 +1,15 @@
+package com.bazaarvoice.emodb.databus.api;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Specification for tracing events for databus move and replay operations.  When tracing each event which is moved
+ * or replayed is inserted into a trace log.  The nature of the trace log is dependent on the spec.
+ */
+@JsonTypeInfo (use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property="type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value=BlobCSVEventTracerSpec.class)
+})
+public interface DatabusEventTracerSpec {
+}

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/MoveSubscriptionRequest.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/MoveSubscriptionRequest.java
@@ -1,0 +1,52 @@
+package com.bazaarvoice.emodb.databus.api;
+
+/**
+ * Request object for moving all content from one databus subscription into another, as used by
+ * {@link Databus#moveAsync(MoveSubscriptionRequest)}.  The only required attributes are "from" and "to.
+ * 
+ * @see Databus#moveAsync(MoveSubscriptionRequest)
+ */
+public class MoveSubscriptionRequest {
+
+    private String _from;
+    private String _to;
+    private DatabusEventTracerSpec _tracer;
+
+    /**
+     * Empty constructor.  If used the caller must at some point call {@link #from(String)} and {@link #to(String)}.
+     */
+    public MoveSubscriptionRequest() {
+    }
+
+    public MoveSubscriptionRequest(String from, String to) {
+        from(from);
+        to(to);
+    }
+
+    public MoveSubscriptionRequest from(String from) {
+        _from = from;
+        return this;
+    }
+
+    public MoveSubscriptionRequest to(String to) {
+        _to = to;
+        return this;
+    }
+
+    public MoveSubscriptionRequest withTracing(DatabusEventTracerSpec tracer) {
+        _tracer = tracer;
+        return this;
+    }
+
+    public String getFrom() {
+        return _from;
+    }
+
+    public String getTo() {
+        return _to;
+    }
+
+    public DatabusEventTracerSpec getTracer() {
+        return _tracer;
+    }
+}

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/ReplaySubscriptionRequest.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/ReplaySubscriptionRequest.java
@@ -1,0 +1,51 @@
+package com.bazaarvoice.emodb.databus.api;
+
+import java.util.Date;
+
+/**
+ * Request object for replaying all content from up to the past two days into a subscription, as used by
+ * {@link Databus#replayAsync(ReplaySubscriptionRequest)}.  The only required attribute is "subscription".
+ *
+ * @see Databus#replayAsync(ReplaySubscriptionRequest)
+ */
+public class ReplaySubscriptionRequest {
+
+    private String _subscription;
+    private Date _since;
+    private DatabusEventTracerSpec _tracer;
+
+    public ReplaySubscriptionRequest() {
+        // empty
+    }
+
+    public ReplaySubscriptionRequest(String subscription) {
+        subscription(subscription);
+    }
+
+    public ReplaySubscriptionRequest subscription(String subscription) {
+        _subscription = subscription;
+        return this;
+    }
+
+    public ReplaySubscriptionRequest since(Date since) {
+        _since = since;
+        return this;
+    }
+
+    public ReplaySubscriptionRequest withTracing(DatabusEventTracerSpec tracer) {
+        _tracer = tracer;
+        return this;
+    }
+
+    public String getSubscription() {
+        return _subscription;
+    }
+
+    public Date getSince() {
+        return _since;
+    }
+
+    public DatabusEventTracerSpec getTracer() {
+        return _tracer;
+    }
+}

--- a/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusAuthenticatorProxy.java
+++ b/databus-client-common/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusAuthenticatorProxy.java
@@ -3,8 +3,10 @@ package com.bazaarvoice.emodb.databus.client;
 import com.bazaarvoice.emodb.databus.api.AuthDatabus;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.api.MoveSubscriptionRequest;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.PollResult;
+import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionRequest;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -69,6 +71,11 @@ class DatabusAuthenticatorProxy implements Databus {
     }
 
     @Override
+    public String moveAsync(MoveSubscriptionRequest request) {
+        return _authDatabus.moveAsync(_apiKey, request);
+    }
+
+    @Override
     public void unclaimAll(@PartitionKey String subscription) {
         _authDatabus.unclaimAll(_apiKey, subscription);
     }
@@ -121,6 +128,11 @@ class DatabusAuthenticatorProxy implements Databus {
     @Override
     public String replayAsyncSince(String subscription, Date since) {
         return _authDatabus.replayAsyncSince(_apiKey, subscription, since);
+    }
+
+    @Override
+    public String replayAsync(ReplaySubscriptionRequest request) {
+        return _authDatabus.replayAsync(_apiKey, request);
     }
 
     @Override

--- a/databus/pom.xml
+++ b/databus/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>emodb-auth-client</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.bazaarvoice.emodb</groupId>
+            <artifactId>emodb-blob-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- 3rd-party dependencies -->
         <dependency>

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
@@ -38,6 +38,7 @@ import com.bazaarvoice.emodb.databus.repl.DefaultReplicationManager;
 import com.bazaarvoice.emodb.databus.repl.DefaultReplicationSource;
 import com.bazaarvoice.emodb.databus.repl.ReplicationEnabledTask;
 import com.bazaarvoice.emodb.databus.repl.ReplicationSource;
+import com.bazaarvoice.emodb.databus.tracer.DatabusEventTracerFactory;
 import com.bazaarvoice.emodb.event.DedupEnabled;
 import com.bazaarvoice.emodb.event.EventStoreHostDiscovery;
 import com.bazaarvoice.emodb.event.EventStoreModule;
@@ -99,6 +100,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  * <li> DataStore {@link DataStoreConfiguration}
  * <li> {@link com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer}
  * <li> @{@link DefaultJoinFilter} Supplier&lt;{@link Condition}&gt;
+ * <li> {@link com.bazaarvoice.emodb.blob.api.BlobStore}
  * <li> {@link Clock}
  * </ul>
  * Exports the following:
@@ -151,7 +153,8 @@ public class DatabusModule extends PrivateModule {
         bind(RateLimitedLogFactory.class).to(DefaultRateLimitedLogFactory.class).asEagerSingleton();
         bind(SubscriptionEvaluator.class).asEagerSingleton();
         bind(DedupMigrationTask.class).asEagerSingleton();
-
+        bind(DatabusEventTracerFactory.class).asEagerSingleton();
+        
         // Expose the event store directly for use by debugging APIs
         bind(DatabusEventStore.class).asEagerSingleton();
         expose(DatabusEventStore.class);

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusFactory.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusFactory.java
@@ -2,8 +2,10 @@ package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.api.MoveSubscriptionRequest;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.PollResult;
+import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionRequest;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -105,12 +107,18 @@ public class DatabusFactory {
 
             @Override
             public String replayAsync(String subscription) {
-                return _ownerAwareDatabus.replayAsync(ownerId, subscription);
+                return replayAsync(new ReplaySubscriptionRequest(subscription));
             }
 
             @Override
             public String replayAsyncSince(String subscription, Date since) {
-                return _ownerAwareDatabus.replayAsyncSince(ownerId, subscription, since);
+                return replayAsync(new ReplaySubscriptionRequest(subscription).since(since));
+            }
+
+            @Override
+            public String replayAsync(ReplaySubscriptionRequest request) {
+                return _ownerAwareDatabus.replayAsyncSince(
+                        ownerId, request.getSubscription(), request.getSince(), request.getTracer());
             }
 
             @Override
@@ -120,7 +128,12 @@ public class DatabusFactory {
 
             @Override
             public String moveAsync(String from, String to) {
-                return _ownerAwareDatabus.moveAsync(ownerId, from, to);
+                return moveAsync(new MoveSubscriptionRequest(from, to));
+            }
+
+            @Override
+            public String moveAsync(MoveSubscriptionRequest request) {
+                return _ownerAwareDatabus.moveAsync(ownerId, request.getFrom(), request.getTo(), request.getTracer());
             }
 
             @Override

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DedupMigrationTask.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DedupMigrationTask.java
@@ -122,7 +122,7 @@ public class DedupMigrationTask extends Task {
         out.flush();
 
         try {
-            _eventStore.moveToRawChannel(queue, queue);
+            _eventStore.moveToRawChannel(queue, queue, null);
             out.println(" COMPLETE");
         } catch (ReadOnlyQueueException e) {
             out.println(" skipped");

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/MoveSubscriptionRequest.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/MoveSubscriptionRequest.java
@@ -1,7 +1,10 @@
 package com.bazaarvoice.emodb.databus.core;
 
+import com.bazaarvoice.emodb.databus.api.DatabusEventTracerSpec;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -10,6 +13,8 @@ public class MoveSubscriptionRequest {
     private final String _ownerId;
     private final String _from;
     private final String _to;
+    @Nullable
+    private DatabusEventTracerSpec _tracer;
 
     @JsonCreator
     public MoveSubscriptionRequest(@JsonProperty ("ownerId") String ownerId,
@@ -30,5 +35,14 @@ public class MoveSubscriptionRequest {
 
     public String getTo() {
         return _to;
+    }
+
+    @Nullable
+    public DatabusEventTracerSpec getTracer() {
+        return _tracer;
+    }
+
+    public void setTracer(DatabusEventTracerSpec tracer) {
+        _tracer = tracer;
     }
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OwnerAwareDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OwnerAwareDatabus.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.databus.core;
 
+import com.bazaarvoice.emodb.databus.api.DatabusEventTracerSpec;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.PollResult;
@@ -14,7 +15,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Parallel interface for {@link com.bazaarvoice.emodb.databus.api.Databus} that includes the owner's internal ID
@@ -60,16 +60,13 @@ public interface OwnerAwareDatabus {
     void acknowledge(String ownerId, String subscription, Collection<String> eventKeys)
         throws UnauthorizedSubscriptionException;
 
-    String replayAsync(String ownerId, String subscription)
-        throws UnauthorizedSubscriptionException;
-
-    String replayAsyncSince(String ownerId, String subscription, Date since)
+    String replayAsyncSince(String ownerId, String subscription, Date since, DatabusEventTracerSpec tracer)
         throws UnauthorizedSubscriptionException;
 
     ReplaySubscriptionStatus getReplayStatus(String ownerId, String reference)
         throws UnauthorizedSubscriptionException;
 
-    String moveAsync(String ownerId, String from, String to)
+    String moveAsync(String ownerId, String from, String to, DatabusEventTracerSpec tracer)
         throws UnauthorizedSubscriptionException;
 
     MoveSubscriptionStatus getMoveStatus(String ownerId, String reference)

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/ReplaySubscriptionRequest.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/ReplaySubscriptionRequest.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.databus.core;
 
+import com.bazaarvoice.emodb.databus.api.DatabusEventTracerSpec;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -18,6 +19,8 @@ public class ReplaySubscriptionRequest {
     private String _subscription;
     @Nullable
     private Date _since;
+    @Nullable
+    private DatabusEventTracerSpec _tracer;
 
     @JsonCreator
     public ReplaySubscriptionRequest(@JsonProperty ("ownerId") String ownerId,
@@ -38,5 +41,14 @@ public class ReplaySubscriptionRequest {
 
     public Date getSince() {
         return _since;
+    }
+
+    @Nullable
+    public DatabusEventTracerSpec getTracer() {
+        return _tracer;
+    }
+
+    public void setTracer(@Nullable DatabusEventTracerSpec tracer) {
+        _tracer = tracer;
     }
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/TrustedDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/TrustedDatabus.java
@@ -4,8 +4,10 @@ import com.bazaarvoice.emodb.auth.proxy.Credential;
 import com.bazaarvoice.emodb.databus.api.AuthDatabus;
 import com.bazaarvoice.emodb.databus.api.Databus;
 import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.api.MoveSubscriptionRequest;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.PollResult;
+import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionRequest;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -45,6 +47,11 @@ public class TrustedDatabus implements AuthDatabus {
         return _databus.moveAsync(from, to);
     }
 
+    @Override
+    public String moveAsync(@Credential String apiKey, MoveSubscriptionRequest request) {
+        return _databus.moveAsync(request);
+    }
+
     public Iterator<Event> peek(@Credential String apiKey, String subscription, int limit) {
         return _databus.peek(subscription, limit);
     }
@@ -60,6 +67,11 @@ public class TrustedDatabus implements AuthDatabus {
     @Override
     public String replayAsync(@Credential String apiKey, String subscription) {
         return _databus.replayAsync(subscription);
+    }
+
+    @Override
+    public String replayAsync(@Credential String apiKey, ReplaySubscriptionRequest request) {
+        return _databus.replayAsync(request);
     }
 
     @Override

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/tracer/BlobCSVEventTracer.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/tracer/BlobCSVEventTracer.java
@@ -1,0 +1,93 @@
+package com.bazaarvoice.emodb.databus.tracer;
+
+import com.bazaarvoice.emodb.blob.api.BlobStore;
+import com.bazaarvoice.emodb.databus.api.BlobCSVEventTracerSpec;
+import com.bazaarvoice.emodb.event.api.EventTracer;
+import com.bazaarvoice.emodb.event.tracer.CSVEventTracer;
+import com.bazaarvoice.emodb.sor.api.UnknownTableException;
+import com.google.common.base.Charsets;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.ByteBuffer;
+import java.util.zip.GZIPOutputStream;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * {@link EventTracer} implementation which writes the results of a event tracer as a CSV in the blob store.
+ * This works by writing the CSV to a local temporary file.  When the trace is closed the file is then copied to the
+ * blob store and deleted.  The CSV file can optionally be gzipped and/or have a limited TTL.
+ */
+public class BlobCSVEventTracer implements EventTracer {
+
+    private final Logger _log = LoggerFactory.getLogger(getClass());
+
+    private final BlobStore _blobStore;
+    private final String _table;
+    private final String _blobId;
+    private final boolean _gzipped;
+    private final Duration _ttl;
+    private File _tmpFile;
+    private CSVEventTracer _csvEventTracer;
+
+    public BlobCSVEventTracer(BlobStore blobStore, BlobCSVEventTracerSpec spec) {
+        this(blobStore, spec.getTable(), spec.getBlobId(), spec.getTtl(), spec.isGzipped());
+    }
+
+    public BlobCSVEventTracer(BlobStore blobStore, String table, String blobId, @Nullable Duration ttl, boolean gzipped) {
+        _blobStore = checkNotNull(blobStore, "blobStore");
+        _table = checkNotNull(table, "table");
+        _blobId = checkNotNull(blobId, "blobId");
+        _ttl = ttl;
+        _gzipped = gzipped;
+    }
+
+    @Override
+    public void trace(String source, ByteBuffer data) {
+        if (_tmpFile == null) {
+            try {
+                _tmpFile = File.createTempFile("emo", ".tmp");
+                OutputStream out = new FileOutputStream(_tmpFile);
+                if (_gzipped) {
+                    out = new GZIPOutputStream(out);
+                }
+                _csvEventTracer = new DatabusCSVEventTracer(new OutputStreamWriter(out, Charsets.UTF_8), true);
+            } catch (IOException e) {
+                throw Throwables.propagate(e);
+            }
+        }
+
+        _csvEventTracer.trace(source, data);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (_tmpFile != null) {
+            try {
+                _csvEventTracer.close();
+                _blobStore.put(_table, _blobId, Files.asByteSource(_tmpFile), ImmutableMap.of(), _ttl);
+            } catch (UnknownTableException e) {
+                // For this specific exception log the problem locally; don't pass up to the caller.
+                _log.warn("Blob trace attempted to store results in unknown table: {}", _table);
+            } catch(Exception e){
+                Throwables.propagateIfInstanceOf(e, IOException.class);
+                throw Throwables.propagate(e);
+            } finally{
+                if (_tmpFile != null) {
+                    _tmpFile.delete();
+                }
+            }
+        }
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/tracer/DatabusCSVEventTracer.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/tracer/DatabusCSVEventTracer.java
@@ -1,0 +1,44 @@
+package com.bazaarvoice.emodb.databus.tracer;
+
+import com.bazaarvoice.emodb.common.json.ISO8601DateFormat;
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.databus.core.UpdateRefSerializer;
+import com.bazaarvoice.emodb.event.tracer.CSVEventTracer;
+import com.bazaarvoice.emodb.sor.core.UpdateRef;
+import com.google.common.collect.ImmutableList;
+
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.text.DateFormat;
+import java.util.List;
+
+/**
+ * Extension of {@link CSVEventTracer} for writing databus events.  Columns are, by position:
+ *
+ * <ol>
+ *     <li>Original document change ID</li>
+ *     <li>Document change timestamp</li>
+ *     <li>table</li>
+ *     <li>key</li>
+ *     <li>source</li>
+ * </ol>
+ */
+public class DatabusCSVEventTracer extends CSVEventTracer {
+
+    private final DateFormat _dateFormat = ISO8601DateFormat.getInstance();
+
+    public DatabusCSVEventTracer(Writer out, boolean closeWriterOnClose) {
+        super(out, closeWriterOnClose);
+    }
+
+    @Override
+    protected List<Object> toColumns(String source, ByteBuffer data) {
+        UpdateRef ref = UpdateRefSerializer.fromByteBuffer(data);
+        return ImmutableList.of(
+                ref.getChangeId(),
+                _dateFormat.format(TimeUUIDs.getDate(ref.getChangeId())),
+                ref.getTable(),
+                ref.getKey(),
+                source);
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/tracer/DatabusEventTracerFactory.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/tracer/DatabusEventTracerFactory.java
@@ -1,0 +1,34 @@
+package com.bazaarvoice.emodb.databus.tracer;
+
+import com.bazaarvoice.emodb.blob.api.BlobStore;
+import com.bazaarvoice.emodb.databus.api.BlobCSVEventTracerSpec;
+import com.bazaarvoice.emodb.databus.api.DatabusEventTracerSpec;
+import com.bazaarvoice.emodb.event.api.EventTracer;
+import com.google.inject.Inject;
+
+/**
+ * Factory for producing {@link EventTracer} instances from {@link DatabusEventTracerSpec} specifications.
+ * Current implementation supports a single specification, {@link BlobCSVEventTracerSpec}.
+ */
+public class DatabusEventTracerFactory {
+
+    private final BlobStore _blobStore;
+
+    @Inject
+    public DatabusEventTracerFactory(BlobStore blobStore) {
+        _blobStore = blobStore;
+    }
+
+    public EventTracer createTracer(DatabusEventTracerSpec spec) {
+        if (spec == null) {
+            return null;
+        }
+
+        if (spec instanceof BlobCSVEventTracerSpec) {
+            BlobCSVEventTracerSpec blobSpec = (BlobCSVEventTracerSpec) spec;
+            return new BlobCSVEventTracer(_blobStore, blobSpec);
+        }
+
+        throw new IllegalArgumentException("Unsupported tracer specification: " + spec.getClass());
+    }
+}

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.databus;
 
+import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
 import com.bazaarvoice.emodb.common.cassandra.CassandraConfiguration;
 import com.bazaarvoice.emodb.common.cassandra.KeyspaceConfiguration;
@@ -112,7 +113,8 @@ public class DatabusModuleTest {
                 bind(new TypeLiteral<Supplier<Condition>>(){}).annotatedWith(DefaultJoinFilter.class)
                         .toInstance(Suppliers.ofInstance(Conditions.alwaysFalse()));
                 bind(DatabusAuthorizer.class).toInstance(mock(DatabusAuthorizer.class));
-
+                bind(BlobStore.class).toInstance(mock(BlobStore.class));
+                
                 MetricRegistry metricRegistry = new MetricRegistry();
                 bind(MetricRegistry.class).toInstance(metricRegistry);
                 bind(Clock.class).toInstance(mock(Clock.class));

--- a/event/src/main/java/com/bazaarvoice/emodb/event/api/BaseEventStore.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/api/BaseEventStore.java
@@ -4,6 +4,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Multimap;
 import org.joda.time.Duration;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Date;
@@ -48,10 +49,10 @@ public interface BaseEventStore {
      * Copies events matching the specified predicate from one channel to another.
      * If a non-null "since" timestamp is provided, only events since that time will be copied.
      */
-    void copy(String from, String to, Predicate<ByteBuffer> filter, Date since);
+    void copy(String from, String to, Predicate<ByteBuffer> filter, Date since, @Nullable EventTracer tracer);
 
     /** Moves all events from one channel to another. */
-    void move(String from, String to);
+    void move(String from, String to, @Nullable EventTracer trace);
 
     void unclaimAll(String channel);
 

--- a/event/src/main/java/com/bazaarvoice/emodb/event/api/DedupEventStore.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/api/DedupEventStore.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.event.api;
 
 import com.google.common.base.Predicate;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Date;
 
@@ -16,8 +17,8 @@ public interface DedupEventStore extends BaseEventStore {
      * Copies events matching the specified predicate from a non-dedup'd channel to a dedup'd channel.
      * If a non-null "since" timestamp is non-null, only events since that time will be copied.
      */
-    void copyFromRawChannel(String from, String to, Predicate<ByteBuffer> filter, Date since);
+    void copyFromRawChannel(String from, String to, Predicate<ByteBuffer> filter, Date since, @Nullable EventTracer tracer);
 
     /** Moves all data from a dedup'd channel to a non-dedup'd channel. */
-    void moveToRawChannel(String from, String to);
+    void moveToRawChannel(String from, String to, @Nullable EventTracer tracer);
 }

--- a/event/src/main/java/com/bazaarvoice/emodb/event/api/EventTracer.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/api/EventTracer.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.event.api;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+
+/**
+ * Some operations, such as moving events from one source to another, are black boxed by nature such that the caller
+ * gets little insight into the operation other than when it completes.  Where supported, some operations take an optional
+ * EventTracer which can be used to trace those events which are acted upon by the operation.  What happens to the
+ * events which are traced -- such as writing to a log file -- is up to the implementation.
+ */
+public interface EventTracer extends Closeable {
+
+    /**
+     * Primary interface for tracing that an event is being acted upon.
+     * @param source Brief string description for how the event got included in the operation
+     * @param data Context-specific event data
+     */
+    void trace(String source, ByteBuffer data);
+}

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/EventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/EventReaderDAO.java
@@ -1,5 +1,7 @@
 package com.bazaarvoice.emodb.event.db;
 
+import com.bazaarvoice.emodb.event.api.EventTracer;
+
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Date;
@@ -30,7 +32,7 @@ public interface EventReaderDAO {
      * individual event data.  At best this will move all the events, at worst it will move zero events.
      * @return true if all events were definitely moved, false if some events might not have been moved.
      */
-    boolean moveIfFast(String fromChannel, String toChannel);
+    boolean moveIfFast(String fromChannel, String toChannel, @Nullable EventTracer tracer);
 
     /**
      * Returns events previous read using one of the read operations to the unread state.  This hints to the reader that

--- a/event/src/main/java/com/bazaarvoice/emodb/event/tracer/CSVEventTracer.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/tracer/CSVEventTracer.java
@@ -1,0 +1,65 @@
+package com.bazaarvoice.emodb.event.tracer;
+
+import com.bazaarvoice.emodb.event.api.EventTracer;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Throwables;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Helper base implementation of {@link EventTracer} which streams the trace content to a CSV.  Subclasses must implement
+ * the method for converting raw event bytes into CSV columns.
+ */
+abstract public class CSVEventTracer implements EventTracer {
+
+    private final Writer _out;
+    private final boolean _closeWriterOnClose;
+    private final CharMatcher _requiresEscapeMatcher = CharMatcher.anyOf("\",");
+
+    public CSVEventTracer(Writer out, boolean closeWriterOnClose) {
+        _out = checkNotNull(out, "out");
+        _closeWriterOnClose = closeWriterOnClose;
+    }
+
+    /**
+     * Given the event source and data from a call to {@link #trace(String, ByteBuffer)}, return the CSV columns in
+     * order of inclusion.
+     */
+    abstract protected List<Object> toColumns(String source, ByteBuffer data);
+
+    @Override
+    public void trace(String source, ByteBuffer data) {
+        try {
+            for (Iterator<Object> columnIterator = toColumns(source, data).iterator(); columnIterator.hasNext(); ) {
+                Object column = columnIterator.next();
+                if (column != null) {
+                    String value = column.toString();
+                    if (_requiresEscapeMatcher.matchesAnyOf(value)) {
+                        value = String.format("\"%s\"", value.replaceAll("\"", "\"\""));
+                    }
+                    _out.write(value);
+                }
+                if (columnIterator.hasNext()) {
+                    _out.write(",");
+                }
+            }
+            _out.write("\n");
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (_closeWriterOnClose) {
+            _out.flush();
+            _out.close();
+        }
+    }
+}

--- a/event/src/main/java/com/bazaarvoice/emodb/event/tracer/SafeEventTracer.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/tracer/SafeEventTracer.java
@@ -1,0 +1,53 @@
+package com.bazaarvoice.emodb.event.tracer;
+
+import com.bazaarvoice.emodb.event.api.EventTracer;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * {@link EventTracer} implementation which catches all exceptions on each tracer call, logs the exception, then
+ * returns control to the caller.  By delegating an EventTracer to a SafeEventTracer instance the caller can be assured
+ * that any tracing failures will not cause the more important overall operation to fail.
+ */
+public class SafeEventTracer implements EventTracer {
+
+    private final EventTracer _eventTracer;
+    private final Logger _log;
+
+    public SafeEventTracer(EventTracer eventTracer) {
+        this(eventTracer, null);
+    }
+
+    public SafeEventTracer(EventTracer eventTracer, @Nullable Logger log) {
+        _eventTracer = checkNotNull(eventTracer, "eventTracer");
+        _log = log;
+    }
+
+    @Override
+    public void trace(String source, ByteBuffer data) {
+        try {
+            _eventTracer.trace(source, data.asReadOnlyBuffer());
+        } catch (Exception e) {
+            if (_log != null) {
+                _log.warn("Failed to trace event: data={}", ByteBufferUtil.bytesToHex(data), e);
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            _eventTracer.close();
+        } catch (Exception e) {
+            if (_log != null) {
+                _log.warn("Failed to close tracer", e);
+            }
+        }
+    }
+}

--- a/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
@@ -1,5 +1,6 @@
 package test.integration.databus;
 
+import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.cachemgr.CacheManagerModule;
 import com.bazaarvoice.emodb.cachemgr.invalidate.InvalidationService;
 import com.bazaarvoice.emodb.common.cassandra.CassandraConfiguration;
@@ -117,7 +118,8 @@ public class CasDatabusTest {
                                 "app_global", new TestCassandraConfiguration("app_global", "sys_delta")))
                         .setHistoryTtl(Period.days(2)));
                 bind(DataStore.class).annotatedWith(SystemDataStore.class).toInstance(mock(DataStore.class));
-
+                bind(BlobStore.class).toInstance(mock(BlobStore.class));
+                
                 bind(DataCenterConfiguration.class).toInstance(new DataCenterConfiguration()
                         .setCurrentDataCenter("datacenter1")
                         .setSystemDataCenter("datacenter1")

--- a/queue/src/main/java/com/bazaarvoice/emodb/queue/core/AbstractQueueService.java
+++ b/queue/src/main/java/com/bazaarvoice/emodb/queue/core/AbstractQueueService.java
@@ -82,7 +82,7 @@ abstract class AbstractQueueService implements BaseQueueService {
                             public MoveQueueResult run(MoveQueueRequest request)
                                     throws Exception {
                                 try {
-                                    _eventStore.move(request.getFrom(), request.getTo());
+                                    _eventStore.move(request.getFrom(), request.getTo(), null);
                                 } catch (ReadOnlyQueueException e) {
                                     // The from queue is not owned by this server.
                                     return notOwner();

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/AbstractSubjectDatabus.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/AbstractSubjectDatabus.java
@@ -2,9 +2,12 @@ package com.bazaarvoice.emodb.web.resources.databus;
 
 import com.bazaarvoice.emodb.auth.jersey.Subject;
 import com.bazaarvoice.emodb.databus.api.Databus;
+import com.bazaarvoice.emodb.databus.api.DatabusEventTracerSpec;
 import com.bazaarvoice.emodb.databus.api.Event;
+import com.bazaarvoice.emodb.databus.api.MoveSubscriptionRequest;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.PollResult;
+import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionRequest;
 import com.bazaarvoice.emodb.databus.api.ReplaySubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.api.UnknownSubscriptionException;
@@ -87,13 +90,11 @@ public abstract class AbstractSubjectDatabus implements SubjectDatabus {
     }
 
     @Override
-    public String replayAsync(Subject subject, String subscription) {
-        return databus(subject).replayAsync(subscription);
-    }
-
-    @Override
-    public String replayAsyncSince(Subject subject, String subscription, Date since) {
-        return databus(subject).replayAsyncSince(subscription, since);
+    public String replayAsyncSince(Subject subject, String subscription, Date since, DatabusEventTracerSpec tracer) {
+        return databus(subject).replayAsync(
+                new ReplaySubscriptionRequest(subscription)
+                        .since(since)
+                        .withTracing(tracer));
     }
 
     @Override
@@ -102,8 +103,8 @@ public abstract class AbstractSubjectDatabus implements SubjectDatabus {
     }
 
     @Override
-    public String moveAsync(Subject subject, String from, String to) {
-        return databus(subject).moveAsync(from, to);
+    public String moveAsync(Subject subject, String from, String to, DatabusEventTracerSpec tracer) {
+        return databus(subject).moveAsync(new MoveSubscriptionRequest(from, to).withTracing(tracer));
     }
 
     @Override

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/SubjectDatabus.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/SubjectDatabus.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.web.resources.databus;
 
 import com.bazaarvoice.emodb.auth.jersey.Subject;
+import com.bazaarvoice.emodb.databus.api.DatabusEventTracerSpec;
 import com.bazaarvoice.emodb.databus.api.Event;
 import com.bazaarvoice.emodb.databus.api.MoveSubscriptionStatus;
 import com.bazaarvoice.emodb.databus.api.PollResult;
@@ -62,13 +63,11 @@ public interface SubjectDatabus {
 
     void acknowledge(Subject subject, String subscription, Collection<String> eventKeys);
 
-    String replayAsync(Subject subject, String subscription);
-
-    String replayAsyncSince(Subject subject, String subscription, Date since);
+    String replayAsyncSince(Subject subject, String subscription, Date since, DatabusEventTracerSpec tracer);
 
     ReplaySubscriptionStatus getReplayStatus(Subject subject, String reference);
 
-    String moveAsync(Subject subject, String from, String to);
+    String moveAsync(Subject subject, String from, String to, DatabusEventTracerSpec tracer);
 
     MoveSubscriptionStatus getMoveStatus(Subject subject, String reference);
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/TracerParam.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/TracerParam.java
@@ -1,0 +1,25 @@
+package com.bazaarvoice.emodb.web.resources.databus;
+
+import com.bazaarvoice.emodb.common.json.RisonHelper;
+import com.bazaarvoice.emodb.databus.api.DatabusEventTracerSpec;
+import com.bazaarvoice.emodb.sor.api.Audit;
+import com.google.common.base.Strings;
+import io.dropwizard.jersey.params.AbstractParam;
+
+public class TracerParam extends AbstractParam<DatabusEventTracerSpec> {
+
+    public TracerParam(String input) {
+        super(input);
+    }
+
+    @Override
+    protected String errorMessage(String input, Exception e) {
+        return "Invalid O-Rison parameter (as described at http://mjtemplate.org/examples/rison.html)" +
+                (Strings.isNullOrEmpty(e.getMessage()) ? "" : ", " + e.getMessage()) + ": " + input;
+    }
+
+    @Override
+    protected DatabusEventTracerSpec parse(String input) throws Exception {
+        return RisonHelper.fromORison(input, DatabusEventTracerSpec.class);
+    }
+}


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

There have been reports that after a databus replay and move operation a small number of events which should have been posted to a client's databus subscription are not present.  The client has logged all databus events which they received and a comparative analysis shows that several records that were updated within the window of the replay request did not appear in the final subscription after the replay and move.  However, it is still unknown if the issue was on the client's side, with the client presumably discarding events prior to client logging call, or on Emo's side due to some squirrelly difficult-to-reproduce error.  Specifically, there is no way to definitively compare the client's log to what was actually replayed and moved by Emo, making it impossible to resolve the issue or even know which system requires further investigation.

This PR adds the ability to trace every event replayed or moved in one of those operations and dump the log to a CSV file in the blob store.  For example:

```csv
7041a0ef-13ef-11e7-a105-2eb4b6c28252,3/28/17 2:47 PM,sample_table,record-995,DedupQueue#moveToRawChannel
7041a0f1-13ef-11e7-a105-2eb4b6c28252,3/28/17 2:47 PM,sample_table,record-996,DedupQueue#moveToRawChannel
7041a0f3-13ef-11e7-a105-2eb4b6c28252,3/28/17 2:47 PM,sample_table,record-997,DedupQueue#moveToRawChannel
7041a0f5-13ef-11e7-a105-2eb4b6c28252,3/28/17 2:47 PM,sample_table,record-998,DedupQueue#moveToRawChannel
7041a0f7-13ef-11e7-a105-2eb4b6c28252,3/28/17 2:47 PM,sample_table,record-999,DedupQueue#moveToRawChannel
```

It's possible to extend this to support other logging options, such as writing a file to S3 or just plain log4j, but for now a blob document seemed like a good compromise for providing a publicly-accessible trace dump without adding any external dependencies or relying on an Emo admin's intervention, such as would be needed if the log were written to a local file on the Emo instance.
## How to Test and Verify

1. Check out this PR
2. Create a blob table called "movetrace"
3. Create a subscription "sourceSub" with condition `alwaysTrue()`
4. Create at least one SoR table and add multiple documents to it.
5. Create another subscription called "destSub", also with condition `alwaysTrue()`
6. Perform a move operation with a trace parameter, such as:

   `POST /bus/1/_move?from=sourceSub&to=destSub&tracer=type:blob,table:movetrace,blobId:trace1,ttl:1209600000,gzipped:!t`

7. Get the CSV blob from "movetrace/trace1" and un-gzip it
8. Verify all documents which should have been in `sourceSub` were moved and a record of each is in the CSV.
9. Repeat with a replay operation

## Risk

Low.  I believe all of the locations where events are operated on in move and replay are included, but even if wrong there's no additional risk.  The move and replay operations themselves will continue to work as they did before this change.  If any errors of omission in the logs are found they can be resolved in future updates.  Additionally, all calls to the tracer are protected so even if an exception were thrown by the tracer it shouldn't affect the actual operation.

### Level 

`Medium`

### Required Testing

`Manual`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
