### PR TITLE
Disabled long polling in default web-local configuration

### DIFF
--- a/web-local/config-local-main-role.yaml
+++ b/web-local/config-local-main-role.yaml
@@ -101,6 +101,9 @@ systemOfRecord:
 
 
 databus:
+  longPollPollingThreadCount: 0
+  longPollKeepAliveThreadCount: 0
+
   # Cassandra connection settings
   cassandra:
     cluster: Databus Cluster

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -100,6 +100,9 @@ systemOfRecord:
 
 
 databus:
+  longPollPollingThreadCount: 0
+  longPollKeepAliveThreadCount: 0
+
   # Cassandra connection settings
   cassandra:
     cluster: Databus Cluster


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

An older feature of Emo is long polling, where a databus poll connection is kept open if a subscription is empty and the databus is re-polled internally for up to 20 seconds.  The theory behind this is that it discourages callers from spamming Emo with poll requests when a subscription is empty.  In practice, however, we've found problems with long polling and have it disabled in all of our deployment environments.  This update merely changes the default service started by web-local to also disable long polling.  This way integration tests run against a local Emo will more closely resemble an actual deployment environment.  This can still be overridden by creating an alternate `config.yaml` and passing that as a maven parameter.

## How to Test and Verify

1. Check out this PR
2. Build and run Emo from `web-local/start.sh`
3. Create a subscription for `alwaysTrue()`
4. Without having created any tables or updated any documents poll the subscription.  It should return quickly with no results and the `X-BV-Databus-Empty` header set to true.

## Risk

Low.  This only affects starting Emo locally.

### Level 

`Low`

### Required Testing

`Regression`
## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
