### PR TITLE
Change start script

### DIFF
--- a/web-local/pom.xml
+++ b/web-local/pom.xml
@@ -18,6 +18,8 @@
         <mavenVersion>3.1.1</mavenVersion>
         <mavenPluginAnnotationsVersion>3.2</mavenPluginAnnotationsVersion>
         <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
+        <config.file>config-local.yaml</config.file>
+        <ddl.file>config-ddl-local.yaml</ddl.file>
     </properties>
 
     <dependencies>
@@ -145,8 +147,8 @@
                                     <mainClass>com.bazaarvoice.emodb.local.EmoServiceWithZK</mainClass>
                                     <arguments>
                                         <argument>server</argument>
-                                        <argument>${project.basedir}/config-local.yaml</argument>
-                                        <argument>${project.basedir}/config-ddl-local.yaml</argument>
+                                        <argument>${project.basedir}/${config.file}</argument>
+                                        <argument>${project.basedir}/${ddl.file}</argument>
                                         <argument>-z</argument>
                                     </arguments>
                                 </configuration>

--- a/web-local/start.sh
+++ b/web-local/start.sh
@@ -1,21 +1,68 @@
 #!/bin/bash
 
-#
-# Starts the following servers locally:
-# - EmoDB (ports 8080, 8081)
-# - Cassandra (port 9160)
-# - ZooKeeper (port 2181)
-#
-# The first time this is run, Cassandra will be initialized with a default
-# schema and an empty # data set.  Data will be stored in "target/cassandra".
-# On subsequent runs where "target/cassandra" already exists, the Cassandra
-# schema and data will not be modified.
-#
-# Once the server is running you can access the Cassandra command line
-# interface using the following commands:
-#
-#   cd target/cassandra/bin
-#   java -jar cassandra-cli.jar
-#
+CONFIG_FILE="config-local.yaml"
+DDL_FILE="config-ddl-local.yaml"
 
-mvn verify -P init-cassandra,start-emodb
+function print_usage_and_exit {
+    cat <<EOF
+    $(basename $0) - Start EmoDB locally.
+
+
+     Starts the following servers locally (using ${DDL_FILE} and ${CONFIG_FILE}):
+     - EmoDB (ports 8080, 8081)
+     - Cassandra (port 9160)
+     - ZooKeeper (port 2181)
+
+     The first time this is run, Cassandra will be initialized with a default
+     schema and an empty # data set.  Data will be stored in "target/cassandra".
+     On subsequent runs where "target/cassandra" already exists, the Cassandra
+     schema and data will not be modified.
+
+     Once the server is running you can access the Cassandra command line
+     interface using the following commands:
+
+       cd target/cassandra/bin
+       java -jar cassandra-cli.jar
+
+     Options:
+
+        --ddl-file       Which ddl file to use [Default: emodb/web-local/${DDL_FILE}]
+        --config-file    Which config file to use [Default: emodb/web-local/${CONFIG_FILE}]
+
+     Examples:
+
+        Using default files
+            $(basename $0)
+
+        Passing in files
+            $(basename $0) --ddl-file config-ddl-local-2.yaml --config-file config-local-2.yaml
+
+EOF
+
+    exit 2
+}
+
+
+if [[ $# -gt 0 ]]; then
+    while [[ $# -gt 0 ]]; do
+        case "${1}" in
+            -h|--help)
+                print_usage_and_exit
+                ;;
+            --ddl-file)
+                DDL_FILE="${2}"
+                shift 2
+                ;;
+            --config-file)
+                CONFIG_FILE="${2}"
+                shift 2
+                ;;
+            *)
+                error "Unknown option ${1}"
+                ;;
+        esac
+    done
+fi
+
+
+mvn verify -P init-cassandra,start-emodb -Dconfig.file="${CONFIG_FILE}" -Dddl.file="${DDL_FILE}"


### PR DESCRIPTION
## Github Issue #

n/a

## What Are We Doing Here?

Instead of creating new start scripts or running java command with config files to start EmoDB, I've added the ability to specify config files to start script.

## How to Test and Verify

1. Check out this PR
2. Use parameters `--config-file` and `--ddl-file` to start EmoDB
3. Ensure that the proper config files were used to start EmoDB

## Risk

### Level 

`Low`

### Required Testing

`Smoke`

### Risk Summary

No Risks

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
