### PR TITLE
Added ability to configure DDL config file

### DIFF
--- a/sdk/src/main/java/com/bazaarvoice/emodb/sdk/AbstractEmoMojo.java
+++ b/sdk/src/main/java/com/bazaarvoice/emodb/sdk/AbstractEmoMojo.java
@@ -77,6 +77,9 @@ public abstract class AbstractEmoMojo extends AbstractMojo {
     @Parameter
     protected String emoConfigurationFile;
 
+    @Parameter
+    protected String ddlConfigurationFile;
+
     @Parameter(property = "emo.maxMemory", defaultValue = "1000")
     protected int emoMaxMemory; // megabytes
 

--- a/sdk/src/main/java/com/bazaarvoice/emodb/sdk/EmoStartMojo.java
+++ b/sdk/src/main/java/com/bazaarvoice/emodb/sdk/EmoStartMojo.java
@@ -111,6 +111,19 @@ public class EmoStartMojo extends AbstractEmoMojo {
         }
     }
 
+    private void copyDdlConfigurationFile() throws MojoExecutionException, IOException {
+        if (StringUtils.isBlank(ddlConfigurationFile)) {
+            copyDefaultDdlConfigurationFile();
+        } else {
+            try {
+                // copy configuration file to well-known emodb DDL config directory and filename "config-ddl.yaml"
+                FileUtils.copyFile(new File(ddlConfigurationFile), new File(emoConfigurationDirectory(), "config-ddl.yaml"));
+            } catch (Exception e) {
+                throw new MojoExecutionException("failed to copy configuration file from " + ddlConfigurationFile, e);
+            }
+        }
+    }
+
     private void copyEmoServiceArtifactToWorkingDirectory() throws MojoExecutionException, MojoFailureException {
         // NOTE: this emo service artifact is an "uberjar" created by the maven-shade-plugin
         final ArtifactItem emoServiceArtifact = new ArtifactItem();
@@ -229,7 +242,7 @@ public class EmoStartMojo extends AbstractEmoMojo {
         }
     }
 
-    private void copyDdlConfigurationFile() throws MojoFailureException, IOException {
+    private void copyDefaultDdlConfigurationFile() throws MojoExecutionException, IOException {
         InputStream source = null;
         FileOutputStream target = null;
         try {
@@ -237,7 +250,7 @@ public class EmoStartMojo extends AbstractEmoMojo {
             target = new FileOutputStream(new File(emoConfigurationDirectory(), "config-ddl.yaml"));
             IOUtils.copy(source, target);
         } catch (IOException e) {
-            throw new MojoFailureException("could not find the ddl configuration file");
+            throw new MojoExecutionException("could not find the ddl configuration file");
         } finally {
             Closeables.close(source, false);
             Closeables.close(target, false);


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

The Emo SDK has a maven mojo which is used to start EmoDB using maven plugins. The configuration for this plugin allows specifying the "config.yaml" file but not the "config-ddl.yaml" file. As a result the configuration is limited to only those placements from the default configuration. This PR changes the configuration so the pom can set both configuration files.

## How to Test and Verify

This PR is difficult to test directly, since it only affects the emo-sdk plugin.  To test you'd need to create another project which uses the sdk plugin and configure with a custom config.yaml and config-ddl.yaml.

## Risk

Low 

### Level 

`Low`

### Required Testing

`Smoke`

### Risk Summary

This is a low risk change.  It only affects users using the SDK, which includes Emo's own integration tests.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
