### PR TITLE
Relocate jline dependency in the shaded client.

### DIFF
--- a/shaded-clients/shaded-clients-core/pom.xml
+++ b/shaded-clients/shaded-clients-core/pom.xml
@@ -200,6 +200,10 @@
                             <pattern>javax.validation</pattern>
                             <shadedPattern>shaded.emodb.javax.validation</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>jline</pattern>
+                            <shadedPattern>shaded.emodb.jline</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## Github Issue #

N/A

## What Are We Doing Here?

It looks like the shaded client includes `jline` but does not relocate it. This change just moves it into the shaded namespace so that it won't conflict with other downstream project dependencies.

## How to Test and Verify

1. Check out this PR
2. Run `mvn package` for the shaded client
3. Unzip the jar and confirm that the `jline` dependency is in `shaded.emodb.jline` instead of just `jline`

## Risk

### Level 

Low

### Required Testing

Regression

### Risk Summary

This should only fix things, and if it causes any builds to fail, then it presents an opportunity for that build to fix its dependencies.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
