### PR TITLE
Refactored provider to use a single ZooKeeperHostDiscovery over its lifetime

### DIFF
--- a/cachemgr/src/main/java/com/bazaarvoice/emodb/cachemgr/invalidate/LocalDataCenterEndPointProvider.java
+++ b/cachemgr/src/main/java/com/bazaarvoice/emodb/cachemgr/invalidate/LocalDataCenterEndPointProvider.java
@@ -1,44 +1,211 @@
 package com.bazaarvoice.emodb.cachemgr.invalidate;
 
 import com.bazaarvoice.emodb.common.dropwizard.guice.Global;
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.zookeeper.Sync;
 import com.bazaarvoice.ostrich.HostDiscovery;
 import com.bazaarvoice.ostrich.ServiceEndPoint;
 import com.bazaarvoice.ostrich.discovery.zookeeper.ZooKeeperHostDiscovery;
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
+import io.dropwizard.lifecycle.Managed;
 import org.apache.curator.framework.CuratorFramework;
 import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Queries the local data center's ZooKeeper server for the hosts that implement the specified end point.
  */
-public class LocalDataCenterEndPointProvider implements EndPointProvider {
+public class LocalDataCenterEndPointProvider implements EndPointProvider, Managed {
     private static final Duration SYNC_TIMEOUT = Duration.standardSeconds(10);
+    private static final long DELAY_TIMEOUT = Duration.standardSeconds(2).getMillis();
+
+    private final Logger _log = LoggerFactory.getLogger(LocalDataCenterEndPointProvider.class);
 
     private final CuratorFramework _curator;
     private final InvalidationServiceEndPointAdapter _endPointAdapter;
     private final ServiceEndPoint _self;
     private final MetricRegistry _metricRegistry;
 
+    private final ReentrantLock _lock = new ReentrantLock();
+    private final Condition _endpointsAvailable = _lock.newCondition();
+    private final DelayQueue<DelayedInvalidationCheck> _delayedInvalidationQueue;
+    private ZooKeeperHostDiscovery _hostDiscovery;
+    private ExecutorService _delayedInvalidationService;
+    private boolean _shutdownDelayedInvalidationService;
+
+    private volatile ImmutableList<EndPoint> _endPoints = ImmutableList.of();
+
+
     @Inject
     public LocalDataCenterEndPointProvider(@Global CuratorFramework curator,
                                            InvalidationServiceEndPointAdapter endPointAdapter,
                                            ServiceEndPoint self,
-                                           MetricRegistry metricRegistry) {
+                                           MetricRegistry metricRegistry,
+                                           LifeCycleRegistry lifeCycleRegistry) {
+        this(curator, endPointAdapter, self, metricRegistry, lifeCycleRegistry, null);
+    }
+
+    @VisibleForTesting
+    LocalDataCenterEndPointProvider(CuratorFramework curator,
+                                    InvalidationServiceEndPointAdapter endPointAdapter,
+                                    ServiceEndPoint self,
+                                    MetricRegistry metricRegistry,
+                                    LifeCycleRegistry lifeCycleRegistry,
+                                    ExecutorService delayedInvalidationService) {
         _curator = curator;
         _endPointAdapter = endPointAdapter;
         _self = self;
         _metricRegistry = metricRegistry;
+        _delayedInvalidationService = delayedInvalidationService;
+
+        _delayedInvalidationQueue = new DelayQueue<>();
+        
+        lifeCycleRegistry.manage(this);
+    }
+
+    @Override
+    public void start() throws Exception {
+        _hostDiscovery = new ZooKeeperHostDiscovery(_curator, _endPointAdapter.getServiceName(), _metricRegistry);
+        _hostDiscovery.addListener(new HostDiscovery.EndPointListener() {
+            @Override
+            public void onEndPointAdded(final ServiceEndPoint host) {
+                rebuildEndpoints();
+            }
+
+            @Override
+            public void onEndPointRemoved(ServiceEndPoint endPoint) {
+                rebuildEndpoints();
+            }
+        });
+
+        if (_delayedInvalidationService == null) {
+            _delayedInvalidationService = Executors.newSingleThreadExecutor(
+                    new ThreadFactoryBuilder().setNameFormat("local-dc-invalidation-%d").build());
+            _shutdownDelayedInvalidationService = true;
+        }
+
+        _delayedInvalidationService.execute(this::pollForDelayedEndPoints);
+
+        // Initialize endpoints by rebuilding
+        rebuildEndpoints();
+    }
+
+    @Override
+    public void stop() throws Exception {
+        if (_shutdownDelayedInvalidationService) {
+            _delayedInvalidationService.shutdownNow();
+        }
+        try {
+            _hostDiscovery.close();
+        } catch (IOException e) {
+            // Ignore errors from stopping host discovery
+        }
+    }
+
+    private void rebuildEndpoints() {
+        // Null out the endpoints to invalidate them immediately
+        _endPoints = null;
+
+        _lock.lock();
+        try {
+            _endPoints = getEndPointsFromHostDiscovery();
+            _endpointsAvailable.signalAll();
+
+            if (_log.isDebugEnabled()) {
+                _log.debug("Endpoints are now: {}", Joiner.on(',').join(_endPoints.stream().map(EndPoint::getAddress).iterator()));
+            }
+        } finally {
+            _lock.unlock();
+        }
+    }
+
+    /**
+     * Returns the current list of endPoints.  If possible a cached version is used, so typically this is faster than
+     * calling {@link #getEndPointsFromHostDiscovery()} and reuses an existing immutable list rather than rebuilding a
+     * new one on each call.
+     */
+    private ImmutableList<EndPoint> getEndPoints() {
+        ImmutableList<EndPoint> endPoints = _endPoints;
+        if (endPoints == null) {
+            boolean locked = false;
+            try {
+                long timeout = System.currentTimeMillis() + 10;
+
+                locked = _lock.tryLock(10, TimeUnit.MILLISECONDS);
+                if (locked) {
+                    endPoints = _endPoints;
+                    long waitTime = timeout - System.currentTimeMillis();
+                    if (endPoints == null && waitTime > 0) {
+                        _endpointsAvailable.await(waitTime, TimeUnit.MILLISECONDS);
+                        endPoints = _endPoints;
+                    }
+                }
+            } catch (InterruptedException e) {
+                // ignore
+            } finally {
+                if (locked) {
+                    _lock.unlock();
+                }
+            }
+
+            if (endPoints == null) {
+                // Took too long waiting for the background to re-populate endpoints, just fetch from the source
+                endPoints = getEndPointsFromHostDiscovery();
+            }
+        }
+        
+        return endPoints;
+    }
+
+    /**
+     * Returns the current list of endPoints.  Unlike {@link #getEndPoints()} the host discovery is queried and a new
+     * list of endPoints is generated on every call.
+     */
+    private ImmutableList<EndPoint> getEndPointsFromHostDiscovery() {
+        Iterable<ServiceEndPoint> hosts = _hostDiscovery.getHosts();
+
+        ImmutableList.Builder<EndPoint> endPoints = ImmutableList.builder();
+        for (final ServiceEndPoint host : hosts) {
+            if (host.equals(_self)) {
+                continue;
+            }
+            endPoints.add(new EndPoint() {
+                @Override
+                public String getAddress() {
+                    return _endPointAdapter.toEndPointAddress(host);
+                }
+
+                @Override
+                public boolean isValid() {
+                    return Iterables.contains(_hostDiscovery.getHosts(), host);
+                }
+            });
+        }
+
+        return endPoints.build();
     }
 
     @Override
@@ -48,29 +215,81 @@ public class LocalDataCenterEndPointProvider implements EndPointProvider {
         // is up as of the time the sendToAll() method begins.
         checkState(Sync.synchronousSync(_curator, SYNC_TIMEOUT), "ZooKeeper sync failed.");
 
-        try (final HostDiscovery hostDiscovery = new ZooKeeperHostDiscovery(_curator, _endPointAdapter.getServiceName(), _metricRegistry)) {
-            Iterable<ServiceEndPoint> hosts = hostDiscovery.getHosts();
+        List<EndPoint> endPoints = getEndPoints();
 
-            List<EndPoint> endPoints = Lists.newArrayList();
-            for (final ServiceEndPoint host : hosts) {
-                if (host.equals(_self)) {
-                    continue;
+        function.apply(endPoints);
+
+        // Although the previous sync ensures ZooKeeper has the most up-to-date information it may take a few
+        // milliseconds for the host discovery to asynchronously be updated with any changes to the set of endpoints.
+        // To account for this, asynchronously re-visit this function in 2 seconds so any new endpoints that come
+        // online between now and then also are acted upon.
+        _delayedInvalidationQueue.offer(new DelayedInvalidationCheck(endPoints, function));
+    }
+
+    private void pollForDelayedEndPoints() {
+        while (!_delayedInvalidationService.isShutdown()) {
+            try {
+                // Don't block for more than 5 seconds so this loop can terminate if the provider is stopped
+                DelayedInvalidationCheck delayedInvalidationCheck = _delayedInvalidationQueue.poll(5, TimeUnit.SECONDS);
+                if (delayedInvalidationCheck != null) {
+                    // The list of endpoints should be updated infrequently, only when instances come online or offline.
+                    // Whenever the list is updated a new list is generated.  So start by performing a fast identity
+                    // check to verify the list is unchanged.
+                    List<EndPoint> sentEndPoints = delayedInvalidationCheck.getEndPoints();
+                    List<EndPoint> currentEndPoints = getEndPoints();
+
+                    if (sentEndPoints != currentEndPoints) {
+                        // Not the same instance; perform a deeper check to verify any new instances are acted upon
+
+                        Set<String> sentAddresses = sentEndPoints.stream().map(EndPoint::getAddress).collect(Collectors.toSet());
+                        List<EndPoint> unsentEndPoints = currentEndPoints.stream()
+                                .filter(endPoint -> !sentAddresses.contains(endPoint.getAddress()))
+                                .collect(Collectors.toList());
+
+                        if (!unsentEndPoints.isEmpty()) {
+                            delayedInvalidationCheck.getFunction().apply(unsentEndPoints);
+                        }
+                    }
                 }
-                endPoints.add(new EndPoint() {
-                    @Override
-                    public String getAddress() {
-                        return _endPointAdapter.toEndPointAddress(host);
-                    }
-                    @Override
-                    public boolean isValid() {
-                        return Iterables.contains(hostDiscovery.getHosts(), host);
-                    }
-                });
+            } catch (Exception e) {
+                // Catch all exceptions so the loop doesn't terminate while the service is still running
+                if (!_delayedInvalidationService.isShutdown()) {
+                    _log.error("Exception caught polling for delayed endpoints", e);
+                }
             }
+        }
+    }
 
-            function.apply(endPoints);
-        } catch (IOException ex) {
-            // suppress any IOExceptions that might result from closing our ZooKeeperHostDiscovery
+    final static class DelayedInvalidationCheck implements Delayed {
+        private final List<EndPoint> _endPoints;
+        private final Function<Collection<EndPoint>, ?> _function;
+        private final long _executeAtMs;
+
+        public DelayedInvalidationCheck(List<EndPoint> endPoints, Function<Collection<EndPoint>, ?> function) {
+            _endPoints = endPoints;
+            _function = function;
+            _executeAtMs = System.currentTimeMillis() + DELAY_TIMEOUT;
+        }
+
+        public List<EndPoint> getEndPoints() {
+            return _endPoints;
+        }
+
+        public Function<Collection<EndPoint>, ?> getFunction() {
+            return _function;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return unit.convert(_executeAtMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public int compareTo(Delayed o) {
+            if (o == this || ((DelayedInvalidationCheck) o)._executeAtMs == _executeAtMs) {
+                return 0;
+            }
+            return _executeAtMs < ((DelayedInvalidationCheck) o)._executeAtMs ? -1 : 1;
         }
     }
 }

--- a/cachemgr/src/test/java/com/bazaarvoice/emodb/cachemgr/invalidate/LocalDataCenterEndPointProviderTest.java
+++ b/cachemgr/src/test/java/com/bazaarvoice/emodb/cachemgr/invalidate/LocalDataCenterEndPointProviderTest.java
@@ -1,11 +1,13 @@
 package com.bazaarvoice.emodb.cachemgr.invalidate;
 
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.SimpleLifeCycleRegistry;
 import com.bazaarvoice.emodb.common.json.JsonHelper;
 import com.bazaarvoice.ostrich.ServiceEndPoint;
 import com.bazaarvoice.ostrich.ServiceEndPointBuilder;
 import com.bazaarvoice.ostrich.registry.zookeeper.ZooKeeperServiceRegistry;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Function;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -14,15 +16,24 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.BoundedExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
+import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class LocalDataCenterEndPointProviderTest {
     private TestingServer _zooKeeperServer;
@@ -56,37 +67,104 @@ public class LocalDataCenterEndPointProviderTest {
         serviceRegistry.register(host1);
         serviceRegistry.register(host2);
 
-        LocalDataCenterEndPointProvider provider = new LocalDataCenterEndPointProvider(_curator, adapter, self, metricRegistry);
+        SimpleLifeCycleRegistry lifeCycleRegistry = new SimpleLifeCycleRegistry();
 
-        final boolean[] called = {false};
-        provider.withEndPoints(new Function<Collection<EndPoint>, Void>() {
-            @Override
-            public Void apply(Collection<EndPoint> endPoints) {
-                called[0] = true;
-                assertEndPointsMatch(endPoints, ImmutableSet.of(
-                        "http://169.254.1.1:8081/tasks/invalidate",
-                        "http://169.254.1.2:8081/tasks/invalidate"));
-                return null;
-            }
+        LocalDataCenterEndPointProvider provider = new LocalDataCenterEndPointProvider(
+                _curator, adapter, self, metricRegistry, lifeCycleRegistry);
+        lifeCycleRegistry.start();
+
+        assertWithin(provider, Duration.ZERO, endPoints -> {
+            assertEndPointsMatch(endPoints, ImmutableSet.of(
+                    "http://169.254.1.1:8081/tasks/invalidate",
+                    "http://169.254.1.2:8081/tasks/invalidate"));
+            return null;
         });
-        Assert.assertTrue(called[0]);
 
-        // Unregister a host and verify that withEndPoints excludes it immediately (ie. performs zk sync).
+        // Unregister a host and verify that withEndPoints excludes it immediately, with a brief consideration
+        // for the PathChildrenCache to be updated.
         serviceRegistry.unregister(host2);
-        called[0] = false;
-        provider.withEndPoints(new Function<Collection<EndPoint>, Void>() {
-            @Override
-            public Void apply(Collection<EndPoint> endPoints) {
-                called[0] = true;
-                assertEndPointsMatch(endPoints, ImmutableSet.of("http://169.254.1.1:8081/tasks/invalidate"));
-                return null;
-            }
+
+        assertWithin(provider, Duration.ofMillis(200), endPoints -> {
+            assertEndPointsMatch(endPoints, ImmutableSet.of("http://169.254.1.1:8081/tasks/invalidate"));
+            return null;
         });
-        Assert.assertTrue(called[0]);
 
         // Cleanup
         serviceRegistry.unregister(host1);
         serviceRegistry.close();
+        lifeCycleRegistry.stop();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testEndPointProviderWithDelay() throws Exception {
+        InvalidationServiceEndPointAdapter adapter = new InvalidationServiceEndPointAdapter("emodb-cachemgr",
+                HostAndPort.fromString("localhost:8080"), HostAndPort.fromString("localhost:8081"));
+        ServiceEndPoint self = adapter.toSelfEndPoint();
+
+        MetricRegistry metricRegistry = new MetricRegistry();
+
+        ZooKeeperServiceRegistry serviceRegistry = new ZooKeeperServiceRegistry(_curator, metricRegistry);
+        ServiceEndPoint host1 = getRemoteHost("169.254.1.1");
+        ServiceEndPoint host2 = getRemoteHost("169.254.1.2");
+        serviceRegistry.register(host1);
+
+        SimpleLifeCycleRegistry lifeCycleRegistry = new SimpleLifeCycleRegistry();
+
+        // To control for the unreliability of thread timing provide our own implementation for the invalidation service
+        ExecutorService service = mock(ExecutorService.class);
+
+        // Simulate the service being shutdown after exactly one iteration
+        when(service.isShutdown())
+                .thenReturn(false)
+                .thenReturn(true);
+
+        LocalDataCenterEndPointProvider provider = new LocalDataCenterEndPointProvider(
+                _curator, adapter, self, metricRegistry, lifeCycleRegistry, service);
+        lifeCycleRegistry.start();
+
+        final Set<String> endPointsInvalidated = Sets.newHashSet();
+
+        assertWithin(provider, Duration.ZERO, endPoints -> {
+            endPoints.forEach(endPoint -> endPointsInvalidated.add(endPoint.getAddress()));
+            return null;
+        });
+
+        Assert.assertEquals(endPointsInvalidated, ImmutableSet.of("http://169.254.1.1:8081/tasks/invalidate"));
+        endPointsInvalidated.clear();
+
+        // Register the second host
+        serviceRegistry.register(host2);
+
+        // Now that the second host is definitively registered execute the invalidation runnable synchronously
+        ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(service).execute(runnableCaptor.capture());
+        Runnable runnable = runnableCaptor.getValue();
+        runnable.run();
+        
+        Assert.assertEquals(endPointsInvalidated, ImmutableSet.of("http://169.254.1.2:8081/tasks/invalidate"));
+
+        serviceRegistry.unregister(host1);
+        serviceRegistry.close();
+        lifeCycleRegistry.stop();
+    }
+
+    private void assertWithin(LocalDataCenterEndPointProvider provider, Duration timeLimit, Function<Collection<EndPoint>, Void> function) {
+        AtomicBoolean called = new AtomicBoolean(false);
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        do {
+            provider.withEndPoints(endPoints -> {
+                try {
+                    function.apply(endPoints);
+                    called.set(true);
+                } catch (AssertionError e) {
+                    // Yield and try again until time is expired
+                    Thread.yield();
+                }
+                return null;
+            });
+        } while (!called.get() && stopwatch.elapsed(TimeUnit.MILLISECONDS) < timeLimit.toMillis());
+        Assert.assertTrue(called.get());
     }
 
     private void assertEndPointsMatch(Collection<EndPoint> endPoints, Collection<String> expected) {


### PR DESCRIPTION
## Github Issue #

[111](https://github.com/bazaarvoice/emodb/issues/111)

## What Are We Doing Here?

As noted in the [associated issue](https://github.com/bazaarvoice/emodb/issues/111) a memory leak was found in `LocalDataCenterEndPointProvider` caused by creating fresh instances of `ZooKeeperHostDiscovery` on each subscription invalidation.

This PR changes `LocalDataCenterEndPointProvider` to use a single `ZooKeeperHostDiscovery` instance for its lifetime.  This is the typical use for a `ZooKeeperHostDiscovery`, since it is intended to be a long-lived object which receives notifications from ZooKeeper whenever the set of end points changes.

`LocalDataCenterEndPointProvider` didn't use this approach because it needs to ensure that invalidation messages are sent out to all available hosts at the time of the invalidation.  `ZooKeeperHostDiscovery` relies on a `PathChildrenCache` ZooKeeper recipe to keep the set of hosts up-to-date.  Although this works this means there may be a small lag between when the set of hosts changes and the `PathChildrenCache` is asynchronously updated.  While this delay is short, no more than a few milliseconds, it does mean the list of hosts at invalidation time may be slightly out-of-date due to this delay.    To mitigate this each invalidation function is revisited with a two-second delay.  If any new hosts were added between the original invalidation request and two seconds later then the new hosts are also invalidated.  Two seconds should be more than enough time for the `PathChildrenCache` to be updated after the ZooKeeper sync.  Additionally, a possible delay of two seconds invalidating a subscription on a remote host should be within the already fuzzy boundaries of remote databus invalidation and evaluation caused by eventual consistency and queuing delays.

## How to Test and Verify

See the GitHub issue for details on reproducing.  In this case there should be no evidence of a memory leak.

## Risk

Medium.  This is actually a fairly low-risk change, but since it involves databus subscriptions the risk involved is naturally greater.

### Level 

`Medium`
### Required Testing

`Regression`

### Risk Summary

As previously noted, the biggest risk with this change is that potential two-second delay invalidating subscriptions on a remote host.  However, given a) the high cost of synchronously querying ZooKeeper for remote hosts on every invalidation rather than relying on a cache, and b) the infrequency of Emo hosts being added or removed, this seems like a reasonable solution.  Clients should already be aware that changes to a subscription may not have an immediate effect on documents updated around the time of the change due to queuing delays and invalidation propagation.  Perhaps the best approach is to publicize that while we don't yet have a definitive upper bound on this the lower bound is 2 seconds.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
