### PR TITLE
Fixed databus error when events in the queue are from dropped facades

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -32,6 +32,7 @@ import com.bazaarvoice.emodb.job.api.JobStatus;
 import com.bazaarvoice.emodb.sor.api.Coordinate;
 import com.bazaarvoice.emodb.sor.api.Intrinsic;
 import com.bazaarvoice.emodb.sor.api.ReadConsistency;
+import com.bazaarvoice.emodb.sor.api.UnknownPlacementException;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
@@ -653,8 +654,8 @@ public class DefaultDatabus implements OwnerAwareDatabus, Managed {
             try {
                 annotatedGet.add(coord.getTable(), coord.getId());
                 remaining -= 1;
-            } catch (UnknownTableException e) {
-                // It's likely the table was dropped since the event was queued.  Discard the events.
+            } catch (UnknownTableException | UnknownPlacementException e) {
+                // It's likely the table or facade was dropped since the event was queued.  Discard the events.
                 EventList list = entry.getValue();
                 for (Pair<String, UUID> pair : list.getEventAndChangeIds()) {
                     eventIdsToDiscard.add(pair.first());
@@ -1017,8 +1018,8 @@ public class DefaultDatabus implements OwnerAwareDatabus, Managed {
             // Query the table/key pair.
             try {
                 annotatedGet.add(coord.getTable(), coord.getId());
-            } catch (UnknownTableException e) {
-                // It's likely the table was dropped since the event was queued.  Discard the events.
+            } catch (UnknownTableException | UnknownPlacementException e) {
+                // It's likely the table or facade was dropped since the event was queued.  Discard the events.
                 EventList list = entry.getValue();
                 for (Pair<String, UUID> pair : list.getEventAndChangeIds()) {
                     eventIdsToDiscard.add(pair.first());

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/test/InMemoryTable.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/test/InMemoryTable.java
@@ -42,6 +42,10 @@ public class InMemoryTable implements Table {
 
     @Override
     public TableAvailability getAvailability() {
+        if (!_facade) {
+            return new TableAvailability(_options.getPlacement(), false);
+        }
+        // Facades aren't fully supported
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

A recently discovered bug in Emo comes about from the following sequence:

1. A table is created in placement _X_ with a facade in placement _Y_.
2. A databus subscription is created which subscribes to updates for the table in the data center which has the facade.
3. At least one document is written to the facade.
4. The facade in placement _Y_ is dropped.
5. The databus subscription is polled.

When the subscription is polled Emo responds with a 404 and an `UnknownPlacementException`.  The reason is that the databus logic correctly handles discarding events from dropped tables but not from tables which exist but have a dropped facade.

The fix for this is minor and straightforward -- check whether the table is available locally.  This PR contains that fix.

## How to Test and Verify

The following sequence demonstrates how to recreate this issue using a locally-running Emo as started using web-local:

```
$ curl -s -XPUT -H "Content-Type: application/json" "localhost:8080/sor/1/_table/facade:test?options=placement:'app_remote:default'&audit=comment:'test'&APIKey=local_admin" -d '{}'
{"success":true}
$ curl -s -XPUT -H "Content-Type: application/json" "localhost:8080/sor/1/_facade/facade:test?options=placement:'app_global:default'&audit=comment:'test'&APIKey=local_admin"
{"success":true}
$ curl -s -XPUT -H "Content-Type: application/x.json-condition" "localhost:8080/bus/1/facade-sub?APIKey=local_admin" -d 'alwaysTrue()'
{"success":true}
$ curl -s -XPUT -H "Content-Type: application/json" "localhost:8080/sor/1/_facade/facade:test/doc1?audit=comment:'test'&APIKey=local_admin" -d '{"name":"Bob"}' 
{"success":true}
$ curl -s -XDELETE "localhost:8080/sor/1/_facade/facade:test?placement=app_global:default&audit=comment:'test'&APIKey=local_admin"
{"success":true}
$ curl "localhost:8080/bus/1/facade-sub/poll?limit=10&ttl=5&APIKey=local_admin" -v
*   Trying ::1...
* Connected to localhost (::1) port 8080 (#0)
> GET /bus/1/facade-sub/poll?limit=10&ttl=5&APIKey=local_admin HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Date: Mon, 15 May 2017 14:25:35 GMT
< X-BV-Exception: com.bazaarvoice.emodb.sor.api.UnknownPlacementException
< Content-Type: application/json
< Transfer-Encoding: chunked
< 
* Connection #0 to host localhost left intact
{"message":"Table facade:test is stored in a locally inaccessible placement: app_remote:default","placement":"app_remote:default","table":"facade:test","suppressed":[]}
```

With the fix in place the final poll should consistently return an empty list instead of a 404 page.

## Risk

Low.  This is a minor fix whose impact doesn't extend beyond polls and multi-gets in this very specific and rare circumstance.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
