### PR TITLE
Added ability to selectively ignore data centers

### DIFF
--- a/datacenter/src/main/java/com/bazaarvoice/emodb/datacenter/DataCenterConfiguration.java
+++ b/datacenter/src/main/java/com/bazaarvoice/emodb/datacenter/DataCenterConfiguration.java
@@ -2,10 +2,12 @@ package com.bazaarvoice.emodb.datacenter;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
+import java.util.Set;
 
 public class DataCenterConfiguration {
 
@@ -38,6 +40,15 @@ public class DataCenterConfiguration {
     @Valid
     @NotNull
     private URI _dataCenterAdminUri;
+
+    /**
+     * Data centers which should be ignored.  This is uncommon and typically only applies when migrating or removing an
+     * an existing data center.  This allows for a smooth transition from the old to the new data center without any
+     * downtime or fanout errors if either data center unreachable.
+     **/
+    @Valid
+    @NotNull
+    private Set<String> _ignoredDataCenters = ImmutableSet.of();
 
     public boolean isSystemDataCenter() {
         return _currentDataCenter.equals(_systemDataCenter);
@@ -90,5 +101,14 @@ public class DataCenterConfiguration {
 
     public URI getSystemDataCenterServiceUri() {
         return _systemDataCenterServiceUri;
+    }
+
+    public DataCenterConfiguration setIgnoredDataCenters(Set<String> ignoredDataCenters) {
+        _ignoredDataCenters = ignoredDataCenters;
+        return this;
+    }
+
+    public Set<String> getIgnoredDataCenters() {
+        return _ignoredDataCenters;
     }
 }

--- a/datacenter/src/main/java/com/bazaarvoice/emodb/datacenter/DataCenterModule.java
+++ b/datacenter/src/main/java/com/bazaarvoice/emodb/datacenter/DataCenterModule.java
@@ -6,6 +6,7 @@ import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.datacenter.core.DataCenterAnnouncer;
 import com.bazaarvoice.emodb.datacenter.core.DefaultDataCenters;
+import com.bazaarvoice.emodb.datacenter.core.IgnoredDataCenters;
 import com.bazaarvoice.emodb.datacenter.core.SelfCassandraDataCenter;
 import com.bazaarvoice.emodb.datacenter.core.SelfDataCenter;
 import com.bazaarvoice.emodb.datacenter.core.SelfDataCenterAdmin;
@@ -18,6 +19,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
 import java.net.URI;
+import java.util.Set;
 
 /**
  * Guice module for constructing an instance of {@link DataCenters}.
@@ -78,4 +80,10 @@ public class DataCenterModule extends PrivateModule {
     String provideSystemDataCenter(DataCenterConfiguration configuration) {
         return configuration.getSystemDataCenter();
     }
+
+    @Provides @Singleton @IgnoredDataCenters
+    Set<String> provideIgnoredDataCenters(DataCenterConfiguration configuration) {
+        return configuration.getIgnoredDataCenters();
+    }
+
 }

--- a/datacenter/src/main/java/com/bazaarvoice/emodb/datacenter/core/IgnoredDataCenters.java
+++ b/datacenter/src/main/java/com/bazaarvoice/emodb/datacenter/core/IgnoredDataCenters.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.datacenter.core;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for identifying the data centers which should be ignored by this one.
+ * In normal circumstances this is bound to an empty set.
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface IgnoredDataCenters {
+}


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

We are currently attempting to move our EmoDB clusters from one AWS account to another.  To facilitate this we have extended the Cassandra rings -- including databus -- so they each have a data center in the new account.  This way writes in one account are visible in both, and a smooth transition from one cluster to the other is possible.

There are two issues we've identified with this migration:

1. The "old" EmoDB data center is configured as the system data center.  However, the new EmoDB data center in the new account should also be the system data center.  This causes issues if more than one data center is system.
2. The two clusters data centers cannot communicate with one another.  Even if they could we wouldn't want to duplicate fanout since they share the same databus cluster.  Additionally, once we tear down the old data center it will still have a record in `__system_sor:data_center`.  Because of this in-bound replication will continue to be attempted from that data center, causing continuous errors.

This PR adds a configuration option to ignore certain data centers.  In our case the old data center would ignore the new one and vice versa.  In this way each would only have a view of the EmoDB cluster within their respective accounts, while the underlying data is kept consistent between the two accounts via Cassandra.

## Risk

The use of this new configuration is dangerous in normal circumstances.  However, when migrating or tearing down a data center, which is a risky operation unto itself, this change reduces the overall risk of errors.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
