### PR TITLE
Enabled Stash S3 writer to be able to assume another role

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScannerConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScannerConfiguration.java
@@ -58,6 +58,11 @@ public class ScannerConfiguration {
     @JsonProperty ("s3Proxy")
     private Optional<String> _s3Proxy = Optional.absent();
 
+    // If using S3, optionally assume the provided role
+    @Valid
+    @NotNull
+    @JsonProperty ("s3AssumeRole")
+    private Optional<String> _s3AssumeRole = Optional.absent();
     @Valid
     @NotNull
     @JsonProperty ("notifications")
@@ -171,6 +176,15 @@ public class ScannerConfiguration {
 
     public ScannerConfiguration setCompleteScanRangeQueueName(Optional<String> completeScanRangeQueueName) {
         _completeScanRangeQueueName = completeScanRangeQueueName;
+        return this;
+    }
+
+    public Optional<String> getS3AssumeRole() {
+        return _s3AssumeRole;
+    }
+
+    public ScannerConfiguration setS3AssumeRole(Optional<String> s3AssumeRole) {
+        _s3AssumeRole = s3AssumeRole;
         return this;
     }
 }


### PR DESCRIPTION
## Github Issue #

 None

## What Are We Doing Here?

There are use cases where Stash may write need to assume a role to write to the Stash bucket, such as if the bucket is in another AWS account.  This PR gives the ability to configure a role to assume for S3 access for Stash.

## How to Test and Verify

Not really testable locally since the changes are dependent on writing to S3.

## Risk

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
