### PR TITLE
Fixed typo in index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -124,7 +124,7 @@ layout: landing-page
                     <header>
                         <h3>System of Record as a Knowledge Base</h3>
                     </header>
-                    <p>By explicitly separating storage from query you can store your data assets as entities without optimizing for retrieval. Emo databus allows for listeners to choose their own datastore for the entities they wish to watch and index. The System of Record is a knowledge base with known ontologies, instead of a data lake that usually beccomes a data swamp.</p>
+                    <p>By explicitly separating storage from query you can store your data assets as entities without optimizing for retrieval. Emo databus allows for listeners to choose their own datastore for the entities they wish to watch and index. The System of Record is a knowledge base with known ontologies, instead of a data lake that usually becomes a data swamp.</p>
                 </section>
 
             </div>


### PR DESCRIPTION
## Github Issue #

Fixed a 'trivial' typo in our external facing documentation for emoDB.