### PR TITLE
Changed blob store DDL to redirect internally to the system data center

### DIFF
--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/core/BlobStoreProviderProxy.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/core/BlobStoreProviderProxy.java
@@ -1,0 +1,141 @@
+package com.bazaarvoice.emodb.blob.core;
+
+import com.bazaarvoice.emodb.blob.api.Blob;
+import com.bazaarvoice.emodb.blob.api.BlobMetadata;
+import com.bazaarvoice.emodb.blob.api.BlobNotFoundException;
+import com.bazaarvoice.emodb.blob.api.BlobStore;
+import com.bazaarvoice.emodb.blob.api.RangeNotSatisfiableException;
+import com.bazaarvoice.emodb.blob.api.RangeSpecification;
+import com.bazaarvoice.emodb.blob.api.Table;
+import com.bazaarvoice.emodb.sor.api.Audit;
+import com.bazaarvoice.emodb.sor.api.TableExistsException;
+import com.bazaarvoice.emodb.sor.api.TableOptions;
+import com.bazaarvoice.emodb.sor.api.UnknownTableException;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.io.InputSupplier;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.joda.time.Duration;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Supports delegation of DDL operations to the system data center.  This implementation uses a Providers for
+ * the blob store injection to prevent re-entrant injection issues.
+ */
+public class BlobStoreProviderProxy implements BlobStore {
+
+    private final Supplier<BlobStore> _local;
+    private final Supplier<BlobStore> _system;
+
+    @Inject
+    public BlobStoreProviderProxy(@LocalBlobStore Provider<BlobStore> local, @SystemBlobStore Provider<BlobStore> system) {
+        // The providers should be singletons.  Even so, locally memoize to ensure use of a singleton.
+        _local = Suppliers.memoize(local::get);
+        _system = Suppliers.memoize(system::get);
+    }
+
+    // Calls which modify the blob store DDL must be redirected to the system data center
+
+    @Override
+    public void createTable(String table, TableOptions options, Map<String, String> attributes, Audit audit)
+            throws TableExistsException {
+        _system.get().createTable(table, options, attributes, audit);
+    }
+
+    @Override
+    public void dropTable(String table, Audit audit) throws UnknownTableException {
+        _system.get().dropTable(table, audit);
+    }
+
+    @Override
+    public void setTableAttributes(String table, Map<String, String> attributes, Audit audit)
+            throws UnknownTableException {
+        _system.get().setTableAttributes(table, attributes, audit);
+    }
+
+    // All other calls can be serviced locally
+
+    @Override
+    public Iterator<Table> listTables(@Nullable String fromTableExclusive, long limit) {
+        return _local.get().listTables(fromTableExclusive, limit);
+    }
+
+    @Override
+    public void purgeTableUnsafe(String table, Audit audit) throws UnknownTableException {
+        _local.get().purgeTableUnsafe(table, audit);
+    }
+
+    @Override
+    public boolean getTableExists(String table) {
+        return _local.get().getTableExists(table);
+    }
+
+    @Override
+    public boolean isTableAvailable(String table) {
+        return _local.get().isTableAvailable(table);
+    }
+
+    @Override
+    public Table getTableMetadata(String table) {
+        return _local.get().getTableMetadata(table);
+    }
+
+    @Override
+    public Map<String, String> getTableAttributes(String table) throws UnknownTableException {
+        return _local.get().getTableAttributes(table);
+    }
+
+    @Override
+    public TableOptions getTableOptions(String table) throws UnknownTableException {
+        return _local.get().getTableOptions(table);
+    }
+
+    @Override
+    public long getTableApproximateSize(String table) throws UnknownTableException {
+        return _local.get().getTableApproximateSize(table);
+    }
+
+    @Override
+    public BlobMetadata getMetadata(String table, String blobId) throws BlobNotFoundException {
+        return _local.get().getMetadata(table, blobId);
+    }
+
+    @Override
+    public Iterator<BlobMetadata> scanMetadata(String table, @Nullable String fromBlobIdExclusive, long limit) {
+        return _local.get().scanMetadata(table, fromBlobIdExclusive, limit);
+    }
+
+    @Override
+    public Blob get(String table, String blobId) throws BlobNotFoundException {
+        return _local.get().get(table, blobId);
+    }
+
+    @Override
+    public Blob get(String table, String blobId, @Nullable RangeSpecification rangeSpec)
+            throws BlobNotFoundException, RangeNotSatisfiableException {
+        return _local.get().get(table, blobId, rangeSpec);
+    }
+
+    @Override
+    public void put(String table, String blobId, InputSupplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
+            throws IOException {
+        _local.get().put(table, blobId, in, attributes, ttl);
+    }
+
+    @Override
+    public void delete(String table, String blobId) {
+        _local.get().delete(table, blobId);
+    }
+
+    @Override
+    public Collection<String> getTablePlacements() {
+        return _local.get().getTablePlacements();
+    }
+}

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/core/LocalBlobStore.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/core/LocalBlobStore.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.blob.core;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation indicating that the annotated object is the 'local' blob store.
+ */
+@BindingAnnotation
+@Target({FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface LocalBlobStore {
+}
+

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/core/SystemBlobStore.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/core/SystemBlobStore.java
@@ -1,0 +1,21 @@
+package com.bazaarvoice.emodb.blob.core;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation indicating that the annotated object is the 'system' blob store client.
+ * The bound object will be a client that makes remote calls to the system data center when
+ * instantiated outside of the system data center.
+ */
+@BindingAnnotation
+@Target({FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface SystemBlobStore {
+}

--- a/blob/src/test/java/com/bazaarvoice/emodb/blob/BlobStoreModuleTest.java
+++ b/blob/src/test/java/com/bazaarvoice/emodb/blob/BlobStoreModuleTest.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.blob;
 
 import com.bazaarvoice.emodb.blob.api.BlobStore;
+import com.bazaarvoice.emodb.blob.core.SystemBlobStore;
 import com.bazaarvoice.emodb.blob.db.astyanax.AstyanaxStorageProvider;
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
 import com.bazaarvoice.emodb.common.cassandra.CassandraConfiguration;
@@ -112,6 +113,7 @@ public class BlobStoreModuleTest {
                         .setSystemDataCenter("datacenter1")
                         .setCurrentDataCenter("datacenter1"));
 
+                bind(BlobStore.class).annotatedWith(SystemBlobStore.class).toInstance(mock(BlobStore.class));
                 bind(HostAndPort.class).annotatedWith(SelfHostAndPort.class).toInstance(HostAndPort.fromString("localhost:8080"));
                 bind(Client.class).toInstance(mock(Client.class));
                 bind(CacheRegistry.class).toInstance(rootCacheRegistry);

--- a/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
@@ -8,6 +8,7 @@ import com.bazaarvoice.emodb.blob.api.BlobMetadata;
 import com.bazaarvoice.emodb.blob.api.BlobNotFoundException;
 import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.blob.api.Table;
+import com.bazaarvoice.emodb.blob.core.SystemBlobStore;
 import com.bazaarvoice.emodb.cachemgr.CacheManagerModule;
 import com.bazaarvoice.emodb.cachemgr.invalidate.InvalidationService;
 import com.bazaarvoice.emodb.common.cassandra.CassandraConfiguration;
@@ -131,6 +132,7 @@ public class CasBlobStoreTest {
                                 "app_global", new TestCassandraConfiguration("app_global", "sys_delta")))
                         .setHistoryTtl(Period.days(2)));
                 bind(DataStore.class).annotatedWith(SystemDataStore.class).toInstance(mock(DataStore.class));
+                bind(BlobStore.class).annotatedWith(SystemBlobStore.class).toInstance(mock(BlobStore.class));
                 bind(JobService.class).toInstance(mock(JobService.class));
                 bind(JobHandlerRegistry.class).toInstance(mock(JobHandlerRegistry.class));
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -117,6 +117,17 @@
         </dependency>
         <dependency>
             <groupId>com.bazaarvoice.emodb</groupId>
+            <artifactId>emodb-blob-client</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.bazaarvoice.emodb</groupId>
             <artifactId>emodb-plugins</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -6,6 +6,10 @@ import com.bazaarvoice.emodb.auth.AuthZooKeeper;
 import com.bazaarvoice.emodb.blob.BlobStoreConfiguration;
 import com.bazaarvoice.emodb.blob.BlobStoreModule;
 import com.bazaarvoice.emodb.blob.BlobStoreZooKeeper;
+import com.bazaarvoice.emodb.blob.api.BlobStore;
+import com.bazaarvoice.emodb.blob.client.BlobStoreClient;
+import com.bazaarvoice.emodb.blob.client.BlobStoreClientFactory;
+import com.bazaarvoice.emodb.blob.core.SystemBlobStore;
 import com.bazaarvoice.emodb.cachemgr.CacheManagerModule;
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
 import com.bazaarvoice.emodb.cachemgr.invalidate.InvalidationService;
@@ -353,6 +357,31 @@ public class EmoModule extends AbstractModule {
         @Provides @Singleton @BlobStoreZooKeeper
         CuratorFramework provideBlobStoreZooKeeperConnection(@Global CuratorFramework curator) {
             return withComponentNamespace(curator, "blob");
+        }
+
+        /** Provides a BlobStore client that delegates to the remote system center data store. */
+        @Provides @Singleton @SystemBlobStore
+        BlobStore provideSystemBlobStore (DataCenterConfiguration config, Client jerseyClient, @Named ("AdminKey") String apiKey, MetricRegistry metricRegistry) {
+
+            ServiceFactory<BlobStore> clientFactory = BlobStoreClientFactory
+                    .forClusterAndHttpClient(_configuration.getCluster(), jerseyClient)
+                    .usingCredentials(apiKey);
+
+            URI uri = config.getSystemDataCenterServiceUri();
+            ServiceEndPoint endPoint = new ServiceEndPointBuilder()
+                    .withServiceName(clientFactory.getServiceName())
+                    .withId(config.getSystemDataCenter())
+                    .withPayload(new PayloadBuilder()
+                            .withUrl(uri.resolve(BlobStoreClient.SERVICE_PATH))
+                            .withAdminUrl(uri)
+                            .toString())
+                    .build();
+
+            return ServicePoolBuilder.create(BlobStore.class)
+                    .withMetricRegistry(metricRegistry)
+                    .withHostDiscovery(new FixedHostDiscovery(endPoint))
+                    .withServiceFactory(clientFactory)
+                    .buildProxy(new ExponentialBackoffRetry(30, 1, 10, TimeUnit.SECONDS));
         }
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -359,7 +359,7 @@ public class EmoModule extends AbstractModule {
             return withComponentNamespace(curator, "blob");
         }
 
-        /** Provides a BlobStore client that delegates to the remote system center data store. */
+        /** Provides a BlobStore client that delegates to the remote system center blob store. */
         @Provides @Singleton @SystemBlobStore
         BlobStore provideSystemBlobStore (DataCenterConfiguration config, Client jerseyClient, @Named ("AdminKey") String apiKey, MetricRegistry metricRegistry) {
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -14,7 +14,6 @@ import com.bazaarvoice.emodb.common.json.deferred.LazyJsonModule;
 import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
 import com.bazaarvoice.emodb.databus.core.DatabusEventStore;
 import com.bazaarvoice.emodb.databus.repl.ReplicationSource;
-import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.plugin.lifecycle.ServerStartedListener;
 import com.bazaarvoice.emodb.queue.api.DedupQueueService;
 import com.bazaarvoice.emodb.queue.api.QueueService;
@@ -45,8 +44,8 @@ import com.bazaarvoice.emodb.web.resources.queue.QueueResource1;
 import com.bazaarvoice.emodb.web.resources.report.ReportResource1;
 import com.bazaarvoice.emodb.web.resources.sor.DataStoreResource1;
 import com.bazaarvoice.emodb.web.resources.uac.ApiKeyResource1;
-import com.bazaarvoice.emodb.web.resources.uac.UserAccessControlRequestMessageBodyReader;
 import com.bazaarvoice.emodb.web.resources.uac.RoleResource1;
+import com.bazaarvoice.emodb.web.resources.uac.UserAccessControlRequestMessageBodyReader;
 import com.bazaarvoice.emodb.web.resources.uac.UserAccessControlResource1;
 import com.bazaarvoice.emodb.web.scanner.ScanUploader;
 import com.bazaarvoice.emodb.web.scanner.resource.ScanUploadResource1;
@@ -247,13 +246,12 @@ public class EmoService extends Application<EmoConfiguration> {
             return;
         }
 
-        DataCenters dataCenters = _injector.getInstance(DataCenters.class);
         BlobStore blobStore = _injector.getInstance(BlobStore.class);
         Set<String> approvedContentTypes = _injector.getInstance(
                 Key.get(new TypeLiteral<Set<String>>(){}, ApprovedBlobContentTypes.class));
         // Start the Blob service
         ResourceRegistry resources = _injector.getInstance(ResourceRegistry.class);
-        resources.addResource(_cluster, "emodb-blob-1", new BlobStoreResource1(blobStore, dataCenters, approvedContentTypes));
+        resources.addResource(_cluster, "emodb-blob-1", new BlobStoreResource1(blobStore, approvedContentTypes));
     }
 
     private void evaluateDatabus()


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Blob store DDL changes (creating and dropping tables primarily) must be done in the system data center to avoid potential conflicts where multiple users try to perform like operations on the same table concurrently.  Data store has this same requirement.  The way data store handles it is to internally forward DDL calls from the non-system data center to the system data center.  Blob store works differently; it returns a 301 (moved permanently) response with the URI of the system data center.

We recently discovered a flaw in the way blob store's solution works.  If the client and blob store service are in separate domains it's possible the redirect URI returned by blob store is inaccessible by the client.  A more robust approach would be to use the data store solution; have the blob store internally forward the DDL call to the system data center.

This PR does exactly that.  Additionally to avoid awkward 500 errors the few DDL calls not implemented in blob store client also had to be implemented.  These were originally unimplemented because Emo at the time did not have API keys, so it was a poor-man's solution to prevent clients from making calls they normally shouldn't.  Now that API keys are used an prevent unauthorized DDL calls this obfuscation is no longer necessary.

## How to Test and Verify

1. Running Emo in two data centers.
2. Create and drop tables from both data centers.
3. Verify that all DDL calls are forwarded to the system data center.

## Risk

This is a low risk change.  Core functionality is not being modified, only the forwarding of requests to the system data center which, as previously mentioned, is the approach already taken by data store.

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

There is one design decision which should be mentioned.  The system blob store client used in the non-system data center always authenticates as an admin.  This opens the potential for privilege escalation for DDL calls in the non-system data center which are forwarded to the system data center.  This should be addressed at some point, but my justification for the approach taken in this PR are:

- The caller is already authenticated in the non-system data center, so the call will only be forwarded if the caller had permission to perform the operation.
- There are only three calls which are forwarded -- create table, drop table, and set table attributes -- and all of these operations have no side effects which require additional permissions beyond those already checked by the non-system data center.
- Data store already takes the approach used here, so it would make sense to refactor both at the same time to use authenticators.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
