### PR TITLE
Changed API facing uses of CL_ONE to CL_LOCAL_ONE

### DIFF
--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/db/astyanax/AstyanaxStorageProvider.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/db/astyanax/AstyanaxStorageProvider.java
@@ -99,7 +99,7 @@ public class AstyanaxStorageProvider implements StorageProvider, DataCopyDAO, Da
 
     private static final int DEFAULT_CHUNK_SIZE = 0x10000; // 64kb
     private static final ConsistencyLevel CONSISTENCY_STRONG = ConsistencyLevel.CL_LOCAL_QUORUM;
-    private static final ConsistencyLevel CONSISTENCY_WEAK = ConsistencyLevel.CL_ONE;
+    private static final ConsistencyLevel CONSISTENCY_WEAK = ConsistencyLevel.CL_LOCAL_ONE;
     private static final int MAX_SCAN_METADATA_BATCH_SIZE = 250;
 
     private final Token.TokenFactory _tokenFactory;

--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/ConsistencyTopologyAdapter.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/ConsistencyTopologyAdapter.java
@@ -21,7 +21,7 @@ public class ConsistencyTopologyAdapter {
         if ((consistencyLevel == ConsistencyLevel.CL_LOCAL_QUORUM || consistencyLevel == ConsistencyLevel.CL_EACH_QUORUM) && !_networkTopology) {
             consistencyLevel = ConsistencyLevel.CL_QUORUM;
         }
-        if (consistencyLevel == ConsistencyLevel.CL_LOCAL_ONE || !_networkTopology) {
+        if (consistencyLevel == ConsistencyLevel.CL_LOCAL_ONE && !_networkTopology) {
             consistencyLevel = ConsistencyLevel.CL_ONE;
         }
 

--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/ConsistencyTopologyAdapter.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/ConsistencyTopologyAdapter.java
@@ -21,6 +21,9 @@ public class ConsistencyTopologyAdapter {
         if ((consistencyLevel == ConsistencyLevel.CL_LOCAL_QUORUM || consistencyLevel == ConsistencyLevel.CL_EACH_QUORUM) && !_networkTopology) {
             consistencyLevel = ConsistencyLevel.CL_QUORUM;
         }
+        if (consistencyLevel == ConsistencyLevel.CL_LOCAL_ONE || !_networkTopology) {
+            consistencyLevel = ConsistencyLevel.CL_ONE;
+        }
 
         // we may want to write to at two or three servers to ensure the write survives the
         // permanent failure of any single server.  but if the ring has fewer servers to

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -165,7 +165,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
         // we can't trust results w/ConsistencyLevel.CL_ONE.
 
         Iterable<Column<ByteBuffer>> manifestColumns = executePaginated(
-                _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_ONE)
+                _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_LOCAL_ONE)
                         .getKey(channel)
                         .withColumnRange(new RangeBuilder().setLimit(100).build())
                         .autoPaginate(true));
@@ -175,7 +175,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
 
             if (total <= limit) {
                 int count = execute(
-                        _keyspace.prepareQuery(ColumnFamilies.SLAB, ConsistencyLevel.CL_ONE)
+                        _keyspace.prepareQuery(ColumnFamilies.SLAB, ConsistencyLevel.CL_LOCAL_ONE)
                                 .getKey(slabId)
                                 .withColumnRange(0, Constants.OPEN_SLAB_MARKER - 1, false, Integer.MAX_VALUE)
                                 .getCount());
@@ -185,7 +185,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
                 // Clients may just want to distinguish "a few" vs. "lots.  Calculate an exact count up to 'limit'
                 // then estimate anything larger by counting slabs and assuming each has a full set of events.
                 int slabs = execute(
-                        _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_ONE)
+                        _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_LOCAL_ONE)
                                 .getKey(channel)
                                 .withColumnRange(new RangeBuilder().setStart(slabId).build())
                                 .getCount());
@@ -285,7 +285,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
         //    data is written and first read.
 
         Iterable<Column<ByteBuffer>> manifestColumns = executePaginated(
-                _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_ONE)
+                _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_LOCAL_ONE)
                         .getKey(channel)
                         .withColumnRange(new RangeBuilder().setLimit(50).build())
                         .autoPaginate(true));

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/SorConsistencies.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/SorConsistencies.java
@@ -13,7 +13,7 @@ abstract class SorConsistencies {
     public static ConsistencyLevel toAstyanax(ReadConsistency consistency) {
         switch (consistency) {
             case WEAK:
-                return ConsistencyLevel.CL_ONE;           // first node to respond
+                return ConsistencyLevel.CL_LOCAL_ONE;           // first node to respond
             case STRONG:
                 return ConsistencyLevel.CL_LOCAL_QUORUM;  // single data center quorum
             default:
@@ -24,7 +24,7 @@ abstract class SorConsistencies {
     public static com.datastax.driver.core.ConsistencyLevel toCql(ReadConsistency consistency) {
         switch (consistency) {
             case WEAK:
-                return com.datastax.driver.core.ConsistencyLevel.ONE;
+                return com.datastax.driver.core.ConsistencyLevel.LOCAL_ONE;
             case STRONG:
                 return com.datastax.driver.core.ConsistencyLevel.LOCAL_QUORUM;
             default:


### PR DESCRIPTION
## Github Issue

None

## What Are We Doing Here?

While launching new Cassandra data centers we found that the use of CL_ONE instead of CL_LOCAL_ONE was forwarding queries to the unprepared data centers.  This PR replaces all uses operational uses of CL_ONE with CL_LOCAL_ONE.  The only exception is in the Cassandra health check.

## How to Test and Verify

1. Check out this PR
2. Run through normal services, particularly around blob store since it most heavily utilizes weak consistency reads.

## Risk

Low.  Logically CL_LOCAL_ONE should be more localized than CL_ONE.

### Level 

`Low

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
