### PR TITLE
Added finer metrics around 5xx errors

### DIFF
--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/jersey/ServerErrorResponseMetricsFilter.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/jersey/ServerErrorResponseMetricsFilter.java
@@ -1,0 +1,52 @@
+package com.bazaarvoice.emodb.common.dropwizard.jersey;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * By default DropWizard includes a metric tracking all 5xx errors returned by the application:
+ * "io.dropwizard.jetty.MutableServletContextHandler.5xx-responses".  However, it is frequently useful to
+ * track 5xx responses by specific response code.  For example, a spike in 500 errors may indicate a different issue
+ * from a spike in 503 errors and it may be desirable to tune logging and alerting around these independently.
+ *
+ * This filter maintains metrics for 500 and 503 responses independently.  All other 5xx responses are grouped together
+ * in a third "other" metric since as of this writing none are explicitly returned by EmoDB.  There is no metric
+ * which counts all 5xx errors since that would be redundant with the DropWizard metric.
+ *
+ * @see org.eclipse.jetty.server.handler.StatisticsHandler
+ */
+public class ServerErrorResponseMetricsFilter implements ContainerResponseFilter {
+
+    private final Meter _meter500;
+    private final Meter _meter503;
+    private final Meter _meterOther;
+    
+    public ServerErrorResponseMetricsFilter(MetricRegistry metricRegistry) {
+        _meter500 = metricRegistry.meter(MetricRegistry.name("bv.emodb.web", "500-responses"));
+        _meter503 = metricRegistry.meter(MetricRegistry.name("bv.emodb.web", "503-responses"));
+        _meterOther = metricRegistry.meter(MetricRegistry.name("bv.emodb.web", "5xx-other-responses"));
+    }
+
+    @Override
+    public ContainerResponse filter(ContainerRequest request, ContainerResponse response) {
+        if (response.getStatusType().getFamily() == Response.Status.Family.SERVER_ERROR) {
+            switch (response.getStatus()) {
+                case 500:
+                    _meter500.mark();
+                    break;
+                case 503:
+                    _meter503.mark();
+                    break;
+                default:
+                    _meterOther.mark();
+                    break;
+            }
+        }
+        return response;
+    }
+}

--- a/quality/integration/src/test/java/test/integration/uac/UserAccessControlJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/uac/UserAccessControlJerseyTest.java
@@ -41,6 +41,7 @@ import com.bazaarvoice.emodb.web.resources.uac.RoleResource1;
 import com.bazaarvoice.emodb.web.resources.uac.UserAccessControlRequestMessageBodyReader;
 import com.bazaarvoice.emodb.web.resources.uac.UserAccessControlResource1;
 import com.bazaarvoice.emodb.web.uac.LocalSubjectUserAccessControl;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -86,7 +87,7 @@ public class UserAccessControlJerseyTest extends ResourceTest {
         _roleManager = new InMemoryRoleManager(permissionManager);
 
         LocalSubjectUserAccessControl uac = new LocalSubjectUserAccessControl(_roleManager, permissionResolver,
-                _authIdentityManager, HostAndPort.fromParts("localhost", 8080));
+                _authIdentityManager, HostAndPort.fromParts("localhost", 8080), new MetricRegistry());
         
         createRole(_roleManager, null, "uac-all", ImmutableSet.of("role|*", "apikey|*"));
         createRole(_roleManager, null, "uac-none", ImmutableSet.of());

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -457,7 +457,8 @@ public class EmoModule extends AbstractModule {
             SubjectDatabus client = ServicePoolBuilder.create(SubjectDatabus.class)
                     .withHostDiscovery(hostDiscovery)
                     .withServiceFactory(
-                            new PartitionAwareServiceFactory<>(SubjectDatabus.class, serviceFactory, localSubjectDatabus, self, healthCheckRegistry))
+                            new PartitionAwareServiceFactory<>(SubjectDatabus.class, serviceFactory, localSubjectDatabus,
+                                    self, healthCheckRegistry, metricRegistry))
                     .withMetricRegistry(metricRegistry)
                     .withCachingPolicy(ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy())
                     .buildProxy(new ExponentialBackoffRetry(5, 50, 1000, TimeUnit.MILLISECONDS));
@@ -501,7 +502,7 @@ public class EmoModule extends AbstractModule {
             MultiThreadedServiceFactory<AuthQueueService> serviceFactory = new PartitionAwareServiceFactory<>(
                     AuthQueueService.class,
                     QueueClientFactory.forClusterAndHttpClient(_configuration.getCluster(), jerseyClient),
-                    new TrustedQueueService(queueService), self, healthCheckRegistry);
+                    new TrustedQueueService(queueService), self, healthCheckRegistry, metricRegistry);
             AuthQueueService client = ServicePoolBuilder.create(AuthQueueService.class)
                     .withHostDiscovery(new ZooKeeperHostDiscovery(curator, serviceFactory.getServiceName(), metricRegistry))
                     .withServiceFactory(serviceFactory)
@@ -533,11 +534,14 @@ public class EmoModule extends AbstractModule {
         @Provides @Singleton @PartitionAwareClient
         DedupQueueServiceAuthenticator provideDedupQueueClient(MultiThreadedServiceFactory<AuthDedupQueueService> serviceFactory,
                                                                @DedupQueueHostDiscovery HostDiscovery hostDiscovery,
-                                                               DedupQueueService databus, @SelfHostAndPort HostAndPort self, HealthCheckRegistry healthCheckRegistry) {
+                                                               DedupQueueService databus, @SelfHostAndPort HostAndPort self,
+                                                               HealthCheckRegistry healthCheckRegistry,
+                                                               MetricRegistry metricRegistry) {
             AuthDedupQueueService client = ServicePoolBuilder.create(AuthDedupQueueService.class)
                     .withHostDiscovery(hostDiscovery)
                     .withServiceFactory(new PartitionAwareServiceFactory<>(
-                            AuthDedupQueueService.class, serviceFactory, new TrustedDedupQueueService(databus), self, healthCheckRegistry))
+                            AuthDedupQueueService.class, serviceFactory, new TrustedDedupQueueService(databus), self,
+                            healthCheckRegistry, metricRegistry))
                     .withMetricRegistry(_environment.metrics())
                     .withCachingPolicy(ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy())
                     .buildProxy(new ExponentialBackoffRetry(5, 50, 1000, TimeUnit.MILLISECONDS));

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -5,6 +5,7 @@ import com.bazaarvoice.emodb.blob.api.BlobStore;
 import com.bazaarvoice.emodb.cachemgr.invalidate.InvalidationService;
 import com.bazaarvoice.emodb.common.dropwizard.discovery.ManagedRegistration;
 import com.bazaarvoice.emodb.common.dropwizard.discovery.ResourceRegistry;
+import com.bazaarvoice.emodb.common.dropwizard.jersey.ServerErrorResponseMetricsFilter;
 import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
 import com.bazaarvoice.emodb.common.dropwizard.metrics.EmoGarbageCollectorMetricSet;
 import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
@@ -217,6 +218,11 @@ public class EmoService extends Application<EmoConfiguration> {
         _environment.servlets().addServlet("/ping", new PingServlet());
         // Serve static assets
         _environment.jersey().register(FaviconResource.class);
+
+        // Add a filter to provide finer 5xx metrics than the default DropWizard metrics include.
+        //noinspection unchecked
+        _environment.jersey().getResourceConfig().getContainerResponseFilters()
+                .add(new ServerErrorResponseMetricsFilter(_environment.metrics()));
     }
 
     private void evaluateInvalidateCaches()

--- a/web/src/main/java/com/bazaarvoice/emodb/web/partition/PartitionAwareServiceFactory.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/partition/PartitionAwareServiceFactory.java
@@ -5,6 +5,8 @@ import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
 import com.bazaarvoice.ostrich.ServiceEndPoint;
 import com.bazaarvoice.ostrich.ServiceFactory;
 import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheck;
 import com.google.common.base.Predicate;
 import com.google.common.base.Throwables;
@@ -31,15 +33,19 @@ public class PartitionAwareServiceFactory<S> implements MultiThreadedServiceFact
     private final S _local;
     private final String _localId;
     private final HealthCheckRegistry _healthCheckRegistry;
+    private final Meter _errorMeter;
     private final Map<S, S> _proxiedToDelegateServices = Maps.newIdentityHashMap();
 
     public PartitionAwareServiceFactory(Class<S> serviceClass, MultiThreadedServiceFactory<S> delegate, S local,
-                                        HostAndPort self, HealthCheckRegistry healthCheckRegistry) {
+                                        HostAndPort self, HealthCheckRegistry healthCheckRegistry,
+                                        MetricRegistry metricRegistry) {
         _serviceClass = checkNotNull(serviceClass, "serviceClass");
         _delegate = checkNotNull(delegate, "delegate");
         _local = checkNotNull(local, "local");
         _localId = self.toString();
         _healthCheckRegistry = healthCheckRegistry;
+        _errorMeter = metricRegistry.meter(MetricRegistry.name("bv.emodb.web.partition-forwarding",
+                serviceClass.getSimpleName(), "errors"));
     }
 
     @Override
@@ -109,6 +115,7 @@ public class PartitionAwareServiceFactory<S> implements MultiThreadedServiceFact
                     // It's possible the connection timed out due to a problem on the target, but from our perspective
                     // there's no definitive way of knowing.
                     if (targetException instanceof ClientHandlerException) {
+                        _errorMeter.mark();
                         throw new PartitionForwardingException("Failed to handle request at endpoint", targetException.getCause());
                     }
                     throw Throwables.propagate(targetException);


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

There is a single metric, "io.dropwizard.jetty.MutableServletContextHandler.5xx-responses", which tracks all 5xx responses.  We've found that it would be beneficial if we could track 503s (which come from a finite set of known causes) independently from 500s (which don't).

This PR adds several new metrics:

- At a broad level it adds metrics specifically for 500 and 503 errors.
- At a finer level there are new metrics which track what is precipitating the 503 errors.

## How to Test and Verify

It's difficult to test this locally since the root cause for 503 errors typically requires the use of multiple servers.  You can, however, verify that the metrics exist:

1. Check out this PR
2. Run Emo using `web-local/start.sh`
3. `curl localhost:8081/metrics`
4. Verify the new metrics exist, such as "bv.emodb.web.500-responses", "bv.emodb.web.503-responses", "bv.emodb.web.partition-forwarding.SubjectDatabus.errors" and "bv.emodb.web.uac.acquire-update-lock.timeouts".

## Risk

This is a low risk update.  Nothing in the business critical path is changing.  This PR only adds a new response filter and some metrics.

### Level 

`Low`

### Required Testing

`Regression`


## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
