### PR TITLE
add delta size metric

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
@@ -27,6 +27,7 @@ import com.bazaarvoice.emodb.table.db.TableSet;
 import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxStorage;
 import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxTable;
 import com.bazaarvoice.emodb.table.db.astyanax.PlacementCache;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -108,6 +109,7 @@ public class CqlDataReaderDAO implements DataReaderDAO {
     private final CqlDriverConfiguration _driverConfig;
     private final Meter _randomReadMeter;
     private final Timer _readBatchTimer;
+    private final Histogram _deltaSizeHistogram;
 
     // Support AB testing of various uses of the CQL driver versus the older but (at this point) more vetted Astyanax driver.
     private volatile Supplier<Boolean> _useCqlForMultiGets = Suppliers.ofInstance(true);
@@ -123,6 +125,7 @@ public class CqlDataReaderDAO implements DataReaderDAO {
         _changeEncoder = changeEncoder;
         _randomReadMeter = metricRegistry.meter(getMetricName("random-reads"));
         _readBatchTimer = metricRegistry.timer(getMetricName("readBatch"));
+        _deltaSizeHistogram = metricRegistry.histogram(getMetricName("delta-size"));
     }
 
     private String getMetricName(String name) {
@@ -278,6 +281,17 @@ public class CqlDataReaderDAO implements DataReaderDAO {
      */
     private Record newRecordFromCql(Key key, Iterable<Row> rows) {
         Iterator<Map.Entry<UUID, Change>> changeIter = decodeChangesFromCql(rows.iterator());
+        Iterator<Map.Entry<UUID, Compaction>> compactionIter = decodeCompactionsFromCql(rows.iterator());
+        Iterator<RecordEntryRawMetadata> rawMetadataIter = rawMetadataFromCql(rows.iterator());
+
+        return new RecordImpl(key, compactionIter, changeIter, rawMetadataIter);
+    }
+
+    private Record newRecordFromCqlForStash(Key key, Iterable<Row> rows) {
+        Iterator<Map.Entry<UUID, Change>> changeIter = Iterators.transform(rows.iterator(), row -> {
+            _deltaSizeHistogram.update(getValue(row).remaining());
+            return Maps.immutableEntry(getChangeId(row), _changeEncoder.decodeChange(getChangeId(row), getValue(row)));
+        });
         Iterator<Map.Entry<UUID, Compaction>> compactionIter = decodeCompactionsFromCql(rows.iterator());
         Iterator<RecordEntryRawMetadata> rawMetadataIter = rawMetadataFromCql(rows.iterator());
 
@@ -637,7 +651,7 @@ public class CqlDataReaderDAO implements DataReaderDAO {
 
                     int shardId = AstyanaxStorage.getShardId(rowKey);
                     String key = AstyanaxStorage.getContentKey(rowKey);
-                    Record record = newRecordFromCql(new Key(_table, key), filteredRows);
+                    Record record = newRecordFromCqlForStash(new Key(_table, key), filteredRows);
                     return new MultiTableScanResult(rowKey, shardId, tableUuid, _droppedTable, record);
                 }
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Adding metrics to stash in order to get a basic benchmark of what the size distribution of deltas is. This change should be temporary, as we really only need these metrics for a single stash.

## How to Test and Verify

1. Check out this PR
2. Run Emo using `web-local/start.sh`
3. `curl localhost:8081/metrics`
4. Verify the new `bv.emodb.sor.CqlDataReaderDAO.delta-size` metric exists

## Risk
It's difficult to test this locally, as our local stash configuration has issues, but the only change this makes is adding a metric so it's hard to foresee any potential issues.

There is a question of how much time this will add to stash, but I can't see a single metric adding any significant overhead.

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
