### PR TITLE
EMO-6444: Changed partitioner validation to accept Emo BOP implementation

### DIFF
--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/CassandraPartitioner.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/CassandraPartitioner.java
@@ -39,7 +39,28 @@ public enum CassandraPartitioner {
 
         @Override
         public boolean matches(String cassandraPartitioner) {
-            return ByteOrderedPartitioner.class.getName().equals(cassandraPartitioner);
+            return ByteOrderedPartitioner.class.getName().equals(cassandraPartitioner) ||
+                    isEmoBOPImplementation(cassandraPartitioner);
+        }
+
+        /**
+         * EmoDB requires a partitioner whose token generation is identical to {@link ByteOrderedPartitioner}.
+         * However, the Emo team has found it beneficial to sometimes utilize an alternate implementation of BOP
+         * in the Cassandra ring, whether for logging or to solve performance issues of the partitioner unrelated to
+         * the task of generating tokens.
+         *
+         * Currently EmoDB uses a mix of the native Cassandra driver and the thrift Astyanax driver.  Without going
+         * into the full details of why this is or why it would be difficult to abandon Asytanax completely it is
+         * undesirable to create a new implementation of the Astyanax {@link Partitioner} class for each alternate
+         * BOP implementation. This is especially true since Astyanax only requires the partitioner for a limited
+         * number of calls and for those the implementation would be identical to that in {@link BOP20Partitioner}.
+         *
+         * As a compromise, rather than create a new partitioner implementation for each alternate BOP implementation or
+         * even require an enumeration of all possible alternate BOP implementations this method simply looks for the
+         * substring "emo" within the partitioner name and, if found, presumes it is a BOP-compatible partitioner.
+         */
+        private boolean isEmoBOPImplementation(String cassandraPartitioner) {
+            return cassandraPartitioner.toLowerCase().contains("emo");
         }
     };
 

--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/CassandraPartitioner.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/CassandraPartitioner.java
@@ -45,22 +45,21 @@ public enum CassandraPartitioner {
 
         /**
          * EmoDB requires a partitioner whose token generation is identical to {@link ByteOrderedPartitioner}.
-         * However, the Emo team has found it beneficial to sometimes utilize an alternate implementation of BOP
-         * in the Cassandra ring, whether for logging or to solve performance issues of the partitioner unrelated to
-         * the task of generating tokens.
+         * However, the EmoDB team has found that ByteOrderedPartitioner itself has inefficiencies at scale unrelated to
+         * token management.  To address this the EmoDB team has created an alternate implementation, EmoPartitioner,
+         * which resolves these inefficiencies while otherwise behaving identically to BOP.  (As of this writing
+         * EmoPartitioner is not yet open sourced but this is the intention.)
          *
          * Currently EmoDB uses a mix of the native Cassandra driver and the thrift Astyanax driver.  Without going
-         * into the full details of why this is or why it would be difficult to abandon Asytanax completely it is
-         * undesirable to create a new implementation of the Astyanax {@link Partitioner} class for each alternate
-         * BOP implementation. This is especially true since Astyanax only requires the partitioner for a limited
-         * number of calls and for those the implementation would be identical to that in {@link BOP20Partitioner}.
+         * into the full details of why this is or why it would be difficult to abandon Asytanax completely, to support
+         * EmoPartitioner we would normally need to create a corresponding implementation of the Astyanax
+         * {@link Partitioner} for it.  However, Astyanax only requires the partitioner for a limited number of
+         * calls and for those the implementation would be identical to that in {@link BOP20Partitioner}  So if
+         * the Cassandra partitioner is EmoPartitioner then return BOP as an equivalent substitute.
          *
-         * As a compromise, rather than create a new partitioner implementation for each alternate BOP implementation or
-         * even require an enumeration of all possible alternate BOP implementations this method simply looks for the
-         * substring "emo" within the partitioner name and, if found, presumes it is a BOP-compatible partitioner.
          */
         private boolean isEmoBOPImplementation(String cassandraPartitioner) {
-            return cassandraPartitioner.toLowerCase().contains("emo");
+            return "com.bazaarvoice.emodb.partitioner.EmoPartitioner".equals(cassandraPartitioner);
         }
     };
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

The Emo team has been running experiments using an alternate implementation of `ByteOrderedPartitioner`.  The short version for why is to address performance issues with BOP we are observing in versions of Cassandra 2.1+ which we have proven to be related to the default BOP implementation.  However, there are several places where EmoDB explicitly checks for the partitioner in use and, if it isn't exactly BOP, fails to start.

This PR allows EmoDB to start if the partitioner in use is BOP or if it is a specific implementation, `com.bazaarvoice.emodb.partitioner.EmoPartitioner`, which behaves identically to BOP.

## How to Test and Verify

Really the only check to be done is regression.  Checkout EmoDB and run the usual integration tests.

## Risk

The risk with this approach is tied to any problems with EmoPartitioner itself, which is unrelated to the EmoDB project.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
