### PR TITLE
Added unique cluster metric names

### DIFF
--- a/sdk/src/main/resources/emodb-default-config.yaml
+++ b/sdk/src/main/resources/emodb-default-config.yaml
@@ -68,6 +68,7 @@ systemOfRecord:
   cassandraClusters:
     emo:
       cluster: emo_cluster
+      clusterMetric: sor_emo_cluster
       dataCenter: datacenter1
       seeds: 127.0.0.1
       # zooKeeperServiceName: dev_sor_ugc_default-cassandra
@@ -92,6 +93,7 @@ databus:
   # Cassandra connection settings
   cassandra:
     cluster: Databus Cluster
+    clusterMetric: databus_emo_cluster
     dataCenter: datacenter1
     seeds: 127.0.0.1
     # zooKeeperServiceName: dev_datacenter1_databus_default-cassandra
@@ -118,6 +120,7 @@ blobStore:
   cassandraClusters:
     media_global:
       cluster: emo_cluster
+      clusterMetric: blob_emo_cluster
       dataCenter: datacenter1
       seeds: 127.0.0.1
       # zooKeeperServiceName: dev_sor_ugc_default-cassandra
@@ -155,6 +158,7 @@ queueService:
   # Cassandra connection settings
   cassandra:
     cluster: Databus Cluster
+    clusterMetric: queue_emo_cluster
     dataCenter: datacenter1
     seeds: 127.0.0.1
     # zooKeeperServiceName: dev_datacenter1_databus_default-cassandra


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

There is a minor configuration issue which prevents the Maven SDK plugin from starting Emo with the default configuration file.  Because the same cluster name is used by multiple clusters the server will fail to start with numerous stack trace such as:

```
Error in custom provider, java.lang.IllegalArgumentException: A metric named bv.emodb.astyanax.Databus Cluster.ConnectionPool.open-connections already exists
```

This PR updates each cluster to have a unique metric name, which resolves this issue.

## How to Test and Verify

1. Check out this PR
2. Build Emo
3. Start Emo using the config files in `/sdk/src/main/resources`
4. Verify it starts OK

## Risk

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

This only affects EmoDB when started using the Maven SDK plugin, and this is already broken without the fix, so risk is low.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
