### PR TITLE
Changed anonymous permissions to be configurable using UAC API

### DIFF
--- a/docs/_posts/2016-08-31-securityadmin.md
+++ b/docs/_posts/2016-08-31-securityadmin.md
@@ -70,16 +70,14 @@ other sensitive credential.
 Anonymous Access
 ----------------
 
-If you choose you can configure EmoDB to allow anonymous access.  An anonymous user has full permission to perform
-most standard operations in the data store, blob, databus, and queue services (see
-[DefaultRoles.java](https://github.com/bazaarvoice/emodb/blob/master/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java#L126)
-for full anonymous permissions).  While we don't recommend running EmoDB with anonymous access enabled it does
-lower the bar for quickly getting going with EmoDB.  To enable anonymous access set the following attribute in
-your `config.yaml` file:
+If you choose you can configure EmoDB to allow anonymous access.  An anonymous user has the roles explicitly defined
+in `config.yaml`.  The permissions associated with those roles can be configured using the User Access Control API.
+To enable anonymous access set the following attribute with the anonymous role(s) in your `config.yaml` file:
 
 ```
 auth:
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - list_of_roles
 ```
 
 Anonymous access enables the following behavior:

--- a/quality/integration/pom.xml
+++ b/quality/integration/pom.xml
@@ -200,6 +200,17 @@
                             <autoStartEmo>true</autoStartEmo>
                             <skip>${skipTests}</skip>
                             <emoLogFile>${basedir}/target/emodb-main.log</emoLogFile>
+                            <roles>
+                                <role>
+                                    <name>anonymous</name>
+                                    <permissions>
+                                        <permission>sor|if(or("read","create_table"))|*</permission>
+                                        <permission>blob|read|*</permission>
+                                        <permission>databus|*</permission>
+                                        <permission>queue|*</permission>
+                                    </permissions>
+                                </role>
+                            </roles>
                         </configuration>
                     </execution>
 

--- a/quality/integration/src/test/resources/config-blob-role.yaml
+++ b/quality/integration/src/test/resources/config-blob-role.yaml
@@ -183,7 +183,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/quality/integration/src/test/resources/config-main-role.yaml
+++ b/quality/integration/src/test/resources/config-main-role.yaml
@@ -156,7 +156,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:

--- a/quality/integration/src/test/resources/config-stash-role.yaml
+++ b/quality/integration/src/test/resources/config-stash-role.yaml
@@ -164,7 +164,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 
 scanner:

--- a/sdk/src/main/java/com/bazaarvoice/emodb/sdk/EmoStartMojo.java
+++ b/sdk/src/main/java/com/bazaarvoice/emodb/sdk/EmoStartMojo.java
@@ -306,7 +306,7 @@ public class EmoStartMojo extends AbstractEmoMojo {
                         .path(name)
                         .queryParam("APIKey", adminApiKey)
                         .type("application/x.json-create-role")
-                        .put(String.class, JsonHelper.asJson(entity));
+                        .post(String.class, JsonHelper.asJson(entity));
 
                 getLog().info("Response to create role " + name);
                 getLog().info(response);

--- a/sdk/src/main/resources/emodb-default-config.yaml
+++ b/sdk/src/main/resources/emodb-default-config.yaml
@@ -188,7 +188,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/web-local/config-dc2.yaml
+++ b/web-local/config-dc2.yaml
@@ -166,7 +166,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/web-local/config-jenkins.yaml
+++ b/web-local/config-jenkins.yaml
@@ -216,7 +216,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/web-local/config-local-2.yaml
+++ b/web-local/config-local-2.yaml
@@ -220,7 +220,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/web-local/config-local-blob-role.yaml
+++ b/web-local/config-local-blob-role.yaml
@@ -215,7 +215,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/web-local/config-local-main-role.yaml
+++ b/web-local/config-local-main-role.yaml
@@ -216,7 +216,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -225,7 +225,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/web-local/config-migrator.yaml
+++ b/web-local/config-migrator.yaml
@@ -206,7 +206,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/web-local/config-scantest.yaml
+++ b/web-local/config-scantest.yaml
@@ -196,7 +196,8 @@ auth:
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
   tablePlacement: "app_global:sys"
-  allowAnonymousAccess: true
+  anonymousRoles:
+  - anonymous
 
 scanner:
   scanStatusTable: "__system_scan_upload"

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
@@ -1,6 +1,9 @@
 package com.bazaarvoice.emodb.web.auth;
 
+import com.google.common.collect.ImmutableSet;
+
 import javax.validation.constraints.NotNull;
+import java.util.Set;
 
 /**
  * Configuration for the API keys of internal EmoDB users.
@@ -37,8 +40,8 @@ public class AuthorizationConfiguration {
     // Replication key used for replicating across data centers
     @NotNull
     private String _replicationApiKey;
-    // If true allow anonymous access, otherwise all restricted resources will require authentication
-    private boolean _allowAnonymousAccess;
+    // Set of roles assigned for anonymous user.  If the set is empty anonymous access is disabled.
+    private Set<String> _anonymousRoles = ImmutableSet.of();
 
     public String getIdentityTable() {
         return _identityTable;
@@ -112,12 +115,12 @@ public class AuthorizationConfiguration {
         return this;
     }
 
-    public boolean isAllowAnonymousAccess() {
-        return _allowAnonymousAccess;
+    public Set<String> getAnonymousRoles() {
+        return _anonymousRoles;
     }
 
-    public AuthorizationConfiguration setAllowAnonymousAccess(boolean allowAnonymousAccess) {
-        _allowAnonymousAccess = allowAnonymousAccess;
+    public AuthorizationConfiguration setAnonymousRoles(Set<String> anonymousRoles) {
+        _anonymousRoles = anonymousRoles;
         return this;
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
@@ -131,13 +131,8 @@ public enum DefaultRoles {
     // Reserved role for replication databus traffic between data centers
     replication (
             ImmutableSet.of(sor_read),
-            Permissions.replicateDatabus()),
-
-    // Reserved role for anonymous access
-    anonymous (
-            // TODO:  Lock this down.  For now this will permit all standard client operations with excluding pii tables/placements in SOR.
-            ImmutableSet.of(sor_standard_without_pii, blob_standard, queue_standard, databus_standard));
-
+            Permissions.replicateDatabus());
+    
     private Set<String> _permissions;
 
     private DefaultRoles(String... permissions) {


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Currently EmoDB can be configured to allow anonymous access without providing an API key.  However, once enabled the permissions associated with the anonymous user are hard-coded.  This PR changes anonymous access such that the _roles_ associated with the anonymous user are set via `config.yaml`, and assigning permissions to those roles is done using the UAC API just like with any other role.

## How to Test and Verify

1. Check out this PR
2. Start Emo using web-local
3. `curl localhost:8080/sor/1/_table/foo` should return a 403 exception
4. `curl -XPOST 'localhost:8080/uac/1/role/_/anonymous' -H 'X-BV-API-Key: local_admin' -H 'Content-Type: application/x.json-create-role' -d '{"name":"anonymous","permissions":["sor|*"]}'`
5. Repeat the request in step 3.  This time it should return 404

## Risk

The biggest risk is that the admin doesn't set up anonymous roles to match the existing needs prior to deploying this change, otherwise anonymous users could start seeing 403s.  The admin should ensure the proper roles exist and have the right permission before applying this update.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
