### PR TITLE
Added support for Stash to buckets in all regions

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/AmazonS3Provider.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/AmazonS3Provider.java
@@ -1,0 +1,108 @@
+package com.bazaarvoice.emodb.web.scanner.writer;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.regions.Region;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.inject.Inject;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Provides {@link AmazonS3} client's configured for the same region as an S3 bucket.  The clients are cached between
+ * requests.
+ */
+public class AmazonS3Provider {
+
+    private AWSCredentialsProvider _credentialsProvider;
+    private String _localRegionName;
+
+    private final LoadingCache<String, AmazonS3> _clientsByRegion;
+    private final Cache<String, AmazonS3> _clientsByBucket;
+
+    @Inject
+    public AmazonS3Provider(@S3CredentialsProvider AWSCredentialsProvider credentialsProvider, Region region) {
+        this(credentialsProvider, region.getName());
+    }
+
+    @VisibleForTesting
+    public AmazonS3Provider(AWSCredentialsProvider credentialsProvider, String localRegionName) {
+        _credentialsProvider = credentialsProvider;
+        _localRegionName = localRegionName;
+
+        _clientsByRegion = CacheBuilder.newBuilder()
+                .maximumSize(4)
+                .build(new CacheLoader<String, AmazonS3>() {
+                    @Override
+                    public AmazonS3 load(String regionName) throws Exception {
+                        return createS3ClientForRegion(regionName);
+                    }
+                });
+
+        _clientsByBucket = CacheBuilder.newBuilder()
+                .maximumSize(10)
+                .build();
+    }
+
+    public AmazonS3 getLocalS3Client() {
+        return _clientsByRegion.getUnchecked(_localRegionName);
+    }
+
+    public AmazonS3 getS3ClientForBucket(String bucket) {
+        AmazonS3 client = _clientsByBucket.getIfPresent(bucket);
+        
+        if (client == null) {
+            String regionName = getRegionForBucket(bucket);
+
+            if (regionName == null) {
+                // If the bucket does not exist then just use the current region.  It really doesn't matter which client
+                // we use since the bucket doesn't exist anywhere.  But don't cache the client in case the bucket gets
+                // created between now and a future request.
+                return getLocalS3Client();
+            }
+
+            client = _clientsByRegion.getUnchecked(regionName);
+            _clientsByBucket.put(bucket, client);
+        }
+
+        return client;
+    }
+
+    /**
+     * The version of the AWS SDK Emo uses doesn't have support for some of the newer Amazon regions, such as
+     * "us-east-2" and "eu-west-2".  This leads to unexpected errors when accessing to an S3 bucket in one of these
+     * regions.  The work-around is to use {@link AmazonS3#setEndpoint(String)} instead of the simpler
+     * {@link AmazonS3#setRegion(Region)} since this doesn't run into the same issues.  The only downside is the
+     * necessity to code in the s3 endpoint pattern, but this is extremely unlikely to change.
+     */
+    public AmazonS3 createS3ClientForRegion(String regionName) {
+        return new AmazonS3Client(_credentialsProvider)
+                .withEndpoint(String.format("s3.%s.amazonaws.com", regionName));
+    }
+
+    public String getRegionForBucket(String bucket) {
+        // Just querying for the location for a bucket can be done with the local client
+        AmazonS3 client = getLocalS3Client();
+        try {
+            String region = client.getBucketLocation(bucket);
+            if ("US".equals(region)) {
+                // GetBucketLocation requests return null for us-east-1 which the SDK then replaces with "US".
+                // So change it to the actual region.
+                region = "us-east-1";
+            }
+            return region;
+        } catch (AmazonS3Exception e) {
+            if (e.getStatusCode() == Response.Status.NOT_FOUND.getStatusCode()) {
+                // If the bucket doesn't exist then return null
+                return null;
+            }
+            throw e;
+        }
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/S3CredentialsProvider.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/S3CredentialsProvider.java
@@ -1,0 +1,16 @@
+package com.bazaarvoice.emodb.web.scanner.writer;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface S3CredentialsProvider {
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/S3ScanWriter.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/S3ScanWriter.java
@@ -12,6 +12,7 @@ import com.amazonaws.util.BinaryUtils;
 import com.bazaarvoice.emodb.web.scanner.ScanUploadService;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
@@ -38,6 +39,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
@@ -56,11 +58,14 @@ public class S3ScanWriter extends TemporaryFileScanWriter {
 
     @Inject
     public S3ScanWriter(@Assisted int taskId, @Assisted URI baseUri, @Assisted Optional<Integer> maxOpenShards,
-                        MetricRegistry metricRegistry, AmazonS3 amazonS3,
+                        MetricRegistry metricRegistry, AmazonS3Provider amazonS3Provider,
                         @ScanUploadService ScheduledExecutorService uploadService) {
         super("s3", taskId, baseUri, Compression.GZIP, metricRegistry, maxOpenShards);
 
-        _amazonS3 = checkNotNull(amazonS3, "amazonS3 is required");
+        checkNotNull(amazonS3Provider, "amazonS3Provider is required");
+        String bucket = baseUri.getHost();
+        checkArgument(!Strings.isNullOrEmpty(bucket), "bucket is required");
+        _amazonS3 = amazonS3Provider.getS3ClientForBucket(bucket);
         _uploadService = checkNotNull(uploadService, "uploadService is required");
     }
 

--- a/web/src/test/java/com/bazaarvoice/emodb/web/scanner/writer/S3ScanWriterTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/scanner/writer/S3ScanWriterTest.java
@@ -67,7 +67,10 @@ public class S3ScanWriterTest {
                         }
                     });
 
-            S3ScanWriter scanWriter = new S3ScanWriter(1, baseUri, Optional.of(2), metricRegistry, amazonS3, uploadService);
+            AmazonS3Provider amazonS3Provider = mock(AmazonS3Provider.class);
+            when(amazonS3Provider.getS3ClientForBucket("test-bucket")).thenReturn(amazonS3);
+
+            S3ScanWriter scanWriter = new S3ScanWriter(1, baseUri, Optional.of(2), metricRegistry, amazonS3Provider, uploadService);
             ShardWriter shardWriter = scanWriter.writeShardRows("testtable", "p0", 0, 1);
             shardWriter.getOutputStream().write("This is a test line".getBytes(Charsets.UTF_8));
             shardWriter.closeAndTransferAysnc(Optional.of(1));
@@ -95,7 +98,10 @@ public class S3ScanWriterTest {
         when(amazonS3.putObject(any(PutObjectRequest.class)))
                 .thenThrow(new AmazonClientException("Simulated transfer failure"));
 
-        S3ScanWriter scanWriter = new S3ScanWriter(1, baseUri, Optional.of(2), metricRegistry, amazonS3, uploadService);
+        AmazonS3Provider amazonS3Provider = mock(AmazonS3Provider.class);
+        when(amazonS3Provider.getS3ClientForBucket("test-bucket")).thenReturn(amazonS3);
+
+        S3ScanWriter scanWriter = new S3ScanWriter(1, baseUri, Optional.of(2), metricRegistry, amazonS3Provider, uploadService);
         scanWriter.setRetryDelay(Duration.millis(10));
 
         try {
@@ -130,7 +136,10 @@ public class S3ScanWriterTest {
             when(amazonS3.putObject(argThat(putsIntoBucket("test-bucket"))))
                     .thenReturn(putObjectResult);
 
-            S3ScanWriter scanWriter = new S3ScanWriter(1, baseUri, Optional.of(2), new MetricRegistry(), amazonS3, uploadService);
+            AmazonS3Provider amazonS3Provider = mock(AmazonS3Provider.class);
+            when(amazonS3Provider.getS3ClientForBucket("test-bucket")).thenReturn(amazonS3);
+
+            S3ScanWriter scanWriter = new S3ScanWriter(1, baseUri, Optional.of(2), new MetricRegistry(), amazonS3Provider, uploadService);
 
             ShardWriter shardWriter[] = new ShardWriter[2];
 
@@ -165,7 +174,10 @@ public class S3ScanWriterTest {
             when(amazonS3.putObject(argThat(putsIntoBucket("test-bucket"))))
                     .thenReturn(putObjectResult);
 
-            S3ScanWriter scanWriter = new S3ScanWriter(1, baseUri, Optional.of(2), new MetricRegistry(), amazonS3, uploadService);
+            AmazonS3Provider amazonS3Provider = mock(AmazonS3Provider.class);
+            when(amazonS3Provider.getS3ClientForBucket("test-bucket")).thenReturn(amazonS3);
+
+            S3ScanWriter scanWriter = new S3ScanWriter(1, baseUri, Optional.of(2), new MetricRegistry(), amazonS3Provider, uploadService);
 
             ShardWriter shardWriter[] = new ShardWriter[2];
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

EmoDB Stash currently assumes the S3 bucket being written to is in the same region as the Stash cluster itself.  While this is normally the case there may be situations where Stashing to another bucket is required.  The current Stash implementation can fail for two reasons:

1. The version of the AWS SDK EmoDB uses is older and does not support all regions, such as us-east-2 and eu-west-2.
2. The S3 client generated always uses the local region.  If the bucket is in another region the client should be configured for that region.

This PR addresses both issues:

1. When creating S3 clients for Stash Emo sets the endpoint explicitly instead of the region, which bypasses the issue of not all regions being explicitly enumerated in the SDK.
2. An S3 client provider is bound instead of a single S3 client.  The provider returns a cached instance based on the region in which the Stash bucket exists.

## How to Test and Verify

This isn't really possible to verify locally.  The best way to verify is to create an EmoDB Stash in AWS which writes to a bucket in another region and verify it can generate Stash correctly.

## Risk

This a fairly low risk change.  In the extremely common case Stash is writing to an S3 bucket in the local region, so performance shouldn't really be affected.  The biggest risk is that S3 endpoints are now hard-coded into EmoDB.  These are correct for all current regions but should AWS change the endpoints EmoDB would need to be updated.  However, were this to happen there'd likely be far greater impact than just to EmoDB.

### Level 

`Medium`

### Required Testing

`Manual`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
