### PR TITLE
Fixed master and inbound replication channels all registering with the same name

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
@@ -97,7 +97,7 @@ public class DefaultFanoutManager implements FanoutManager {
                     }
                 });
         ServiceFailureListener.listenTo(leaderService, _metricRegistry);
-        _dropwizardTask.register("databus-fanout", leaderService);
+        _dropwizardTask.register("databus-fanout-" + name, leaderService);
         return leaderService;
     }
 }


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

For all multi-region environments there are several databus fanout processes running:

1. Master fanout
2. Inbound fanout from each remote data center

The former is responsible for writing local databus updates to all of the local subscribers and to the outbound replication channel. The latter is responsible for polling the inbound replication channel and replicating updates to all of the local subscribers.

In the simple case where there are exactly two data centers there would be two separate tasks, one per fanout, each of which run on one server based on leadership election. It's possible both tasks are running on the same server or that they are each running on a different server. However, both register with the same task identifier, "databus-fanout", which makes tracking them using the leader task difficult.

This PR updates the registration so each uses a unique name.

## How to Test and Verify

1. Check out this PR
2. Run locally using `web-local/start.sh`
3. Once started run another Emo for another virtual data center.  From the web-local directory:
```
java -jar ../web/target/emodb-web-5.6.2-SNAPSHOT.jar server ./config-local-2.yaml config-ddl-local-2.yaml
```
4. Once both servers have started it may take up to 5 minutes for fanout polling to happen in both directions.
5. Once it has run the following to verify the tasks are run independently (I've removed unrelated tasks for clarity):
```
$ curl localhost:8081/tasks/leader -XPOST
databus-fanout-in-datacenter2: RUNNING (leader=10.201.27.71:8080)
databus-fanout-master: RUNNING (leader=10.201.27.71:8080)
$ curl localhost:9091/tasks/leader -XPOST
databus-fanout-in-datacenter1: RUNNING (leader=10.201.27.71:9090)
databus-fanout-master: waiting to win leadership election (leader=10.201.27.71:8080)
```

## Risk

This is a low risk update.  Other than providing more information in the leader task it has no effect on the normal EmoDB process.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
