### PR TITLE
Added metrics for approximate databus fanout lag

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanout.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanout.java
@@ -1,15 +1,19 @@
 package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
+import com.bazaarvoice.emodb.common.dropwizard.metrics.MetricsGroup;
+import com.bazaarvoice.emodb.common.dropwizard.time.ClockTicker;
 import com.bazaarvoice.emodb.databus.ChannelNames;
 import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.datacenter.api.DataCenter;
 import com.bazaarvoice.emodb.event.api.EventData;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
@@ -20,7 +24,10 @@ import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
+import java.time.Clock;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -51,6 +58,10 @@ public class DefaultFanout extends AbstractScheduledService {
     private final Meter _eventsRead;
     private final Meter _eventsWrittenLocal;
     private final Meter _eventsWrittenOutboundReplication;
+    private final Clock _clock;
+    private final MetricsGroup _lag;
+    private final Stopwatch _lastLagStopwatch;
+    private int _lastLagSeconds = -1;
 
     public DefaultFanout(String name,
                          EventSource eventSource,
@@ -61,7 +72,7 @@ public class DefaultFanout extends AbstractScheduledService {
                          DataCenter currentDataCenter,
                          RateLimitedLogFactory logFactory,
                          SubscriptionEvaluator subscriptionEvaluator,
-                         MetricRegistry metricRegistry) {
+                         MetricRegistry metricRegistry, Clock clock) {
         _name = checkNotNull(name, "name");
         _eventSource = checkNotNull(eventSource, "eventSource");
         _eventSink = checkNotNull(eventSink, "eventSink");
@@ -75,12 +86,18 @@ public class DefaultFanout extends AbstractScheduledService {
         _eventsRead = newEventMeter("read", metricRegistry);
         _eventsWrittenLocal = newEventMeter("written-local", metricRegistry);
         _eventsWrittenOutboundReplication = newEventMeter("written-outbound-replication", metricRegistry);
+        _lag = new MetricsGroup(metricRegistry);
+        _lastLagStopwatch = Stopwatch.createStarted(ClockTicker.getTicker(clock));
+        _clock = clock;
         ServiceFailureListener.listenTo(this, metricRegistry);
     }
 
     private Meter newEventMeter(String name, MetricRegistry metricRegistry) {
-        String metricName = MetricRegistry.name("bv.emodb.databus", "DefaultFanout", name, _name);
-        return metricRegistry.meter(metricName);
+        return metricRegistry.meter(metricName(name));
+    }
+    
+    private String metricName(String name) {
+        return MetricRegistry.name("bv.emodb.databus", "DefaultFanout", name, _name);
     }
 
     @Override
@@ -104,12 +121,20 @@ public class DefaultFanout extends AbstractScheduledService {
         }
     }
 
+    @Override
+    protected void shutDown() throws Exception {
+        // Leadership lost, stop posting fanout lag
+        _lag.close();
+    }
+
     private boolean copyEvents() {
         // Use peek() not poll() since LeaderSelector ensures we're not competing with other processes for claims.
         List<EventData> rawEvents = _eventSource.get(1000);
 
         // If no events, sleep a little while before doing any more work to allow new events to arrive.
         if (rawEvents.isEmpty()) {
+            // Update the lag metrics to indicate there is no lag
+            updateLagMetrics(null);
             return false;
         }
 
@@ -119,13 +144,14 @@ public class DefaultFanout extends AbstractScheduledService {
 
     @VisibleForTesting
     boolean copyEvents(List<EventData> rawEvents) {
-            // Read the list of subscriptions *after* reading events from the event store to avoid race conditions with
+        // Read the list of subscriptions *after* reading events from the event store to avoid race conditions with
         // creating a new subscription.
         Iterable<OwnedSubscription> subscriptions = _subscriptionsSupplier.get();
 
         // Copy the events to all the destination channels.
         List<String> eventKeys = Lists.newArrayListWithCapacity(rawEvents.size());
         ListMultimap<String, ByteBuffer> eventsByChannel = ArrayListMultimap.create();
+        SubscriptionEvaluator.MatchEventData lastMatchEventData = null;
         int numOutboundReplicationEvents = 0;
         for (EventData rawEvent : rawEvents) {
             eventKeys.add(rawEvent.getId());
@@ -160,12 +186,44 @@ public class DefaultFanout extends AbstractScheduledService {
                 flush(eventKeys, eventsByChannel, numOutboundReplicationEvents);
                 numOutboundReplicationEvents = 0;
             }
+
+            // Track the final match event data record returned
+            lastMatchEventData = matchEventData;
         }
 
         // Final flush.
         flush(eventKeys, eventsByChannel, numOutboundReplicationEvents);
 
+        // Update the lag metrics based on the last event returned.  This isn't perfect for several reasons:
+        // 1. In-order delivery is not guaranteed
+        // 2. The event time is based on the change ID which is close-to but not precisely the time the update occurred
+        // 3. Injected events have artificial change IDs which don't correspond to any clock-based time
+        // However, this is still a useful metric because:
+        // 1. Delivery is in-order the majority of the time
+        // 2. Change IDs are typically within milliseconds of update times
+        // 3. Injected events are extremely rare and should be avoided outside of testing anyway
+        // 4. The lag only becomes a concern on the scale of minutes, far above the uncertainty introduced by the above
+        if (lastMatchEventData != null) {
+            updateLagMetrics(lastMatchEventData.getEventTime());
+        }
+
         return true;
+    }
+
+    private void updateLagMetrics(@Nullable Date eventTime) {
+        int lagSeconds = eventTime == null ? 0 : (int) TimeUnit.MILLISECONDS.toSeconds(_clock.millis() - eventTime.getTime());
+        // As a performance savings only update the metric if both of the following are true:
+        // 1. It has been more than 5 seconds since the last time the metric was updated
+        // 2. The lag changed since the last posting
+
+        if (lagSeconds != _lastLagSeconds && _lastLagStopwatch.elapsed(TimeUnit.SECONDS) >= 5) {
+            _lag.beginUpdates();
+            _lag.gauge(metricName("lagSeconds")).set(lagSeconds);
+            _lag.endUpdates();
+
+            _lastLagSeconds = lagSeconds;
+            _lastLagStopwatch.reset().start();
+        }
     }
 
     private void flush(List<String> eventKeys, Multimap<String, ByteBuffer> eventsByChannel,

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
@@ -26,8 +26,7 @@ import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
-import java.util.Collection;
-import java.util.Iterator;
+import java.time.Clock;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -45,12 +44,14 @@ public class DefaultFanoutManager implements FanoutManager {
     private final RateLimitedLogFactory _logFactory;
     private final SubscriptionEvaluator _subscriptionEvaluator;
     private final MetricRegistry _metricRegistry;
+    private final Clock _clock;
 
     @Inject
     public DefaultFanoutManager(final EventStore eventStore, final SubscriptionDAO subscriptionDao,
                                 SubscriptionEvaluator subscriptionEvaluator, DataCenters dataCenters,
                                 @DatabusZooKeeper CuratorFramework curator, @SelfHostAndPort HostAndPort self,
-                                LeaderServiceTask dropwizardTask, RateLimitedLogFactory logFactory, MetricRegistry metricRegistry) {
+                                LeaderServiceTask dropwizardTask, RateLimitedLogFactory logFactory,
+                                MetricRegistry metricRegistry, Clock clock) {
         _eventStore = checkNotNull(eventStore, "eventStore");
         _subscriptionDao = checkNotNull(subscriptionDao, "subscriptionDao");
         _subscriptionEvaluator = checkNotNull(subscriptionEvaluator, "subscriptionEvaluator");
@@ -60,6 +61,7 @@ public class DefaultFanoutManager implements FanoutManager {
         _dropwizardTask = checkNotNull(dropwizardTask, "dropwizardTask");
         _logFactory = checkNotNull(logFactory, "logFactory");
         _metricRegistry = metricRegistry;
+        _clock = clock;
     }
 
     @Override
@@ -93,7 +95,7 @@ public class DefaultFanoutManager implements FanoutManager {
                     public Service get() {
                         return new DefaultFanout(name, eventSource, eventSink, replicateOutbound, sleepWhenIdle,
                                 subscriptionsSupplier, _dataCenters.getSelf(), _logFactory, _subscriptionEvaluator,
-                                _metricRegistry);
+                                _metricRegistry, _clock);
                     }
                 });
         ServiceFailureListener.listenTo(leaderService, _metricRegistry);

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
+import java.time.Clock;
 import java.util.Date;
 
 import static org.mockito.Matchers.any;
@@ -77,7 +78,7 @@ public class DefaultFanoutTest {
 
         _defaultFanout = new DefaultFanout("test", mock(EventSource.class), eventSink, true, Duration.standardSeconds(1),
                 _subscriptionsSupplier, _currentDataCenter, rateLimitedLogFactory, subscriptionEvaluator,
-                new MetricRegistry());
+                new MetricRegistry(), Clock.systemUTC());
     }
 
     @Test


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

The databus fanout process fans out from two source queue categories:

1. The "master" queue which fans out events locally and to other data centers
2. The in-bound replication queues which fan out events written remotely in other data centers

There are currently metrics which provide the size of the of these queues but does not given an idea of how lagged the data in the queue is.  For example, a replication queue depth of 1M records may have different priorities if this means the posted events are 2 minutes lagged versus 2 hours lagged.

This PR introduces a correlary "bv.emodb.databus.DefaultFanout.lagSeconds._queue_" metric in addition to the existing "bv.emodb.databus.SystemQueue._queue_" metric.  The latter indicates how deep the queue is while the former indicates the staleness of the data in the queue.

## How to Test and Verify

1. Check out this PR
2. Start EmoDB and run some updates
3. `curl localhost:8081/metrics` and verify a metric for "bv.emodb.databus.DefaultFanout.lagSeconds.master" exists

## Risk

This is a low risk change.  The only addition is the new metric.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
