### PR TITLE
Added ability to blacklist tables from stash.

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
@@ -10,6 +10,7 @@ import com.bazaarvoice.emodb.sor.core.UpdateRef;
 import com.bazaarvoice.emodb.table.db.Table;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Maps;
+import com.bazaarvoice.emodb.table.db.TableFilterIntrinsics;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/quality/integration/src/test/java/test/integration/sor/CasStashTableTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/CasStashTableTest.java
@@ -12,6 +12,7 @@ import com.bazaarvoice.emodb.datacenter.api.DataCenter;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
 import com.bazaarvoice.emodb.sor.db.astyanax.DeltaPlacementFactory;
 import com.bazaarvoice.emodb.sor.delta.Delta;
@@ -129,7 +130,7 @@ public class CasStashTableTest  {
         addTable("table0", "ugc_global:ugc", 0x2000L);
         addTable("table1", "app_global:sys", 0x2000L);
 
-        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-inter", ImmutableSet.of("ugc_global:ugc"));
+        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-inter", ImmutableSet.of("ugc_global:ugc"), Conditions.alwaysFalse());
         List<StashTokenRange> ranges = ImmutableList.copyOf(
                 _astyanaxTableDAO.getStashTokenRangesFromSnapshot("stash-inter", "ugc_global:ugc",
                         toToken("10000000000000200001"), toToken("10000000000000200099")));
@@ -144,7 +145,7 @@ public class CasStashTableTest  {
         addTable("table2", "ugc_global:ugc", 0x3000L);
         addTable("table3", "app_global:sys", 0x3000L);
 
-        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-starts-within", ImmutableSet.of("ugc_global:ugc"));
+        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-starts-within", ImmutableSet.of("ugc_global:ugc"), Conditions.alwaysFalse());
         List<StashTokenRange> ranges = ImmutableList.copyOf(
                 _astyanaxTableDAO.getStashTokenRangesFromSnapshot("stash-starts-within", "ugc_global:ugc",
                         toToken("10000000000000300099"), toToken("1000000000000030a0ff")));
@@ -159,7 +160,7 @@ public class CasStashTableTest  {
         addTable("table4", "ugc_global:ugc", 0x4000L);
         addTable("table5", "app_global:sys", 0x4000L);
 
-        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-ends-within", ImmutableSet.of("ugc_global:ugc"));
+        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-ends-within", ImmutableSet.of("ugc_global:ugc"), Conditions.alwaysFalse());
         List<StashTokenRange> ranges = ImmutableList.copyOf(
                 _astyanaxTableDAO.getStashTokenRangesFromSnapshot("stash-ends-within", "ugc_global:ugc",
                         toToken("100000000000003fff00"), toToken("10000000000000400099")));
@@ -174,7 +175,7 @@ public class CasStashTableTest  {
         addTable("table6", "ugc_global:ugc", 0x5000L);
         addTable("table7", "app_global:sys", 0x5000L);
 
-        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-matches", ImmutableSet.of("ugc_global:ugc"));
+        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-matches", ImmutableSet.of("ugc_global:ugc"), Conditions.alwaysFalse());
         List<StashTokenRange> ranges = ImmutableList.copyOf(
                 _astyanaxTableDAO.getStashTokenRangesFromSnapshot("stash-matches", "ugc_global:ugc",
                         toToken("100000000000005000"), toToken("100000000000005001")));
@@ -189,7 +190,7 @@ public class CasStashTableTest  {
         addTable("table8", "ugc_global:ugc", 0x6000L);
         addTable("table9", "app_global:sys", 0x6000L);
 
-        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-surrounds", ImmutableSet.of("ugc_global:ugc"));
+        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-surrounds", ImmutableSet.of("ugc_global:ugc"), Conditions.alwaysFalse());
         List<StashTokenRange> ranges = ImmutableList.copyOf(
                 _astyanaxTableDAO.getStashTokenRangesFromSnapshot("stash-surrounds", "ugc_global:ugc",
                         toToken("100000000000005fff"), toToken("100000000000006002")));
@@ -210,7 +211,7 @@ public class CasStashTableTest  {
         addTable("table13", "ugc_global:ugc", 0x7030L);
         addTable("table15", "app_global:sys", 0x7000L);
 
-        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-multiple", ImmutableSet.of("ugc_global:ugc"));
+        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-multiple", ImmutableSet.of("ugc_global:ugc"), Conditions.alwaysFalse());
         List<StashTokenRange> ranges = ImmutableList.copyOf(
                 _astyanaxTableDAO.getStashTokenRangesFromSnapshot("stash-multiple", "ugc_global:ugc",
                         toToken("100000000000006fff"), toToken("100000000000007100")));
@@ -235,7 +236,7 @@ public class CasStashTableTest  {
         addTable("table16", "ugc_global:ugc", 0x8000L);
         addTable("table17", "ugc_global:ugc", 0x8001L);
 
-        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-consecutive", ImmutableSet.of("ugc_global:ugc"));
+        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-consecutive", ImmutableSet.of("ugc_global:ugc"), Conditions.alwaysFalse());
         List<StashTokenRange> ranges = ImmutableList.copyOf(
                 _astyanaxTableDAO.getStashTokenRangesFromSnapshot("stash-consecutive", "ugc_global:ugc",
                         toToken("100000000000007fff"), toToken("10000000000000800a")));
@@ -253,7 +254,7 @@ public class CasStashTableTest  {
         // Create a single table
         addTable("table18", "ugc_global:ugc", 0x9000L);
 
-        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-all-shards", ImmutableSet.of("ugc_global:ugc"));
+        _astyanaxTableDAO.createStashTokenRangeSnapshot("stash-all-shards", ImmutableSet.of("ugc_global:ugc"), Conditions.alwaysFalse());
 
         // Get all possible ranges.  This should return every shard for the table.
         List<StashTokenRange> ranges = ImmutableList.copyOf(

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
@@ -76,6 +76,19 @@ public class DataStoreConfiguration {
     @JsonProperty
     private int _deltaBlockSizeInKb = 64;
 
+    @Valid
+    @NotNull
+    @JsonProperty("stashBlackListTableCondition")
+    private Optional<String> _stashBlackListTableCondition = Optional.absent();
+
+    public Optional<String> getStashBlackListTableCondition() {
+        return _stashBlackListTableCondition;
+    }
+
+    public void setStashBlackListTableCondition(Optional<String> stashBlackListTableCondition) {
+        _stashBlackListTableCondition = stashBlackListTableCondition;
+    }
+
     public String getSystemTablePlacement() {
         return _systemTablePlacement;
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataTools.java
@@ -6,6 +6,7 @@ import com.bazaarvoice.emodb.sor.db.MultiTableScanOptions;
 import com.bazaarvoice.emodb.sor.db.MultiTableScanResult;
 import com.bazaarvoice.emodb.sor.db.ScanRange;
 import com.bazaarvoice.emodb.sor.db.ScanRangeSplits;
+import com.bazaarvoice.emodb.table.db.StashBlackListTableCondition;
 import com.bazaarvoice.emodb.table.db.TableSet;
 import com.google.common.base.Optional;
 import org.joda.time.DateTime;
@@ -52,7 +53,7 @@ public interface DataTools {
     TableSet createTableSet();
 
     /**
-     * Create a snapshot of all tables in the provided placements and their token ranges for Stash.  Must be called
+     * Create a snapshot of all tables excluding the ones listed in the {@link StashBlackListTableCondition} in the provided placements and their token ranges for Stash.  Must be called
      * prior to {@link #stashMultiTableScan(String, String, ScanRange, LimitCounter, ReadConsistency, DateTime)} 
      * otherwise that call will return no results.
      */

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryDataStore.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.sor.core.test;
 
+import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.DefaultDataStore;
 import com.bazaarvoice.emodb.sor.db.test.InMemoryDataReaderDAO;
 import com.bazaarvoice.emodb.sor.log.NullSlowQueryLog;
@@ -27,6 +28,6 @@ public class InMemoryDataStore extends DefaultDataStore {
     public InMemoryDataStore(EventBus eventBus, InMemoryDataReaderDAO dataDao, MetricRegistry metricRegistry) {
         super(eventBus, new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), MoreExecutors.sameThreadExecutor(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), metricRegistry);
+                Optional.<URI>absent(), Conditions.alwaysFalse(), metricRegistry);
     }
 }

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/RedundantDeltaTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/RedundantDeltaTest.java
@@ -13,6 +13,7 @@ import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
 import com.bazaarvoice.emodb.sor.api.Update;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.test.DiscardingExecutorService;
 import com.bazaarvoice.emodb.sor.core.test.InMemoryAuditStore;
 import com.bazaarvoice.emodb.sor.db.Key;
@@ -60,7 +61,7 @@ public class RedundantDeltaTest {
         InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO();
         DefaultDataStore store = new DefaultDataStore(new EventBus(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), new MetricRegistry());
+                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -116,7 +117,7 @@ public class RedundantDeltaTest {
         InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO();
         DefaultDataStore store = new DefaultDataStore(new EventBus(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), new MetricRegistry());
+                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -196,7 +197,7 @@ public class RedundantDeltaTest {
         InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO();
         DefaultDataStore store = new DefaultDataStore(new EventBus(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), new MetricRegistry());
+                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -215,7 +216,7 @@ public class RedundantDeltaTest {
         InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO();
         DefaultDataStore store = new DefaultDataStore(new EventBus(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), new MetricRegistry());
+                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -291,7 +292,7 @@ public class RedundantDeltaTest {
 
         DefaultDataStore store = new DefaultDataStore(new EventBus(), tableDao, dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), new MetricRegistry());
+                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -362,7 +363,7 @@ public class RedundantDeltaTest {
 
         DefaultDataStore store = new DefaultDataStore(new EventBus(), tableDao, dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), new MetricRegistry());
+                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.sor.test;
 
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.SimpleLifeCycleRegistry;
 import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.AuditStore;
 import com.bazaarvoice.emodb.sor.core.DefaultDataStore;
 import com.bazaarvoice.emodb.sor.core.test.InMemoryAuditStore;
@@ -59,11 +60,11 @@ public class MultiDCDataStores {
             if (asyncCompacter) {
                 _stores[i] = new DefaultDataStore(new SimpleLifeCycleRegistry(), metricRegistry, new EventBus(), _tableDao,
                         _inMemoryDaos[i].setAuditStore(_auditStores[i]), _replDaos[i], new NullSlowQueryLog(), _auditStores[i],
-                        Optional.<URI>absent());
+                        Optional.<URI>absent(), Conditions.alwaysFalse());
             } else {
                 _stores[i] = new DefaultDataStore(new EventBus(), _tableDao, _inMemoryDaos[i].setAuditStore(_auditStores[i]),
                         _replDaos[i], new NullSlowQueryLog(), MoreExecutors.sameThreadExecutor(), _auditStores[i],
-                        Optional.<URI>absent(), metricRegistry);
+                        Optional.<URI>absent(), Conditions.alwaysFalse(), metricRegistry);
             }
         }
     }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/StashBlackListTableCondition.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/StashBlackListTableCondition.java
@@ -1,0 +1,16 @@
+package com.bazaarvoice.emodb.table.db;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target ({ FIELD, PARAMETER, METHOD }) @Retention (RUNTIME)
+public @interface StashBlackListTableCondition {
+}

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/StashTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/StashTableDAO.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.table.db;
 
+import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.table.db.stash.StashTokenRange;
 
 import java.nio.ByteBuffer;
@@ -9,12 +10,12 @@ import java.util.Set;
 public interface StashTableDAO {
 
     /**
-     * Create a snapshot of all tables in the provided placements and their token ranges for Stash.
+     * Create a snapshot of all tables excluding the ones listed in the blackListTableCondition in the provided placements and their token ranges for Stash.
      */
-    void createStashTokenRangeSnapshot(String stashId, Set<String> placements);
+    void createStashTokenRangeSnapshot(String stashId, Set<String> placements, Condition blackListTableCondition);
 
     /**
-     * Gets all token ranges for tables from the previously created snapshot using {@link #createStashTokenRangeSnapshot(String, Set)} 
+     * Gets all token ranges for tables from the previously created snapshot using {@link #createStashTokenRangeSnapshot(String, Set)}
      * in the requested range.
      */
     Iterator<StashTokenRange> getStashTokenRangesFromSnapshot(String stashId, String placement, ByteBuffer fromInclusive, ByteBuffer toExclusive);

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/TableFilterIntrinsics.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/TableFilterIntrinsics.java
@@ -1,13 +1,13 @@
-package com.bazaarvoice.emodb.databus.core;
+package com.bazaarvoice.emodb.table.db;
 
 import com.bazaarvoice.emodb.sor.api.Intrinsic;
 import com.bazaarvoice.emodb.sor.delta.eval.Intrinsics;
 import com.bazaarvoice.emodb.table.db.Table;
 
-class TableFilterIntrinsics implements Intrinsics {
+public class TableFilterIntrinsics implements Intrinsics {
     private final Table _table;
 
-    TableFilterIntrinsics(Table table) {
+    public TableFilterIntrinsics(Table table) {
         _table = table;
     }
 

--- a/table/src/test/java/com/bazaarvoice/emodb/table/db/astyanax/StashBlackListTableTest.java
+++ b/table/src/test/java/com/bazaarvoice/emodb/table/db/astyanax/StashBlackListTableTest.java
@@ -1,0 +1,90 @@
+package com.bazaarvoice.emodb.table.db.astyanax;
+
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.api.TableOptions;
+import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
+import com.bazaarvoice.emodb.table.db.test.InMemoryTable;
+import com.google.common.collect.ImmutableMap;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class StashBlackListTableTest {
+
+    @Test
+    public void testIsTableBlacklisted()
+            throws Exception {
+
+        TableOptions options = new TableOptionsBuilder().setPlacement("sor-ugc").build();
+
+        // TRUE cases
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.alwaysTrue()), true);
+
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer"))), true);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.intrinsic(Intrinsic.TABLE, Conditions.like("*:customer"))), true);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.or(Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer")), Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer2")))), true);
+
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("sor-ugc"))), true);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.like("*sor*"))), true);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.or(Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("sor-ugc")), Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("sor-cat")))), true);
+
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.and(Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer")), Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("sor-ugc")))), true);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.and(Conditions.or(Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer")), Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer2"))),
+                        Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("sor-ugc")))), true);
+
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of("type", "review"), false),
+                Conditions.mapBuilder().contains("type", "review").build()), true);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of("type", "review", "some-key", "some-value"), false),
+                Conditions.mapBuilder().contains("type", "review").build()), true);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of("type", "review"), false),
+                Conditions.or(Conditions.mapBuilder().contains("type", "review").build(), Conditions.mapBuilder().contains("some-key", "some-value").build())), true);
+
+
+        // FALSE cases
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.alwaysFalse()), false);
+
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer2"))), false);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.intrinsic(Intrinsic.TABLE, Conditions.like("cat*:customer"))), false);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.or(Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer2")),
+                        Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer3")))), false);
+
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("sor-cat"))), false);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.like("*cat*"))), false);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.or(Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("databus")),
+                        Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("blob")))), false);
+
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.and(Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer")),
+                        Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("sor-cat")))), false);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.and(Conditions.or(Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer2")), Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer3"))),
+                        Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("sor-ugc")))), false);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of(), false),
+                Conditions.and(Conditions.or(Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer")), Conditions.intrinsic(Intrinsic.TABLE, Conditions.equal("review:customer2"))),
+                        Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.equal("sor-cat")))), false);
+
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of("type", "review"), false),
+                Conditions.mapBuilder().contains("type", "story").build()), false);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of("type", "review", "some-key", "some-value"), false),
+                Conditions.mapBuilder().contains("type", "story").build()), false);
+        Assert.assertEquals(AstyanaxTableDAO.isTableBlacklisted(new InMemoryTable("review:customer", options, ImmutableMap.<String, Object>of("type", "review"), false),
+                Conditions.and(Conditions.mapBuilder().contains("type", "review").build(), Conditions.mapBuilder().contains("some-key", "some-value").build())), false);
+
+    }
+}

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -56,6 +56,10 @@ dataCenter:
 systemOfRecord:
   migrationPhase: PRE_MIGRATION
   stashRoot: s3://emodb-us-east-1/stash/ci
+
+  # Optional property - to exclude the tables satisfying the condition from the daily Stash run.
+  stashBlackListTableCondition: "intrinsic(\"~table\":like(\"nostash:*\"))"
+
   # Where does the SoR store system information such as table definitions?
   systemTablePlacement: app_global:sys
 


### PR DESCRIPTION
## Github Issue #
Add ability to black/whitelist tables from Stash

## What Are We Doing Here?
In the current implementation Stash makes an export of every table in Emo to S3. There are several reasons why this is undesirable:
Not all tables are "publish" tables; some are private and the owners don't want public access to their inner workings.
Stash time grows as more tables are populated. For tables that fall into the previous category this is time wasted by Stash.
The long term goal is to allow the table creators to set attributes on their tables to control Stash behavior; the simplest of which could be a simple (stash/no-stash) flag. However, the reality is that implementing this solution is unlikely in the short term, while data is growing fast enough that Stash's completion time is getting close to putting services at risk of completing outside their SLAs.
As a stop-gap this includes implementing a simple blacklist feature to control which tables get Stashed. 

## Risk and Test/Verify.
Minimal. Once we roll out the feature, we can cross check the stash size (comparing with the previous day) without adding the blacklist property in the configuration file as a first step.   
We could as well make sure the stash isn't including the blacklisted tables specified in the config in the test environments.
