### PR TITLE
Create a Global Stash Snapshot.

### DIFF
--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/service/EmoServiceMode.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/service/EmoServiceMode.java
@@ -50,6 +50,8 @@ public enum EmoServiceMode {
             Aspect.blackList,
             Aspect.throttle,
             Aspect.report,
+            Aspect.compaction_control,
+            Aspect.compaction_control_web,
             Aspect.job,
             Aspect.security,
             Aspect.full_consistency,
@@ -69,6 +71,7 @@ public enum EmoServiceMode {
             Aspect.blobStore_module,
             Aspect.blackList,
             Aspect.throttle,
+            Aspect.compaction_control,
             Aspect.security,
             Aspect.leader_control, // needed for HintsPollerManager
             Aspect.blob_zookeeper_full_consistency,
@@ -92,9 +95,11 @@ public enum EmoServiceMode {
             Aspect.cache,
             Aspect.leader_control,
             Aspect.dataCenter,
+            Aspect.dataCenter_announce,
             Aspect.dataStore_module,
             Aspect.blobStore_module, // needed for permission resolver
             Aspect.scanner,
+            Aspect.compaction_control,
             Aspect.security,
             Aspect.full_consistency
     ),
@@ -165,6 +170,8 @@ public enum EmoServiceMode {
         blackList,
         throttle,
         report,
+        compaction_control,
+        compaction_control_web,
         job,
         full_consistency, // This wires in the fct global zookeeper location
         security,

--- a/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
@@ -32,9 +32,12 @@ import com.bazaarvoice.emodb.sor.DataStoreModule;
 import com.bazaarvoice.emodb.sor.DataStoreZooKeeper;
 import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.compactioncontrol.CompControlApiKey;
+import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
@@ -167,6 +170,9 @@ public class CasBlobStoreTest {
                 bind(ServiceRegistry.class).toInstance(mock(ServiceRegistry.class));
 
                 bind(Clock.class).toInstance(Clock.systemDefaultZone());
+
+                bind(String.class).annotatedWith(CompControlApiKey.class).toInstance("CompControlApiKey");
+                bind(CompactionControlSource.class).annotatedWith(LocalCompactionControl.class).toInstance(mock(CompactionControlSource.class));
 
                 EmoServiceMode serviceMode = EmoServiceMode.STANDARD_ALL;
                 install(new SelfHostAndPortModule());

--- a/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
@@ -32,7 +32,10 @@ import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
 import com.bazaarvoice.emodb.sor.DataStoreModule;
 import com.bazaarvoice.emodb.sor.DataStoreZooKeeper;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.compactioncontrol.CompControlApiKey;
+import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
@@ -165,6 +168,9 @@ public class CasDatabusTest {
                         .toInstance(Suppliers.ofInstance(true));
 
                 bind(Clock.class).toInstance(Clock.systemDefaultZone());
+
+                bind(String.class).annotatedWith(CompControlApiKey.class).toInstance("CompControlApiKey");
+                bind(CompactionControlSource.class).annotatedWith(LocalCompactionControl.class).toInstance(mock(CompactionControlSource.class));
 
                 EmoServiceMode serviceMode = EmoServiceMode.STANDARD_ALL;
                 install(new SelfHostAndPortModule());

--- a/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
@@ -29,6 +29,7 @@ import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.AuditBuilder;
 import com.bazaarvoice.emodb.sor.api.Change;
 import com.bazaarvoice.emodb.sor.api.Compaction;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.api.Intrinsic;
 import com.bazaarvoice.emodb.sor.api.ReadConsistency;
@@ -36,6 +37,8 @@ import com.bazaarvoice.emodb.sor.api.Table;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
 import com.bazaarvoice.emodb.sor.api.Update;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.compactioncontrol.CompControlApiKey;
+import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
@@ -166,6 +169,9 @@ public class CasDataStoreTest {
                 bind(ServiceRegistry.class).toInstance(mock(ServiceRegistry.class));
 
                 bind(Clock.class).toInstance(Clock.systemDefaultZone());
+
+                bind(String.class).annotatedWith(CompControlApiKey.class).toInstance("CompControlApiKey");
+                bind(CompactionControlSource.class).annotatedWith(LocalCompactionControl.class).toInstance(mock(CompactionControlSource.class));
 
                 EmoServiceMode serviceMode = EmoServiceMode.STANDARD_ALL;
                 install(new SelfHostAndPortModule());

--- a/quality/integration/src/test/java/test/integration/sor/CompactionControlJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/CompactionControlJerseyTest.java
@@ -1,0 +1,153 @@
+package test.integration.sor;
+
+import com.bazaarvoice.emodb.auth.apikey.ApiKey;
+import com.bazaarvoice.emodb.auth.apikey.ApiKeyModification;
+import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
+import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
+import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
+import com.bazaarvoice.emodb.auth.role.RoleManager;
+import com.bazaarvoice.emodb.blob.api.BlobStore;
+import com.bazaarvoice.emodb.client.EmoClientException;
+import com.bazaarvoice.emodb.common.jersey.dropwizard.JerseyEmoClient;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.client.CompactionControlClient;
+import com.bazaarvoice.emodb.sor.core.DataStoreAsync;
+import com.bazaarvoice.emodb.test.ResourceTest;
+import com.bazaarvoice.emodb.web.auth.DefaultRoles;
+import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
+import com.bazaarvoice.emodb.web.resources.sor.DataStoreResource1;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.sun.jersey.api.client.ClientResponse;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.testng.Assert.fail;
+
+public class CompactionControlJerseyTest extends ResourceTest {
+    private static final String APIKEY_COMPACTION_CONTROL = "compaction-control-key";
+    private static final String APIKEY_UNAUTHORIZED = "unauthorized-key";
+
+    private DataStore _dataStoreServer = mock(DataStore.class);
+    private CompactionControlSource _compactionControlSourceServer = mock(CompactionControlSource.class);
+
+    @Rule
+    public ResourceTestRule _resourceTestRule = setupReplicationResourceTestRule(ImmutableList.<Object>of(new DataStoreResource1(_dataStoreServer, mock(DataStoreAsync.class),
+                    _compactionControlSourceServer)));
+
+    protected static ResourceTestRule setupReplicationResourceTestRule(List<Object> resourceList) {
+        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
+        authIdentityManager.createIdentity(APIKEY_COMPACTION_CONTROL, new ApiKeyModification().addRoles("sor-compcontrol-role"));
+        authIdentityManager.createIdentity(APIKEY_UNAUTHORIZED, new ApiKeyModification().addRoles("sor-read-only-role"));
+
+        EmoPermissionResolver permissionResolver = new EmoPermissionResolver(mock(DataStore.class), mock(BlobStore.class));
+        InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
+        RoleManager roleManager = new InMemoryRoleManager(permissionManager);
+        createRole(roleManager, null, "sor-compcontrol-role", DefaultRoles.compaction_control.getPermissions());
+        createRole(roleManager, null, "sor-read-only-role", ImmutableSet.of("sor|read|*"));
+
+        return setupResourceTestRule(resourceList, authIdentityManager, permissionManager);
+    }
+
+    @After
+    public void tearDownMocksAndClearState() {
+        verifyNoMoreInteractions(_dataStoreServer);
+        reset(_dataStoreServer);
+        verifyNoMoreInteractions(_compactionControlSourceServer);
+        reset(_compactionControlSourceServer);
+    }
+
+    private CompactionControlSource compactionControlClient() {
+        return compactionControlClient(APIKEY_COMPACTION_CONTROL);
+    }
+
+    private CompactionControlSource compactionControlClient(String apiKey) {
+        return new CompactionControlClient(URI.create("/sor/1"), new JerseyEmoClient(_resourceTestRule.client()), apiKey);
+    }
+
+    @Test
+    public void testUpdateStashTime() {
+        compactionControlClient().updateStashTime("1", 123L, ImmutableList.of("placement-name"), 123L, "datacenter");
+
+        verify(_compactionControlSourceServer).updateStashTime("1", 123L, ImmutableList.of("placement-name"), 123L, "datacenter");
+        verifyNoMoreInteractions(_compactionControlSourceServer);
+    }
+
+    @Test
+    public void testdeleteStashTime() {
+        compactionControlClient().deleteStashTime("1", "datacenter");
+
+        verify(_compactionControlSourceServer).deleteStashTime("1", "datacenter");
+        verifyNoMoreInteractions(_compactionControlSourceServer);
+    }
+
+    @Test
+    public void testGetStashTime() {
+        try {
+            compactionControlClient().getStashTime("1", "datacenter");
+        } catch (EmoClientException e) {
+            // we can expect this as there can be a 404 response.
+        }
+        verify(_compactionControlSourceServer).getStashTime("1", "datacenter");
+        verifyNoMoreInteractions(_compactionControlSourceServer);
+    }
+
+    @Test
+    public void testAllStashTimes() {
+        compactionControlClient().getAllStashTimes();
+
+        verify(_compactionControlSourceServer).getAllStashTimes();
+        verifyNoMoreInteractions(_compactionControlSourceServer);
+    }
+
+    @Test
+    public void testAllStashTimesForPlacement() {
+        compactionControlClient().getStashTimesForPlacement("placement");
+
+        verify(_compactionControlSourceServer).getStashTimesForPlacement("placement");
+        verifyNoMoreInteractions(_compactionControlSourceServer);
+    }
+
+
+    /**
+     * Test delete w/an invalid API key.
+     */
+    @Test
+    public void testdeleteStashTimeUnauthenticated() {
+        try {
+            compactionControlClient(APIKEY_UNAUTHORIZED).deleteStashTime("1", "datacenter");
+            fail();
+        } catch (EmoClientException e) {
+            if (e.getResponse().getStatus() != ClientResponse.Status.FORBIDDEN.getStatusCode()) {
+                throw e;
+            }
+        }
+        verifyNoMoreInteractions(_compactionControlSourceServer);
+    }
+
+    /**
+     * Test delete w/a valid API key but not one that has permission to delete.
+     */
+    @Test
+    public void testDeleteForbidden() {
+        try {
+            compactionControlClient("completely-unknown-key").deleteStashTime("1", "datacenter");
+            fail();
+        } catch (EmoClientException e) {
+            if (e.getResponse().getStatus() != ClientResponse.Status.FORBIDDEN.getStatusCode()) {
+                throw e;
+            }
+        }
+        verifyNoMoreInteractions(_compactionControlSourceServer);
+    }
+}

--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -40,6 +40,7 @@ import com.bazaarvoice.emodb.sor.api.WriteConsistency;
 import com.bazaarvoice.emodb.sor.client.DataStoreAuthenticator;
 import com.bazaarvoice.emodb.sor.client.DataStoreClient;
 import com.bazaarvoice.emodb.sor.client.DataStoreStreaming;
+import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSource;
 import com.bazaarvoice.emodb.sor.core.DataStoreAsync;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
 import com.bazaarvoice.emodb.test.ResourceTest;
@@ -143,7 +144,7 @@ public class DataStoreJerseyTest extends ResourceTest {
         createRole(roleManager, null, "standard", DefaultRoles.standard.getPermissions());
         createRole(roleManager, null, "update-with-events", ImmutableSet.of("sor|update|*"));
 
-        return setupResourceTestRule(Collections.<Object>singletonList(new DataStoreResource1(_server, mock(DataStoreAsync.class))), authIdentityManager, permissionManager);
+        return setupResourceTestRule(Collections.<Object>singletonList(new DataStoreResource1(_server, mock(DataStoreAsync.class), new InMemoryCompactionControlSource())), authIdentityManager, permissionManager);
     }
 
     @After

--- a/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
@@ -14,6 +14,7 @@ import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.client.DataStoreAuthenticator;
 import com.bazaarvoice.emodb.sor.client.DataStoreClient;
+import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSource;
 import com.bazaarvoice.emodb.sor.core.DefaultDataStoreAsync;
 import com.bazaarvoice.emodb.test.ResourceTest;
 import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
@@ -109,7 +110,7 @@ public class AdHocThrottleTest extends ResourceTest {
         createRole(roleManager, null, "all-sor-role", ImmutableSet.of("sor|*|*"));
 
         return setupResourceTestRule(
-                Collections.<Object>singletonList(new DataStoreResource1(_dataStore, new DefaultDataStoreAsync(_dataStore, mock(JobService.class), mock(JobHandlerRegistry.class)))),
+                Collections.<Object>singletonList(new DataStoreResource1(_dataStore, new DefaultDataStoreAsync(_dataStore, mock(JobService.class), mock(JobHandlerRegistry.class)), new InMemoryCompactionControlSource())),
                 Collections.<Object>singletonList(new ConcurrentRequestsThrottlingFilter(_deferringRegulatorSupplier)),
                 authIdentityManager, permissionManager);
     }

--- a/quality/integration/src/test/resources/config-blob-role.yaml
+++ b/quality/integration/src/test/resources/config-blob-role.yaml
@@ -179,6 +179,7 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
+  compControlApiKey: "local_admin" # compaction-control
   anonymousRoles:
   - anonymous
 

--- a/quality/integration/src/test/resources/config-main-role.yaml
+++ b/quality/integration/src/test/resources/config-main-role.yaml
@@ -152,6 +152,7 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
+  compControlApiKey: "local_admin" #compaction-control
   anonymousRoles:
   - anonymous
 

--- a/quality/integration/src/test/resources/config-stash-role.yaml
+++ b/quality/integration/src/test/resources/config-stash-role.yaml
@@ -159,9 +159,9 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
+  compControlApiKey: "local_admin" # compaction-control
   anonymousRoles:
   - anonymous
-
 
 scanner:
   scanStatusTable: "__system_scan_upload"

--- a/sdk/src/main/resources/emodb-default-config.yaml
+++ b/sdk/src/main/resources/emodb-default-config.yaml
@@ -187,6 +187,7 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
+  compControlApiKey: "local_admin" # compaction-control
   anonymousRoles:
   - anonymous
 

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/CompactionControlSource.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/CompactionControlSource.java
@@ -1,0 +1,22 @@
+package com.bazaarvoice.emodb.sor.api;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defines the interface for storing and retrieving the stash start run timestamps.
+ * <p/>
+ * It's used in stash process (to update the start timestamps) and in compaction (to delay the deletion of deltas).
+ */
+public interface CompactionControlSource {
+
+    void updateStashTime(String id, long timestamp, List<String> placements, long expiredTimestamp, String dataCenter);
+
+    void deleteStashTime(String id, String dataCenter);
+
+    StashRunTimeInfo getStashTime(String id, String dataCenter);
+
+    Map<String, StashRunTimeInfo> getAllStashTimes();
+
+    Map<String, StashRunTimeInfo> getStashTimesForPlacement(String placement);
+}

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/StashRunTimeInfo.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/StashRunTimeInfo.java
@@ -1,0 +1,47 @@
+package com.bazaarvoice.emodb.sor.api;
+
+import com.bazaarvoice.emodb.common.json.JsonHelper;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class StashRunTimeInfo {
+
+    private Long _timestamp;
+    private List<String> _placements;
+    private String _dataCenter;
+    private Long _expiredTimestamp;
+
+    public StashRunTimeInfo() {
+    }
+
+    @JsonCreator
+    public StashRunTimeInfo(@JsonProperty ("timestamp") Long timestamp, @JsonProperty ("placements") List<String> placements,
+                            @JsonProperty ("dataCenter") String dataCenter, @JsonProperty ("expiredTimestamp") Long expiredTimestamp) {
+        this._timestamp = timestamp;
+        this._placements = placements;
+        this._dataCenter = dataCenter;
+        this._expiredTimestamp = expiredTimestamp;
+    }
+
+    public Long getTimestamp() {
+        return _timestamp;
+    }
+
+    public List<String> getPlacements() {
+        return _placements;
+    }
+
+    public String getDataCenter() {
+        return _dataCenter;
+    }
+
+    public Long getExpiredTimestamp() {
+        return _expiredTimestamp;
+    }
+
+    public String toString() {
+        return JsonHelper.asJson(this);
+    }
+}

--- a/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/AbstractDataStoreClientFactory.java
+++ b/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/AbstractDataStoreClientFactory.java
@@ -1,71 +1,27 @@
 package com.bazaarvoice.emodb.sor.client;
 
 import com.bazaarvoice.emodb.client.EmoClient;
-import com.bazaarvoice.emodb.client.EmoClientException;
 import com.bazaarvoice.emodb.common.dropwizard.discovery.Payload;
-import com.bazaarvoice.emodb.common.dropwizard.discovery.ServiceNames;
-import com.bazaarvoice.emodb.common.json.JsonStreamingEOFException;
 import com.bazaarvoice.emodb.sor.api.AuthDataStore;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
 import com.bazaarvoice.ostrich.ServiceEndPoint;
 import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
-import com.google.common.net.HttpHeaders;
-
-import java.net.URI;
 
 /**
  * Abstract parent class for data store clients.  Subclasses are expected to create and configure an
  * {@link EmoClient} and then supply it via the constructor.
  */
-abstract public class AbstractDataStoreClientFactory implements MultiThreadedServiceFactory<AuthDataStore> {
-
-    private final String _clusterName;
-    private final EmoClient _client;
+abstract public class AbstractDataStoreClientFactory extends AbstractDataStoreClientFactoryBase<AuthDataStore> {
 
     protected AbstractDataStoreClientFactory(String clusterName, EmoClient client) {
-        _clusterName = clusterName;
-        _client = client;
-    }
-
-    @Override
-    public String getServiceName() {
-        return getServiceName(_clusterName);
-    }
-
-    protected static String getServiceName(String clusterName) {
-        return ServiceNames.forNamespaceAndBaseServiceName(clusterName, DataStoreClient.BASE_SERVICE_NAME);
-    }
-
-    @Override
-    public void configure(ServicePoolBuilder<AuthDataStore> servicePoolBuilder) {
-        // Defaults are ok
+        super(clusterName, client);
     }
 
     @Override
     public AuthDataStore create(ServiceEndPoint endPoint) {
         Payload payload = Payload.valueOf(endPoint.getPayload());
         return new DataStoreClient(payload.getServiceUrl(), _client);
-    }
-
-    @Override
-    public void destroy(ServiceEndPoint endPoint, AuthDataStore service) {
-        // Nothing to do
-    }
-
-    @Override
-    public boolean isRetriableException(Exception e) {
-        return (e instanceof EmoClientException &&
-                ((EmoClientException) e).getResponse().getStatus() >= 500) ||
-                e instanceof JsonStreamingEOFException;
-    }
-
-    @Override
-    public boolean isHealthy(ServiceEndPoint endPoint) {
-        URI adminUrl = Payload.valueOf(endPoint.getPayload()).getAdminUrl();
-        return _client.resource(adminUrl).path("/healthcheck")
-                .header(HttpHeaders.CONNECTION, "close")
-                .head().getStatus() == 200;
     }
 
     public MultiThreadedServiceFactory<DataStore> usingCredentials(final String apiKey) {

--- a/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/AbstractDataStoreClientFactoryBase.java
+++ b/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/AbstractDataStoreClientFactoryBase.java
@@ -1,0 +1,64 @@
+package com.bazaarvoice.emodb.sor.client;
+
+import com.bazaarvoice.emodb.client.EmoClient;
+import com.bazaarvoice.emodb.client.EmoClientException;
+import com.bazaarvoice.emodb.common.dropwizard.discovery.Payload;
+import com.bazaarvoice.emodb.common.dropwizard.discovery.ServiceNames;
+import com.bazaarvoice.emodb.common.json.JsonStreamingEOFException;
+import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
+import com.google.common.net.HttpHeaders;
+
+import java.net.URI;
+
+/**
+ * Abstract parent base class for data store clients.
+ */
+abstract public class AbstractDataStoreClientFactoryBase<T> implements MultiThreadedServiceFactory<T> {
+
+    private final String _clusterName;
+    protected final EmoClient _client;
+
+    protected AbstractDataStoreClientFactoryBase(String clusterName, EmoClient client) {
+        _clusterName = clusterName;
+        _client = client;
+    }
+
+    @Override
+    public String getServiceName() {
+        return getServiceName(_clusterName);
+    }
+
+    protected static String getServiceName(String clusterName) {
+        return ServiceNames.forNamespaceAndBaseServiceName(clusterName, DataStoreClient.BASE_SERVICE_NAME);
+    }
+
+    @Override
+    public void configure(ServicePoolBuilder<T> servicePoolBuilder) {
+        // Defaults are ok
+    }
+
+    @Override
+    public abstract T create(ServiceEndPoint endPoint);
+
+    @Override
+    public void destroy(ServiceEndPoint endPoint, T service) {
+        // Nothing to do
+    }
+
+    @Override
+    public boolean isRetriableException(Exception e) {
+        return (e instanceof EmoClientException &&
+                ((EmoClientException) e).getResponse().getStatus() >= 500) ||
+                e instanceof JsonStreamingEOFException;
+    }
+
+    @Override
+    public boolean isHealthy(ServiceEndPoint endPoint) {
+        URI adminUrl = Payload.valueOf(endPoint.getPayload()).getAdminUrl();
+        return _client.resource(adminUrl).path("/healthcheck")
+                .header(HttpHeaders.CONNECTION, "close")
+                .head().getStatus() == 200;
+    }
+}

--- a/sor-client/src/main/java/com/bazaarvoice/emodb/sor/client/CompactionControlClient.java
+++ b/sor-client/src/main/java/com/bazaarvoice/emodb/sor/client/CompactionControlClient.java
@@ -1,0 +1,138 @@
+package com.bazaarvoice.emodb.sor.client;
+
+import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
+import com.bazaarvoice.emodb.client.EmoClient;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.google.common.base.Preconditions;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class CompactionControlClient implements CompactionControlSource {
+
+    private final EmoClient _client;
+    private final UriBuilder _compactionControlSource;
+    private final String _apiKey;
+
+    public CompactionControlClient(URI endPoint, EmoClient jerseyClient, String apiKey) {
+        _client = Preconditions.checkNotNull(jerseyClient, "jerseyClient");
+        _compactionControlSource = UriBuilder.fromUri(endPoint);
+        _apiKey = Preconditions.checkNotNull(apiKey, "apiKey");
+    }
+
+    @Override
+    public void updateStashTime(String id, long timestamp, List<String> placements, long expiredTimestamp, String dataCenter) {
+        checkNotNull(id, "id");
+        checkNotNull(placements, "placements");
+        checkNotNull(dataCenter, "dataCenter");
+
+        try {
+            UriBuilder uriBuilder = _compactionControlSource.clone()
+                    .segment("_compcontrol", "stash-time", id)
+                    .queryParam("timestamp", timestamp)
+                    .queryParam("expiredTimestamp", expiredTimestamp)
+                    .queryParam("dataCenter", dataCenter);
+            for (String placement : placements) {
+                uriBuilder.queryParam("placement", placement);
+            }
+            URI uri = uriBuilder.build();
+            _client.resource(uri)
+                    .type(MediaType.APPLICATION_JSON_TYPE)
+                    .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
+                    .post();
+        } catch (UniformInterfaceException e) {
+            throw convertException(e);
+        }
+    }
+
+    @Override
+    public void deleteStashTime(String id, String dataCenter) {
+        checkNotNull(id, "id");
+        checkNotNull(dataCenter, "dataCenter");
+
+        try {
+            URI uri = _compactionControlSource.clone()
+                    .segment("_compcontrol", "stash-time", id)
+                    .queryParam("dataCenter", dataCenter)
+                    .build();
+            _client.resource(uri)
+                    .type(MediaType.APPLICATION_JSON_TYPE)
+                    .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
+                    .delete();
+        } catch (UniformInterfaceException e) {
+            throw convertException(e);
+        }
+    }
+
+    @Override
+    public StashRunTimeInfo getStashTime(String id, String dataCenter) {
+        checkNotNull(id, "id");
+        checkNotNull(dataCenter, "dataCenter");
+
+        try {
+            URI uri = _compactionControlSource.clone()
+                    .segment("_compcontrol", "stash-time", id)
+                    .queryParam("dataCenter", dataCenter)
+                    .build();
+            return _client.resource(uri)
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
+                    .get(StashRunTimeInfo.class);
+        } catch (UniformInterfaceException e) {
+            throw convertException(e);
+        }
+    }
+
+    @Override
+    public Map<String, StashRunTimeInfo> getAllStashTimes() {
+        try {
+            URI uri = _compactionControlSource.clone()
+                    .segment("_compcontrol", "stash-time")
+                    .build();
+            return _client.resource(uri)
+                    .type(MediaType.APPLICATION_JSON_TYPE)
+                    .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
+                    .get(Map.class);
+        } catch (UniformInterfaceException e) {
+            throw convertException(e);
+        }
+    }
+
+    @Override
+    public Map<String, StashRunTimeInfo> getStashTimesForPlacement(String placement) {
+        checkNotNull(placement, "placement");
+
+        try {
+            URI uri = _compactionControlSource.clone()
+                    .segment("_compcontrol", "stash-time")
+                    .queryParam("placement", placement)
+                    .build();
+            return _client.resource(uri)
+                    .type(MediaType.APPLICATION_JSON_TYPE)
+                    .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
+                    .get(Map.class);
+        } catch (UniformInterfaceException e) {
+            throw convertException(e);
+        }
+    }
+
+    private RuntimeException convertException(UniformInterfaceException e) {
+        ClientResponse response = e.getResponse();
+        String exceptionType = response.getHeaders().getFirst("X-BV-Exception");
+
+        if (response.getStatus() == Response.Status.BAD_REQUEST.getStatusCode() &&
+                IllegalArgumentException.class.getName().equals(exceptionType)) {
+            return new IllegalArgumentException(response.getEntity(String.class), e);
+        }
+        return e;
+    }
+}

--- a/sor-client/src/main/java/com/bazaarvoice/emodb/sor/client/CompactionControlClientFactory.java
+++ b/sor-client/src/main/java/com/bazaarvoice/emodb/sor/client/CompactionControlClientFactory.java
@@ -1,0 +1,32 @@
+package com.bazaarvoice.emodb.sor.client;
+
+import com.bazaarvoice.emodb.client.EmoClient;
+import com.bazaarvoice.emodb.common.dropwizard.discovery.Payload;
+import com.bazaarvoice.emodb.common.jersey.dropwizard.JerseyEmoClient;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.sun.jersey.api.client.Client;
+
+/**
+ * SOA factory for Jersey clients to use Compaction control resources.
+ */
+public class CompactionControlClientFactory extends AbstractDataStoreClientFactoryBase<CompactionControlSource> {
+
+    private final String _apiKey;
+
+    public static CompactionControlClientFactory forClusterAndHttpClient(String clusterName, Client client, String apiKey) {
+        return new CompactionControlClientFactory(clusterName, new JerseyEmoClient(client), apiKey);
+    }
+
+    public CompactionControlClientFactory(String clusterName, EmoClient client, String apiKey) {
+        super(clusterName, client);
+        _apiKey = apiKey;
+    }
+
+    @Override
+    public CompactionControlSource create(ServiceEndPoint endPoint) {
+        Payload payload = Payload.valueOf(endPoint.getPayload());
+        return new CompactionControlClient(payload.getServiceUrl(), _client, _apiKey);
+    }
+}
+

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -24,6 +24,7 @@ import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.datacenter.api.KeyspaceDiscovery;
 import com.bazaarvoice.emodb.sor.admin.RowKeyTask;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
@@ -124,6 +125,7 @@ import static com.google.common.base.Preconditions.checkState;
  * <li> @{@link CqlForScans} Supplier&lt;Boolean&gt;
  * <li> {@link CqlDriverConfiguration}
  * <li> {@link Clock}
+ * <li> {@link CompactionControlSource}
  * </ul>
  * Exports the following:
  * <ul>

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/CompControlApiKey.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/CompControlApiKey.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.sor.compactioncontrol;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for identifying the API key used by Compaction Control.
+ */
+@BindingAnnotation
+@Target ({FIELD, PARAMETER, METHOD})
+@Retention (RUNTIME)
+public @interface CompControlApiKey {
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/DefaultCompactionControlSource.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/DefaultCompactionControlSource.java
@@ -1,0 +1,94 @@
+package com.bazaarvoice.emodb.sor.compactioncontrol;
+
+import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/*
+ * Default implementation which uses ZooKeeper to store stash times just in the local data center.
+ *
+ */
+public class DefaultCompactionControlSource implements CompactionControlSource {
+
+    private static final Logger _log = LoggerFactory.getLogger(DefaultCompactionControlSource.class);
+
+    private final MapStore<StashRunTimeInfo> _stashStartTimestampInfo;
+    private final Counter _compactionControlTimeCounter;
+
+    @Inject
+    public DefaultCompactionControlSource(@StashRunTimeMapStore final MapStore<StashRunTimeInfo> stashStartTimestampInfo, final MetricRegistry metricRegistry) {
+        _stashStartTimestampInfo = checkNotNull(stashStartTimestampInfo, "stashStartTimestampInfo");
+        _compactionControlTimeCounter = checkNotNull(metricRegistry, "metricRegistry").counter(MetricRegistry.name("bv.emodb.scan", "CompactionControlSource", "time-count"));
+    }
+
+    @Override
+    public void updateStashTime(String id, long timestamp, List<String> placements, long expiredTimestamp, String dataCenter) {
+        checkNotNull(id, "id");
+        checkNotNull(placements, "placements");
+        checkNotNull(dataCenter, "dataCenter");
+        checkState(timestamp > System.currentTimeMillis() + Duration.ofSeconds(10).toMillis(), "specified timestamp seems to be in the past");
+
+        try {
+            _stashStartTimestampInfo.set(zkKey(id, dataCenter), new StashRunTimeInfo(timestamp, placements, dataCenter, expiredTimestamp));
+            _compactionControlTimeCounter.inc();
+        } catch (Exception e) {
+            _log.error("Failed to update stash timestamp info for id: {}, datacenter: {}", id, dataCenter, e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public void deleteStashTime(String id, String dataCenter) {
+        checkNotNull(id, "id");
+        checkNotNull(dataCenter, "dataCenter");
+
+        try {
+            _stashStartTimestampInfo.remove(zkKey(id, dataCenter));
+            _compactionControlTimeCounter.dec();
+        } catch (Exception e) {
+            _log.error("Failed to delete stash timestamp info for id: {}, datacenter: {}", id, dataCenter, e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public StashRunTimeInfo getStashTime(String id, String dataCenter) {
+        checkNotNull(id, "id");
+        checkNotNull(dataCenter, "dataCenter");
+
+        return _stashStartTimestampInfo.get(zkKey(id, dataCenter));
+    }
+
+    @Override
+    public Map<String, StashRunTimeInfo> getAllStashTimes() {
+        return _stashStartTimestampInfo.getAll();
+    }
+
+    @Override
+    public Map<String, StashRunTimeInfo> getStashTimesForPlacement(String placement) {
+        Map<String, StashRunTimeInfo> stashTimes = _stashStartTimestampInfo.getAll();
+        return stashTimes.size() > 0 ? stashTimes.entrySet().stream()
+                .filter(stashTime -> stashTime.getValue().getPlacements().contains(placement))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+                : ImmutableMap.of();
+    }
+
+    private String zkKey(String id, String dataCenter) {
+        return id + "-" + dataCenter;
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/DelegateCompactionControl.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/DelegateCompactionControl.java
@@ -1,0 +1,21 @@
+package com.bazaarvoice.emodb.sor.compactioncontrol;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation indicating that the annotated object is the 'local' Compaction control source.
+ */
+@BindingAnnotation
+@Target ({FIELD, PARAMETER, METHOD})
+@Retention (RUNTIME)
+public @interface DelegateCompactionControl {
+}
+

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/InMemoryCompactionControlSource.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/InMemoryCompactionControlSource.java
@@ -1,0 +1,70 @@
+package com.bazaarvoice.emodb.sor.compactioncontrol;
+
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/* For Testing Purpose only */
+public class InMemoryCompactionControlSource implements CompactionControlSource {
+
+    private static final Logger _log = LoggerFactory.getLogger(InMemoryCompactionControlSource.class);
+
+    private Map<String, StashRunTimeInfo> _stashStartTimestampInfo = Maps.newConcurrentMap();
+
+    @Override
+    public void updateStashTime(String id, long timestamp, List<String> placements, long expiredTimestamp, String dataCenter) {
+        checkNotNull(id, "id");
+        checkNotNull(placements, "placements");
+        checkNotNull(dataCenter, "dataCenter");
+
+        try {
+            _stashStartTimestampInfo.put(id, new StashRunTimeInfo(timestamp, placements, dataCenter, expiredTimestamp));
+        } catch (Exception e) {
+            _log.error("Failed to update stash timestamp info for id: {}", id, e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public void deleteStashTime(String id, String dataCenter) {
+        checkNotNull(id, "id");
+
+        try {
+            _stashStartTimestampInfo.remove(id);
+        } catch (Exception e) {
+            _log.error("Failed to delete stash timestamp info for id: {}", id, e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public StashRunTimeInfo getStashTime(String id, String dataCenter) {
+        checkNotNull(id, "id");
+
+        return _stashStartTimestampInfo.get(id);
+    }
+
+    @Override
+    public Map<String, StashRunTimeInfo> getAllStashTimes() {
+        return _stashStartTimestampInfo;
+    }
+
+    @Override
+    public Map<String, StashRunTimeInfo> getStashTimesForPlacement(String placement) {
+        return _stashStartTimestampInfo.size() > 0 ? _stashStartTimestampInfo.entrySet()
+                .stream()
+                .filter(stashTime -> stashTime.getValue().getPlacements().contains(placement))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+                : ImmutableMap.of();
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/LocalCompactionControl.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/LocalCompactionControl.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.sor.compactioncontrol;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation indicating that the annotated object is the 'local' Compaction control source.
+ */
+@BindingAnnotation
+@Target ({FIELD, PARAMETER, METHOD})
+@Retention (RUNTIME)
+public @interface LocalCompactionControl {
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/StashRunTimeInfoSerializer.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/StashRunTimeInfoSerializer.java
@@ -1,0 +1,42 @@
+package com.bazaarvoice.emodb.sor.compactioncontrol;
+
+import com.bazaarvoice.emodb.common.zookeeper.store.ZkTimestampSerializer;
+import com.bazaarvoice.emodb.common.zookeeper.store.ZkValueSerializer;
+import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Simple serializer for storing {@link StashRunTimeInfo} configurations in ZooKeeper.
+ */
+public class StashRunTimeInfoSerializer implements ZkValueSerializer<StashRunTimeInfo> {
+
+    private static final ZkTimestampSerializer TIMESTAMP_SERIALIZER = new ZkTimestampSerializer();
+
+    @Override
+    public String toString(StashRunTimeInfo stashRunTimeInfo) {
+        return String.format("%s;%s;%s;%s", TIMESTAMP_SERIALIZER.toString(stashRunTimeInfo.getTimestamp()), stashRunTimeInfo.getDataCenter(),
+                stashRunTimeInfo.getExpiredTimestamp(), StringUtils.join(stashRunTimeInfo.getPlacements(), ','));
+    }
+
+    @Override
+    public StashRunTimeInfo fromString(String string) {
+        if (string == null) {
+            return null;
+        }
+        try {
+            List<String> strings = Arrays.asList(StringUtils.split(string, ";"));
+            Long timestamp = TIMESTAMP_SERIALIZER.fromString(strings.get(0));
+            String dataCenter = strings.get(1);
+            Long expiredTimestamp = TIMESTAMP_SERIALIZER.fromString(strings.get(2));
+            List<String> placements = Arrays.asList(StringUtils.split(strings.get(3), ","));
+
+            return new StashRunTimeInfo(timestamp, placements, dataCenter, expiredTimestamp);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("StashRunTimeInfo string must be of the form \"timestamp;datacenter;remote;placement1,placement2,placement3,...\"");
+        }
+    }
+}
+

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/StashRunTimeMapStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/compactioncontrol/StashRunTimeMapStore.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.sor.compactioncontrol;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for saving the timestamp of the running stash.
+ */
+@BindingAnnotation
+@Target ({FIELD, PARAMETER, METHOD})
+@Retention (RUNTIME)
+public @interface StashRunTimeMapStore {
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/Compactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/Compactor.java
@@ -7,7 +7,7 @@ import java.util.Iterator;
 
 public interface Compactor {
 
-    Expanded expand(Record record, long fullConsistencyTimestamp, long compactionConsistencyTimeStamp, MutableIntrinsics intrinsics, boolean ignoreRecent,
+    Expanded expand(Record record, long fullConsistencyTimestamp, long compactionConsistencyTimeStamp, long compactionControlTimestamp, MutableIntrinsics intrinsics, boolean ignoreRecent,
                     Supplier<Record> requeryFn);
 
     Iterator<DataAudit> getAuditedContent(PendingCompaction pendingCompaction,

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
@@ -14,6 +14,7 @@ import com.google.common.collect.PeekingIterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class DistributedCompactor extends AbstractCompactor implements Compactor {
 
@@ -24,12 +25,12 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
         _legacyCompactor = new DefaultCompactor(archiveDeltaSizeInMemory, keepDeltaHistory, metricRegistry);
     }
 
-    public Expanded expand(Record record, long fullConsistencyTimestamp, long compactionConsistencyTimeStamp, MutableIntrinsics intrinsics,
+    public Expanded expand(Record record, long fullConsistencyTimestamp, long compactionConsistencyTimeStamp, long compactionControlTimestamp, MutableIntrinsics intrinsics,
                            boolean ignoreRecent, Supplier<Record> requeryFn) {
         // Bound the # of times we attempt to resolve race conditions--we never want to go into an infinite loop.
         for (int i = 0; i < 10; i++) {
             try {
-                return doExpand(record, fullConsistencyTimestamp, compactionConsistencyTimeStamp, intrinsics, ignoreRecent);
+                return doExpand(record, fullConsistencyTimestamp, compactionConsistencyTimeStamp, compactionControlTimestamp, intrinsics, ignoreRecent);
             } catch (RestartException e) {
                 // Raced another process w/processing compaction records and lost.  Re-query the record and try again.
                 record = requeryFn.get();
@@ -49,7 +50,7 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
      *
      * @throws RestartException
      */
-    protected Expanded doExpand(Record record, long fullConsistencyTimestamp, long compactionConsistencyTimeStamp, MutableIntrinsics intrinsics, boolean ignoreRecent)
+    protected Expanded doExpand(Record record, long fullConsistencyTimestamp, long compactionConsistencyTimeStamp, long compactionControlTimestamp, MutableIntrinsics intrinsics, boolean ignoreRecent)
             throws RestartException {
         List<UUID> keysToDelete = Lists.newArrayList();
         DeltasArchive deltasArchive = new DeltasArchive();
@@ -73,7 +74,7 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
         Compaction compaction = null;
         UUID cutoffId = null;
         UUID initialCutoff = null;
-        Delta cutoffDelta= null;
+        Delta cutoffDelta = null;
         Delta initialCutoffDelta = null;
         boolean compactionChanged = false;
 
@@ -116,7 +117,7 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
             }
 
             // Assert that the resolved compacted content is always a literal
-            assert(compaction.getCompactedDelta().isConstant()) : "Compacted delta was not a literal";
+            assert (compaction.getCompactedDelta().isConstant()) : "Compacted delta was not a literal";
 
             cutoffDelta = compaction.getCompactedDelta();
             initialCutoffDelta = compaction.getCompactedDelta();
@@ -158,6 +159,13 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
             // Re-initialize the resolver with the new compaction state.
             resolver = new DefaultResolver(intrinsics, compaction);
         }
+
+        // consider compactionControlTimestamp here (one case could be that there is a stash run in progress) and not include those Ids.
+        // With this, we are halting the deletion of these deltas in this run.
+        // We could have not included these Ids at the first place in the top section, but just to be cleaner and for better separation, excluding these Ids here.
+        keysToDelete = keysToDelete.stream().filter(keyToDelete -> (TimeUUIDs.getTimeMillis(keyToDelete) > compactionControlTimestamp)).collect(Collectors.toList());
+        compactionKeysToDelete = compactionKeysToDelete.stream().filter(compactionKeyToDelete -> (TimeUUIDs.getTimeMillis(compactionKeyToDelete) > compactionControlTimestamp)).collect(Collectors.toList());
+
         // Persist the compaction, and keys-to-delete.  We must write compaction and delete synchronously to
         // be sure that eventually consistent readers don't see the result of the deletions w/o also
         // seeing the accompanying compaction.

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryDataStore.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.sor.core.test;
 
+import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSource;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.DefaultDataStore;
 import com.bazaarvoice.emodb.sor.db.test.InMemoryDataReaderDAO;
@@ -28,6 +29,6 @@ public class InMemoryDataStore extends DefaultDataStore {
     public InMemoryDataStore(EventBus eventBus, InMemoryDataReaderDAO dataDao, MetricRegistry metricRegistry) {
         super(eventBus, new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), MoreExecutors.sameThreadExecutor(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), Conditions.alwaysFalse(), metricRegistry);
+                Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), metricRegistry);
     }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
@@ -272,7 +272,6 @@ public class InMemoryDataReaderDAO implements DataReaderDAO, DataWriterDAO, Migr
 
         Map<UUID, Change> changes = safePut(_contentChanges, table.getName(), key);
 
-        // delete the old deltas & compaction records
         deleteDeltas(changesToDelete, changes);
 
         // add the compaction record and update the last content of the last delta

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/DataStoreModuleTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/DataStoreModuleTest.java
@@ -16,7 +16,10 @@ import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
 import com.bazaarvoice.emodb.job.api.JobService;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.compactioncontrol.CompControlApiKey;
+import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.sor.db.astyanax.AstyanaxDataReaderDAO;
@@ -142,6 +145,8 @@ public class DataStoreModuleTest {
                 bind(new TypeLiteral<Supplier<Boolean>>(){}).annotatedWith(CqlForMultiGets.class).toInstance(Suppliers.ofInstance(true));
                 bind(new TypeLiteral<Supplier<Boolean>>(){}).annotatedWith(CqlForScans.class).toInstance(Suppliers.ofInstance(true));
                 bind(Clock.class).toInstance(Clock.systemDefaultZone());
+                bind(String.class).annotatedWith(CompControlApiKey.class).toInstance("CompControlApiKey");
+                bind(CompactionControlSource.class).annotatedWith(LocalCompactionControl.class).toInstance(mock(CompactionControlSource.class));
 
                 install(new DataStoreModule(serviceMode));
             }

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/CompactionControlTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/CompactionControlTest.java
@@ -1,0 +1,199 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.sor.api.Change;
+import com.bazaarvoice.emodb.sor.api.ChangeBuilder;
+import com.bazaarvoice.emodb.sor.api.Compaction;
+import com.bazaarvoice.emodb.sor.db.Key;
+import com.bazaarvoice.emodb.sor.db.Record;
+import com.bazaarvoice.emodb.sor.delta.Delta;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Supplier;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class CompactionControlTest {
+
+    @Test
+    public void allDeltasBeforeCompactionControlTimestampShouldNotBeDeleted() {
+
+        long nowInTimeMillis = System.currentTimeMillis();
+
+        UUID t1 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis);
+        UUID t2 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 10 * 1000);
+        UUID t3 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 20 * 1000);
+
+        // note: compaction control timestamp is after all the deltas.
+        long compactionControlTimestamp = nowInTimeMillis + 30 * 1000;
+
+        long fullConsistencyTimestamp = nowInTimeMillis + 40 * 1000;
+
+        Delta delta1 = Deltas.literal(ImmutableMap.of("key1", "value1"));
+        Delta delta2 = Deltas.literal(ImmutableMap.of("key2", "value2"));
+        Delta delta3 = Deltas.mapBuilder().put("key3", "change").build();
+
+        final List<Map.Entry<UUID, Change>> deltas = ImmutableList.of(
+                Maps.immutableEntry(t1, ChangeBuilder.just(t1, delta1)),
+                Maps.immutableEntry(t2, ChangeBuilder.just(t2, delta2)),
+                Maps.immutableEntry(t3, ChangeBuilder.just(t3, delta3)));
+
+        Record record = mock(Record.class);
+        final Key key = mock(Key.class);
+        when(record.getKey()).thenReturn(key);
+        final List<Map.Entry<UUID, Compaction>> compactions = Lists.newArrayList();
+        when(record.passOneIterator()).thenReturn(compactions.iterator());
+        when(record.passTwoIterator()).thenReturn(deltas.iterator());
+
+        //noinspection unchecked
+        Supplier<Record> requeryFn = mock(Supplier.class);
+        when(requeryFn.get()).thenReturn(record);
+
+        MetricRegistry metricRegistry = new MetricRegistry();
+        Counter archiveDeltaSize = metricRegistry.counter(MetricRegistry.name("bv.emodb.sor", "DefaultCompactor", "archivedDeltaSize"));
+        Compactor compactor = new DistributedCompactor(archiveDeltaSize, false, metricRegistry);
+        Expanded expanded = compactor.expand(record, fullConsistencyTimestamp, fullConsistencyTimestamp, compactionControlTimestamp, MutableIntrinsics.create(key), false, requeryFn);
+
+        assertTrue(expanded.getPendingCompaction() != null);
+        // Do not delete deltas just yet; deltas are going to be deleted now in the next read
+        assertTrue(expanded.getPendingCompaction().getKeysToDelete().isEmpty());
+        // Add the compactions to the compaction list
+        UUID compactionTimestamp = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 35 * 1000); // altering this instead of "expanded.getPendingCompaction().getChangeId()"
+        compactions.add(Maps.immutableEntry(compactionTimestamp, expanded.getPendingCompaction().getCompaction()));
+        when(record.passOneIterator()).thenReturn(compactions.iterator());
+        when(record.passTwoIterator()).thenReturn(deltas.iterator());
+
+        expanded = compactor.expand(record, fullConsistencyTimestamp, fullConsistencyTimestamp, compactionControlTimestamp, MutableIntrinsics.create(key), false, requeryFn);
+
+        // In the DistributedCompactor, at first 3 keys will be selected for deletion, and later all 3 keys get filtered out from the deletionList based on the compactionControlTimestamp.
+        // Verify that there are 0 keys for deletion. If there are no keys to be deleted, there will be no pending compaction.
+        assertNull(expanded.getPendingCompaction());
+    }
+
+    @Test
+    public void allDeltasAfterCompactionControlTimestampShouldBeDeleted() {
+
+        long nowInTimeMillis = System.currentTimeMillis();
+
+        // note: compaction control timestamp is before all the deltas.
+        long compactionControlTimestamp = nowInTimeMillis;
+
+        UUID t1 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 10 * 1000);
+        UUID t2 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 20 * 1000);
+        UUID t3 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 30 * 1000);
+
+        long fullConsistencyTimestamp = nowInTimeMillis + 40 * 1000;
+
+        Delta delta1 = Deltas.literal(ImmutableMap.of("key1", "value1"));
+        Delta delta2 = Deltas.literal(ImmutableMap.of("key2", "value2"));
+        Delta delta3 = Deltas.mapBuilder().put("key3", "change").build();
+
+        final List<Map.Entry<UUID, Change>> deltas = ImmutableList.of(
+                Maps.immutableEntry(t1, ChangeBuilder.just(t1, delta1)),
+                Maps.immutableEntry(t2, ChangeBuilder.just(t2, delta2)),
+                Maps.immutableEntry(t3, ChangeBuilder.just(t3, delta3)));
+
+        Record record = mock(Record.class);
+        final Key key = mock(Key.class);
+        when(record.getKey()).thenReturn(key);
+        final List<Map.Entry<UUID, Compaction>> compactions = Lists.newArrayList();
+        when(record.passOneIterator()).thenReturn(compactions.iterator());
+        when(record.passTwoIterator()).thenReturn(deltas.iterator());
+
+        //noinspection unchecked
+        Supplier<Record> requeryFn = mock(Supplier.class);
+        when(requeryFn.get()).thenReturn(record);
+
+        MetricRegistry metricRegistry = new MetricRegistry();
+        Counter archiveDeltaSize = metricRegistry.counter(MetricRegistry.name("bv.emodb.sor", "DefaultCompactor", "archivedDeltaSize"));
+        Compactor compactor = new DistributedCompactor(archiveDeltaSize, false, metricRegistry);
+        Expanded expanded = compactor.expand(record, fullConsistencyTimestamp, fullConsistencyTimestamp, compactionControlTimestamp, MutableIntrinsics.create(key), false, requeryFn);
+
+        assertTrue(expanded.getPendingCompaction() != null);
+        // Do not delete deltas just yet; deltas are going to be deleted now in the next read
+        assertTrue(expanded.getPendingCompaction().getKeysToDelete().isEmpty());
+        // Add the compactions to the compaction list
+        UUID compactionTimestamp = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 35 * 1000); // altering this instead of "expanded.getPendingCompaction().getChangeId()"
+        compactions.add(Maps.immutableEntry(compactionTimestamp, expanded.getPendingCompaction().getCompaction()));
+        when(record.passOneIterator()).thenReturn(compactions.iterator());
+        when(record.passTwoIterator()).thenReturn(deltas.iterator());
+
+        expanded = compactor.expand(record, fullConsistencyTimestamp, fullConsistencyTimestamp, compactionControlTimestamp, MutableIntrinsics.create(key), false, requeryFn);
+
+        // Verify that there are all 3 keys for deletion.
+        // In the DistributedCompactor, at first 3 keys will be selected for deletion, and later no keys get filtered out from the deletionList based on the compactionControlTimestamp.
+        assertTrue(expanded.getPendingCompaction() != null);
+        assertTrue(ImmutableSet.copyOf(expanded.getPendingCompaction().getKeysToDelete()).equals(ImmutableSet.of(t1, t2, t3)));
+    }
+
+    @Test
+    public void deltasAfterCompactionControlTimestampShouldOnlyBeDeletedAndDeltasBeforeCompactionControlTimestampShouldNotBeDeleted() {
+
+        long nowInTimeMillis = System.currentTimeMillis();
+
+        UUID t1 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis);
+        UUID t2 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 10 * 1000);
+
+        // note: compaction control timestamp is after t1, t2 and before t3
+        long compactionControlTimestamp = nowInTimeMillis + 20 * 1000;
+
+        UUID t3 = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 30 * 1000);
+
+        long fullConsistencyTimestamp = nowInTimeMillis + 40 * 1000;
+
+        Delta delta1 = Deltas.literal(ImmutableMap.of("key1", "value1"));
+        Delta delta2 = Deltas.literal(ImmutableMap.of("key2", "value2"));
+        Delta delta3 = Deltas.mapBuilder().put("key3", "change").build();
+
+        final List<Map.Entry<UUID, Change>> deltas = ImmutableList.of(
+                Maps.immutableEntry(t1, ChangeBuilder.just(t1, delta1)),
+                Maps.immutableEntry(t2, ChangeBuilder.just(t2, delta2)),
+                Maps.immutableEntry(t3, ChangeBuilder.just(t3, delta3)));
+
+        Record record = mock(Record.class);
+        final Key key = mock(Key.class);
+        when(record.getKey()).thenReturn(key);
+        final List<Map.Entry<UUID, Compaction>> compactions = Lists.newArrayList();
+        when(record.passOneIterator()).thenReturn(compactions.iterator());
+        when(record.passTwoIterator()).thenReturn(deltas.iterator());
+
+        //noinspection unchecked
+        Supplier<Record> requeryFn = mock(Supplier.class);
+        when(requeryFn.get()).thenReturn(record);
+
+        MetricRegistry metricRegistry = new MetricRegistry();
+        Counter archiveDeltaSize = metricRegistry.counter(MetricRegistry.name("bv.emodb.sor", "DefaultCompactor", "archivedDeltaSize"));
+        Compactor compactor = new DistributedCompactor(archiveDeltaSize, false, metricRegistry);
+        Expanded expanded = compactor.expand(record, fullConsistencyTimestamp, fullConsistencyTimestamp, compactionControlTimestamp, MutableIntrinsics.create(key), false, requeryFn);
+
+        assertTrue(expanded.getPendingCompaction() != null);
+        // Do not delete deltas just yet; deltas are going to be deleted now in the next read
+        assertTrue(expanded.getPendingCompaction().getKeysToDelete().isEmpty());
+        // Add the compactions to the compaction list
+        UUID compactionTimestamp = TimeUUIDs.uuidForTimeMillis(nowInTimeMillis + 35 * 1000); // altering this instead of "expanded.getPendingCompaction().getChangeId()"
+        compactions.add(Maps.immutableEntry(compactionTimestamp, expanded.getPendingCompaction().getCompaction()));
+        when(record.passOneIterator()).thenReturn(compactions.iterator());
+        when(record.passTwoIterator()).thenReturn(deltas.iterator());
+
+        expanded = compactor.expand(record, fullConsistencyTimestamp, fullConsistencyTimestamp, compactionControlTimestamp, MutableIntrinsics.create(key), false, requeryFn);
+
+        // Verify that there is exactly 1 key to be deleted
+        // In the DistributedCompactor, at first 3 keys will be selected for deletion, and later 2 keys get filtered out based on the compactionControlTimestamp.
+        assertTrue(expanded.getPendingCompaction() != null);
+        assertTrue(ImmutableSet.copyOf(expanded.getPendingCompaction().getKeysToDelete()).equals(ImmutableSet.of(t3)));
+    }
+}

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiDCCompactionTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiDCCompactionTest.java
@@ -164,13 +164,13 @@ public class MultiDCCompactionTest {
         //noinspection unchecked
         Supplier<Record> requeryFn = mock(Supplier.class);
 
-        Expanded expand = compactor.expand(record, fctBeforeT2, fctBeforeT2, MutableIntrinsics.create(key), false, requeryFn);
+        Expanded expand = compactor.expand(record, fctBeforeT2, fctBeforeT2, Long.MIN_VALUE, MutableIntrinsics.create(key), false, requeryFn);
 
         // Verify that no pending compaction is produced since the winning compaction is outside of FCT
         assertNull(expand.getPendingCompaction());
 
         // Change the FCT such that the winning compaction (c2) is before FCT
-        expand = compactor.expand(record, fctAfterT2, fctAfterT2, MutableIntrinsics.create(key), false, requeryFn);
+        expand = compactor.expand(record, fctAfterT2, fctAfterT2, Long.MIN_VALUE, MutableIntrinsics.create(key), false, requeryFn);
         List<UUID> deletedCompactions = expand.getPendingCompaction().getCompactionKeysToDelete();
         // Verify that compactions other than c2, are deleted
         Assert.assertTrue(deletedCompactions.contains(t1));

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/RedundantDeltaTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/RedundantDeltaTest.java
@@ -13,6 +13,7 @@ import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
 import com.bazaarvoice.emodb.sor.api.Update;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSource;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.test.DiscardingExecutorService;
 import com.bazaarvoice.emodb.sor.core.test.InMemoryAuditStore;
@@ -61,7 +62,7 @@ public class RedundantDeltaTest {
         InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO();
         DefaultDataStore store = new DefaultDataStore(new EventBus(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
+                Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -117,7 +118,7 @@ public class RedundantDeltaTest {
         InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO();
         DefaultDataStore store = new DefaultDataStore(new EventBus(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
+                Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -197,7 +198,7 @@ public class RedundantDeltaTest {
         InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO();
         DefaultDataStore store = new DefaultDataStore(new EventBus(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
+                Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -216,7 +217,7 @@ public class RedundantDeltaTest {
         InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO();
         DefaultDataStore store = new DefaultDataStore(new EventBus(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
+                Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -275,12 +276,12 @@ public class RedundantDeltaTest {
         Counter archiveDeltaSize = metricRegistry.counter(MetricRegistry.name("bv.emodb.sor", "DistributedCompactor", "archivedDeltaSize"));
         Expanded expanded =
                 new DistributedCompactor(archiveDeltaSize, true, metricRegistry)
-                        .expand(record, now, now, MutableIntrinsics.create(key), false, mock(Supplier.class));
+                        .expand(record, now, now, now, MutableIntrinsics.create(key), false, mock(Supplier.class));
 
         assertTrue(expanded.getResolved().isChangeDeltaRedundant(uuid1), "Legacy compaction issue");
 
         expanded = new DistributedCompactor(archiveDeltaSize, true, metricRegistry)
-                        .expand(record, now, now, MutableIntrinsics.create(key), false, mock(Supplier.class));
+                        .expand(record, now, now, now, MutableIntrinsics.create(key), false, mock(Supplier.class));
         assertFalse(expanded.getResolved().isChangeDeltaRedundant(uuid1), "Legacy compaction issue");
 
     }
@@ -292,7 +293,7 @@ public class RedundantDeltaTest {
 
         DefaultDataStore store = new DefaultDataStore(new EventBus(), tableDao, dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
+                Optional.<URI>absent(),  new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -363,7 +364,7 @@ public class RedundantDeltaTest {
 
         DefaultDataStore store = new DefaultDataStore(new EventBus(), tableDao, dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryAuditStore(),
-                Optional.<URI>absent(), Conditions.alwaysFalse(), new MetricRegistry());
+                Optional.<URI>absent(),  new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.sor.test;
 
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.SimpleLifeCycleRegistry;
 import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSource;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.AuditStore;
 import com.bazaarvoice.emodb.sor.core.DefaultDataStore;
@@ -60,11 +61,11 @@ public class MultiDCDataStores {
             if (asyncCompacter) {
                 _stores[i] = new DefaultDataStore(new SimpleLifeCycleRegistry(), metricRegistry, new EventBus(), _tableDao,
                         _inMemoryDaos[i].setAuditStore(_auditStores[i]), _replDaos[i], new NullSlowQueryLog(), _auditStores[i],
-                        Optional.<URI>absent(), Conditions.alwaysFalse());
+                        Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse());
             } else {
                 _stores[i] = new DefaultDataStore(new EventBus(), _tableDao, _inMemoryDaos[i].setAuditStore(_auditStores[i]),
                         _replDaos[i], new NullSlowQueryLog(), MoreExecutors.sameThreadExecutor(), _auditStores[i],
-                        Optional.<URI>absent(), Conditions.alwaysFalse(), metricRegistry);
+                        Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), metricRegistry);
             }
         }
     }

--- a/web-local/config-local-blob-role.yaml
+++ b/web-local/config-local-blob-role.yaml
@@ -76,9 +76,9 @@ systemOfRecord:
 
   # A per-keyspace map of Cassandra connection settings
   cassandraClusters:
-    app_global:
+    emo_cluster:
       cluster: emo_cluster
-      clusterMetric: emo_cluster_metric_name
+      clusterMetric: emo_sor_metric_name
       dataCenter: datacenter1
       seeds: 127.0.0.1
       # zooKeeperServiceName: dev_sor_ugc_default-cassandra
@@ -92,7 +92,7 @@ systemOfRecord:
       keyspaces:
         app_global: {}
         ugc_global: {}
-        catalog_global: {}
+        catalog_global:  {}
 
   slowQueryLog:
     tooManyDeltasThreshold: 20
@@ -140,9 +140,7 @@ blobStore:
     media_global:
       cluster: emo_cluster
       clusterMetric: emo_media_metric_name
-      keyspace: media_global
       dataCenter: datacenter1
-      healthCheckColumnFamily: ugc_blob
       seeds: 127.0.0.1
       # zooKeeperServiceName: dev_sor_ugc_default-cassandra
       thriftPort: 9160
@@ -211,6 +209,7 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
+  compControlApiKey: "local_admin" # compaction-control
   anonymousRoles:
   - anonymous
 

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -34,8 +34,6 @@ systemTablePlacement: app_global:sys
 #      type: http
 #      apiKey: invalid-key
 
-
-
 dataCenter:
   # Which data center does this server belong to?
   currentDataCenter: datacenter1
@@ -226,6 +224,7 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
+  compControlApiKey: "local_admin" # compaction-control
   anonymousRoles:
   - anonymous
 

--- a/web-local/config-scantest.yaml
+++ b/web-local/config-scantest.yaml
@@ -200,7 +200,6 @@ queueService:
     keyspaces:
       queue: {}
 
-
 cqlDriver:
   multiRowFetchSize: 100
   multiRowPrefetchLimit: 50
@@ -221,6 +220,7 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
+  compControlApiKey: "local_admin" # compaction-control
   anonymousRoles:
   - anonymous
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -87,6 +87,8 @@ import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper
 import com.bazaarvoice.emodb.web.auth.AuthorizationConfiguration;
 import com.bazaarvoice.emodb.web.auth.OwnerDatabusAuthorizer;
 import com.bazaarvoice.emodb.web.auth.SecurityModule;
+import com.bazaarvoice.emodb.web.compactioncontrol.CompactionControlModule;
+import com.bazaarvoice.emodb.web.compactioncontrol.CompactionControlMonitorManager;
 import com.bazaarvoice.emodb.web.migrator.MigratorModule;
 import com.bazaarvoice.emodb.web.partition.PartitionAwareClient;
 import com.bazaarvoice.emodb.web.partition.PartitionAwareServiceFactory;
@@ -150,7 +152,25 @@ import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.*;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.blackList;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.blobStore_module;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.cache;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.compaction_control;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.compaction_control_web;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.dataBus_module;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.dataCenter;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.dataStore_module;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.dataStore_web;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.delta_migrator;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.full_consistency;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.job;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.leader_control;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.queue_module;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.report;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.scanner;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.security;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.throttle;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.web;
 
 public class EmoModule extends AbstractModule {
     private static final Logger _log = LoggerFactory.getLogger(EmoModule.class);
@@ -189,6 +209,8 @@ public class EmoModule extends AbstractModule {
         evaluate(security, new SecuritySetup());
         evaluate(full_consistency, new FullConsistencySetup());
         evaluate(dataStore_web, new DataStoreAsyncSetup());
+        evaluate(compaction_control, new CompactionControlSetup());
+        evaluate(compaction_control_web, new CompactionControlWebSetup());
     }
 
     private class CommonModuleSetup extends AbstractModule {
@@ -563,6 +585,20 @@ public class EmoModule extends AbstractModule {
         @Override
         protected void configure() {
             install(new ReportsModule());
+        }
+    }
+
+    private class CompactionControlSetup extends AbstractModule  {
+        @Override
+        protected void configure() {
+            install(new CompactionControlModule());
+        }
+    }
+
+    private class CompactionControlWebSetup extends AbstractModule  {
+        @Override
+        protected void configure() {
+            bind(CompactionControlMonitorManager.class).asEagerSingleton();
         }
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -22,6 +22,7 @@ import com.bazaarvoice.emodb.queue.api.DedupQueueService;
 import com.bazaarvoice.emodb.queue.api.QueueService;
 import com.bazaarvoice.emodb.queue.client.DedupQueueServiceAuthenticator;
 import com.bazaarvoice.emodb.queue.client.QueueServiceAuthenticator;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.core.DataStoreAsync;
 import com.bazaarvoice.emodb.web.auth.EncryptConfigurationApiKeyCommand;
@@ -30,6 +31,7 @@ import com.bazaarvoice.emodb.web.cli.ListCassandraCommand;
 import com.bazaarvoice.emodb.web.cli.PurgeDatabusEventsCommand;
 import com.bazaarvoice.emodb.web.cli.RegisterCassandraCommand;
 import com.bazaarvoice.emodb.web.cli.UnregisterCassandraCommand;
+import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
 import com.bazaarvoice.emodb.web.ddl.CreateKeyspacesCommand;
 import com.bazaarvoice.emodb.web.ddl.DdlConfiguration;
 import com.bazaarvoice.emodb.web.jersey.ExceptionMappers;
@@ -257,8 +259,10 @@ public class EmoService extends Application<EmoConfiguration> {
         DataStore dataStore = _injector.getInstance(DataStore.class);
         ResourceRegistry resources = _injector.getInstance(ResourceRegistry.class);
         DataStoreAsync dataStoreAsync = _injector.getInstance(DataStoreAsync.class);
+        CompactionControlSource compactionControlSource = _injector.getInstance(Key.get(CompactionControlSource.class, LocalCompactionControl.class));
+
         // Start the System Of Record service
-        resources.addResource(_cluster, "emodb-sor-1", new DataStoreResource1(dataStore, dataStoreAsync));
+        resources.addResource(_cluster, "emodb-sor-1", new DataStoreResource1(dataStore, dataStoreAsync, compactionControlSource));
     }
 
     private void evaluateBlobStore()

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
@@ -37,8 +37,13 @@ public class AuthorizationConfiguration {
     // Replication key used for replicating across data centers
     @NotNull
     private String _replicationApiKey;
+
     // Set of roles assigned for anonymous user.  If the set is empty anonymous access is disabled.
     private Set<String> _anonymousRoles = ImmutableSet.of();
+
+    // Compaction control key
+    @NotNull
+    private String _compControlApiKey;
 
     public String getIdentityTable() {
         return _identityTable;
@@ -109,6 +114,15 @@ public class AuthorizationConfiguration {
 
     public AuthorizationConfiguration setAnonymousRoles(Set<String> anonymousRoles) {
         _anonymousRoles = anonymousRoles;
+        return this;
+    }
+
+    public String getCompControlApiKey() {
+        return _compControlApiKey;
+    }
+
+    public AuthorizationConfiguration setCompControlApiKey(String compControlApiKey) {
+        _compControlApiKey = compControlApiKey;
         return this;
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
+import static com.bazaarvoice.emodb.web.auth.Permissions.ALL;
 import static com.bazaarvoice.emodb.web.auth.Permissions.NON_SYSTEM_NON_PII_TABLE;
 import static com.bazaarvoice.emodb.web.auth.Permissions.NON_SYSTEM_RESOURCE;
 import static com.bazaarvoice.emodb.web.auth.Permissions.NON_SYSTEM_TABLE;
@@ -131,8 +132,12 @@ public enum DefaultRoles {
     // Reserved role for replication databus traffic between data centers
     replication (
             ImmutableSet.of(sor_read),
-            Permissions.replicateDatabus());
-    
+            Permissions.replicateDatabus()),
+
+    // role for using compaction control API.
+    compaction_control (
+            Permissions.compactionControl());
+
     private Set<String> _permissions;
 
     private DefaultRoles(String... permissions) {

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/Permissions.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/Permissions.java
@@ -51,6 +51,7 @@ public class Permissions {
     public final static String GRANT = "grant";
     public final static String CREATE_EXACT = "create_exact";
     public final static String VIEW_BY_KEY = "view_by_key";
+    public final static String COMPACTION_CONTROL = "comp_control";
 
     // Common resource values
     public final static AnyResource ALL = new AnyResource();
@@ -351,5 +352,9 @@ public class Permissions {
      */
     public static String rawDatabus() {
         return format("%s|%s", SYSTEM, RAW_DATABUS);
+    }
+
+    public static String compactionControl() {
+        return format("%s|%s", SYSTEM, COMPACTION_CONTROL);
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
@@ -29,13 +29,14 @@ import com.bazaarvoice.emodb.auth.shiro.InvalidatableCacheManager;
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.discovery.PayloadBuilder;
 import com.bazaarvoice.emodb.common.dropwizard.guice.ServerCluster;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.databus.ReplicationKey;
 import com.bazaarvoice.emodb.databus.SystemIdentity;
 import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.client.DataStoreClient;
-import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
+import com.bazaarvoice.emodb.sor.compactioncontrol.CompControlApiKey;
 import com.bazaarvoice.emodb.uac.api.AuthUserAccessControl;
 import com.bazaarvoice.emodb.uac.client.UserAccessControlClientFactory;
 import com.bazaarvoice.emodb.web.uac.LocalSubjectUserAccessControl;
@@ -99,6 +100,8 @@ import java.util.stream.Collectors;
  * <li> {@link DropwizardAuthConfigurator}
  * <li> @{@link ReplicationKey} String
  * <li> @{@link SystemIdentity} String
+ * <li> @{@link CompControlApiKey} String
+ * <li> @{@link SystemIdentity} String
  * <li> {@link PermissionResolver}
  * <li> {@link InternalAuthorizer}
  * <li> {@link SubjectUserAccessControl}
@@ -140,6 +143,7 @@ public class SecurityModule extends PrivateModule {
 
         expose(DropwizardAuthConfigurator.class);
         expose(Key.get(String.class, ReplicationKey.class));
+        expose(Key.get(String.class, CompControlApiKey.class));
         expose(Key.get(String.class, SystemIdentity.class));
         expose(PermissionResolver.class);
         expose(InternalAuthorizer.class);
@@ -175,6 +179,13 @@ public class SecurityModule extends PrivateModule {
     @ReplicationKey
     String provideReplicationKey(AuthorizationConfiguration config, ApiKeyEncryption encryption) {
         return configurationKeyAsPlaintext(config.getReplicationApiKey(), encryption, "replication");
+    }
+
+    @Provides
+    @Singleton
+    @CompControlApiKey
+    String provideCompControlKey(AuthorizationConfiguration config, ApiKeyEncryption encryption) {
+        return configurationKeyAsPlaintext(config.getCompControlApiKey(), encryption, "compaction-control");
     }
 
     @Provides

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/AllCompactionControlSources.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/AllCompactionControlSources.java
@@ -1,0 +1,21 @@
+package com.bazaarvoice.emodb.web.compactioncontrol;
+
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation indicating that the annotated object is the list of all Compaction control sources, local as well as remotes.
+ */
+@BindingAnnotation
+@Target ({FIELD, PARAMETER, METHOD})
+@Retention (RUNTIME)
+public @interface AllCompactionControlSources {
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlModule.java
@@ -1,0 +1,120 @@
+package com.bazaarvoice.emodb.web.compactioncontrol;
+
+import com.bazaarvoice.emodb.common.dropwizard.discovery.PayloadBuilder;
+import com.bazaarvoice.emodb.common.dropwizard.guice.ServerCluster;
+import com.bazaarvoice.emodb.common.dropwizard.healthcheck.HealthCheckRegistry;
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.bazaarvoice.emodb.common.jersey.dropwizard.JerseyEmoClient;
+import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
+import com.bazaarvoice.emodb.common.zookeeper.store.ZkMapStore;
+import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
+import com.bazaarvoice.emodb.datacenter.api.DataCenter;
+import com.bazaarvoice.emodb.datacenter.api.DataCenters;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.bazaarvoice.emodb.sor.client.CompactionControlClientFactory;
+import com.bazaarvoice.emodb.sor.client.DataStoreClient;
+import com.bazaarvoice.emodb.sor.compactioncontrol.CompControlApiKey;
+import com.bazaarvoice.emodb.sor.compactioncontrol.DefaultCompactionControlSource;
+import com.bazaarvoice.emodb.sor.compactioncontrol.DelegateCompactionControl;
+import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
+import com.bazaarvoice.emodb.sor.compactioncontrol.StashRunTimeInfoSerializer;
+import com.bazaarvoice.emodb.sor.compactioncontrol.StashRunTimeMapStore;
+import com.bazaarvoice.emodb.table.db.astyanax.CurrentDataCenter;
+import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
+import com.bazaarvoice.ostrich.MultiThreadedServiceFactory;
+import com.bazaarvoice.ostrich.ServiceEndPoint;
+import com.bazaarvoice.ostrich.ServiceEndPointBuilder;
+import com.bazaarvoice.ostrich.discovery.FixedHostDiscovery;
+import com.bazaarvoice.ostrich.pool.ServiceCachingPolicyBuilder;
+import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
+import com.bazaarvoice.ostrich.retry.ExponentialBackoffRetry;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Lists;
+import com.google.inject.PrivateModule;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.sun.jersey.api.client.Client;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.utils.ZKPaths;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Guice module
+ * <p/>
+ * Requires the following external references:
+ * <ul>
+ * <li> {@link DataCenters}
+ * <li> {@link MetricRegistry}
+ * <li> Jersey {@link Client}
+ * </ul>
+ * Exports the following:
+ * <ul>
+ * <li> {@link CompactionControlSource}
+ * </ul>
+ */
+public class CompactionControlModule extends PrivateModule {
+
+    @Override
+    protected void configure() {
+        bind(CompactionControlSource.class).annotatedWith(LocalCompactionControl.class).to(DefaultCompactionControlSource.class).asEagerSingleton();
+        expose(CompactionControlSource.class).annotatedWith(LocalCompactionControl.class);
+
+        bind(CompactionControlSource.class).annotatedWith(DelegateCompactionControl.class).to(DelegateCompactionControlSource.class).asEagerSingleton();
+        expose(CompactionControlSource.class).annotatedWith(DelegateCompactionControl.class);
+    }
+
+    @Provides
+    @Singleton
+    @CurrentDataCenter
+    String provideDataCenters(DataCenterConfiguration dataCenterConfiguration) {
+        return dataCenterConfiguration.getCassandraDataCenter();
+    }
+
+    @Provides
+    @Singleton
+    @StashRunTimeMapStore
+    MapStore<StashRunTimeInfo> provideStashRunTimeValues(@CurrentDataCenter String currentDataCenter, @GlobalFullConsistencyZooKeeper CuratorFramework curator,
+                                                         LifeCycleRegistry lifeCycle)
+            throws Exception {
+        // appending the current datacenter name in the zookeeper path. So this means the values stored here are datacenter specific.
+        String zkPath = ZKPaths.makePath("/stash-running-instance/start-timestamp", currentDataCenter);
+        return lifeCycle.manage(new ZkMapStore<>(curator, zkPath, new StashRunTimeInfoSerializer()));
+    }
+
+    @Provides
+    @Singleton
+    @AllCompactionControlSources
+    public List<CompactionControlSource> getAllCompactionControlSources(@LocalCompactionControl CompactionControlSource localCompactionControlSource, @ServerCluster String serverCluster,
+                                                                        Client client, DataCenters dataCenters, @CompControlApiKey String compControlApiKey,
+                                                                        HealthCheckRegistry healthCheckRegistry, MetricRegistry metrics) {
+        List<CompactionControlSource> compactionControlSources = Lists.newArrayList();
+        for (DataCenter dataCenter : dataCenters.getAll()) {
+            MultiThreadedServiceFactory<CompactionControlSource> clientFactory = new CompactionControlClientFactory(serverCluster, new JerseyEmoClient(client), compControlApiKey);
+
+            if (dataCenter.equals(dataCenters.getSelf())) {
+                compactionControlSources.add(localCompactionControlSource);
+            } else {
+                ServiceEndPoint endPoint = new ServiceEndPointBuilder()
+                        .withServiceName(clientFactory.getServiceName())
+                        .withId(dataCenter.getName())
+                        .withPayload(new PayloadBuilder()
+                                .withUrl(dataCenter.getServiceUri().resolve(DataStoreClient.SERVICE_PATH))
+                                .withAdminUrl(dataCenter.getAdminUri())
+                                .toString())
+                        .build();
+
+                compactionControlSources.add(ServicePoolBuilder.create(CompactionControlSource.class)
+                        .withHostDiscovery(new FixedHostDiscovery(endPoint))
+                        .withServiceFactory(clientFactory)
+                        .withCachingPolicy(ServiceCachingPolicyBuilder.getMultiThreadedClientPolicy())
+                        .withMetricRegistry(metrics)
+                        .buildProxy(new ExponentialBackoffRetry(30, 1, 10, TimeUnit.SECONDS)));
+            }
+        }
+        return compactionControlSources;
+    }
+
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitor.java
@@ -1,0 +1,87 @@
+package com.bazaarvoice.emodb.web.compactioncontrol;
+
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Ordering;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A service that checks the stash times, updates the metrics and deletes the expired entries.
+ */
+public class CompactionControlMonitor extends AbstractScheduledService {
+    private static final Logger _log = LoggerFactory.getLogger(CompactionControlMonitor.class);
+
+    @VisibleForTesting
+    protected static final Duration POLL_INTERVAL = Duration.standardMinutes(5);
+
+    private final CompactionControlSource _compactionControlSource;
+    private final Clock _clock;
+    private volatile long _lag;
+
+    public CompactionControlMonitor(CompactionControlSource compactionControlSource, Clock clock, MetricRegistry metricRegistry) {
+        _compactionControlSource = checkNotNull(compactionControlSource, "compactionControlSource");
+        _clock = checkNotNull(clock, "clock");
+        checkNotNull(metricRegistry, "metricRegistry").register(MetricRegistry.name("bv.emodb.scan", "ScanUploader", "compaction-control-time-lag"), (Gauge<Long>) () -> _lag);
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+        return Scheduler.newFixedDelaySchedule(0, POLL_INTERVAL.getMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected void shutDown() {
+    }
+
+    @Override
+    protected void runOneIteration() {
+        try {
+            updateMetrics(_clock.millis());
+            deleteExpiredStashTimes(_clock.millis());
+        } catch (Throwable t) {
+            _log.error("Unexpected exception.", t);
+        }
+    }
+
+    private void updateMetrics(long currentTimeInMillis) {
+        Map<String, StashRunTimeInfo> stashTimeInfoMap = _compactionControlSource.getAllStashTimes();
+        if (stashTimeInfoMap.size() > 0) {
+            long oldestCompactionControlTime = stashTimeInfoMap.values().stream()
+                    .map(StashRunTimeInfo::getTimestamp)
+                    .min(Ordering.natural())
+                    .orElse(currentTimeInMillis);
+            _lag = currentTimeInMillis - oldestCompactionControlTime;
+        } else {
+            _lag = 0L;
+        }
+    }
+
+    @VisibleForTesting
+    protected void deleteExpiredStashTimes(long currentTimeInMillis) {
+        try {
+            _log.debug("Checking for expired stash times at {}", currentTimeInMillis);
+            Map<String, StashRunTimeInfo> expiredStashTimes = _compactionControlSource.getAllStashTimes().entrySet().stream()
+                    .filter(entry -> entry.getValue().getExpiredTimestamp() < currentTimeInMillis).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            for (Map.Entry<String, StashRunTimeInfo> expiredStashTimeInfo : expiredStashTimes.entrySet()) {
+                // If we are deleting the entries here, then there could be a problem which we may want to know. So setting it as a warn.
+                _log.warn("Deleting the stash time entry for id: {}", expiredStashTimeInfo.getKey());
+                _compactionControlSource.deleteStashTime(expiredStashTimeInfo.getKey(), expiredStashTimeInfo.getValue().getDataCenter());
+            }
+        } catch (Exception e) {
+            _log.error("Unexpected exception deleting the expired stash times", e);
+        }
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitorManager.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitorManager.java
@@ -1,0 +1,48 @@
+package com.bazaarvoice.emodb.web.compactioncontrol;
+
+import com.bazaarvoice.curator.recipes.leader.LeaderService;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SelfHostAndPort;
+import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ManagedGuavaService;
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
+import com.bazaarvoice.emodb.datacenter.api.DataCenters;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
+import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Supplier;
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.Service;
+import com.google.inject.Inject;
+import org.apache.curator.framework.CuratorFramework;
+
+import java.time.Clock;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Starts the stash run time monitor, subject to ZooKeeper leader election.
+ */
+public class CompactionControlMonitorManager {
+    @Inject
+    CompactionControlMonitorManager(LifeCycleRegistry lifeCycle,
+                                    @LocalCompactionControl CompactionControlSource compactionControlSource,
+                                    DataCenters dataCenters,
+                                    @GlobalFullConsistencyZooKeeper CuratorFramework curator,
+                                    @SelfHostAndPort HostAndPort self,
+                                    Clock clock,
+                                    LeaderServiceTask dropwizardTask,
+                                    final MetricRegistry metricRegistry) {
+        LeaderService leaderService = new LeaderService(
+                curator, "/leader/compaction-control-monitor", self.toString(), "Leader-CompactionControlMonitor", 30, TimeUnit.MINUTES,
+                new Supplier<Service>() {
+                    @Override
+                    public Service get() {
+                        return new CompactionControlMonitor(compactionControlSource, clock, metricRegistry);
+                    }
+                });
+        ServiceFailureListener.listenTo(leaderService, metricRegistry);
+        dropwizardTask.register("stash-runtime-monitor", leaderService);
+        lifeCycle.manage(new ManagedGuavaService(leaderService));
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/DelegateCompactionControlSource.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/DelegateCompactionControlSource.java
@@ -1,0 +1,89 @@
+package com.bazaarvoice.emodb.web.compactioncontrol;
+
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/*
+ * This delegate implementation
+ * - iterates over all the datacenter sources for update and delete operations.
+ * - queries only the local datacenter for reads.
+ */
+public class DelegateCompactionControlSource implements CompactionControlSource {
+
+    private static final Logger _log = LoggerFactory.getLogger(DelegateCompactionControlSource.class);
+
+    private Provider<List<CompactionControlSource>> _compactionControlSourceListProvider;
+    private CompactionControlSource _localCompactionControl;
+
+    @Inject
+    public DelegateCompactionControlSource(@AllCompactionControlSources Provider<List<CompactionControlSource>> compactionControlSourceListProvider,
+                                           @LocalCompactionControl CompactionControlSource localCompactionSource) {
+        _compactionControlSourceListProvider = checkNotNull(compactionControlSourceListProvider, "compactionControlSourceListProvider");
+        _localCompactionControl = checkNotNull(localCompactionSource, "localCompactionSource");
+    }
+
+    @Override
+    public void updateStashTime(String id, long timestamp, List<String> placements, long expiredTimestamp, String datacenter) {
+        try {
+            for (CompactionControlSource compactionControlSource : _compactionControlSourceListProvider.get()) {
+                compactionControlSource.updateStashTime(id, timestamp, placements, expiredTimestamp, datacenter);
+            }
+        } catch (Exception e) {
+            _log.error("Failed to update stash timestamp info for id: {}", id, e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public void deleteStashTime(String id, String dataCenter) {
+        try {
+            for (CompactionControlSource compactionControlSource : _compactionControlSourceListProvider.get()) {
+                compactionControlSource.deleteStashTime(id, dataCenter);
+            }
+        } catch (Exception e) {
+            _log.error("Failed to delete stash timestamp info for id: {}", id, e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public StashRunTimeInfo getStashTime(String id, String dataCenter) {
+        try {
+            return _localCompactionControl.getStashTime(id, dataCenter);
+        } catch (Exception e) {
+            _log.error("Failed to get stash timestamp info for id: {}", id, e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public Map<String, StashRunTimeInfo> getAllStashTimes() {
+        try {
+            return _localCompactionControl.getAllStashTimes();
+        } catch (Exception e) {
+            _log.error("Failed to get all stash timestamps info", e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    @Override
+    public Map<String, StashRunTimeInfo> getStashTimesForPlacement(String placement) {
+        try {
+            return _localCompactionControl.getStashTimesForPlacement(placement);
+        } catch (Exception e) {
+            _log.error("Failed to get all stash timestamps info for placement: {}", placement, e);
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/compactioncontrol/CompactionControlResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/compactioncontrol/CompactionControlResource1.java
@@ -1,0 +1,81 @@
+package com.bazaarvoice.emodb.web.resources.compactioncontrol;
+
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.bazaarvoice.emodb.web.resources.SuccessResponse;
+import com.google.common.base.Strings;
+import io.dropwizard.jersey.params.LongParam;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Produces (MediaType.APPLICATION_JSON)
+public class CompactionControlResource1 {
+
+    private final CompactionControlSource _compactionControlSource;
+
+    public CompactionControlResource1(CompactionControlSource compactionControlSource) {
+        _compactionControlSource = checkNotNull(compactionControlSource, "compactionControlSource");
+    }
+
+    @POST
+    @Path ("/stash-time/{id}")
+    @RequiresPermissions ("system|comp_control")
+    public SuccessResponse updateStashTime(@PathParam ("id") String id,
+                                           @QueryParam ("timestamp") LongParam timestampInMillisParam,
+                                           @QueryParam ("placement") List<String> placements,
+                                           @QueryParam ("expiredTimestamp") LongParam expiredTimestampInMillisParam,
+                                           @QueryParam ("dataCenter") String dataCenter) {
+        checkArgument(timestampInMillisParam != null, "timestamp is required");
+        checkArgument(!placements.isEmpty(), "Placement is required");
+        checkArgument(expiredTimestampInMillisParam != null, "expired timestamp is required.");
+
+        _compactionControlSource.updateStashTime(id, timestampInMillisParam.get(), placements, expiredTimestampInMillisParam.get(), dataCenter);
+        return SuccessResponse.instance();
+    }
+
+    @DELETE
+    @Path ("/stash-time/{id}")
+    @RequiresPermissions ("system|comp_control")
+    public SuccessResponse deleteStashTime(@PathParam ("id") String id, @QueryParam ("dataCenter") String dataCenter) {
+        checkArgument(!Strings.isNullOrEmpty(id), "id is required");
+        checkArgument(!Strings.isNullOrEmpty(dataCenter), "datacenter is required");
+
+        _compactionControlSource.deleteStashTime(id, dataCenter);
+        return SuccessResponse.instance();
+    }
+
+    @GET
+    @Path ("/stash-time/{id}")
+    @RequiresPermissions ("system|comp_control")
+    public Response getStashTime(@PathParam ("id") String id, @QueryParam ("dataCenter") String dataCenter) {
+        checkArgument(!Strings.isNullOrEmpty(id), "id is required");
+        checkArgument(!Strings.isNullOrEmpty(dataCenter), "datacenter is required");
+
+        StashRunTimeInfo stashTimeInfo = _compactionControlSource.getStashTime(id, dataCenter);
+        if (stashTimeInfo == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(stashTimeInfo).build();
+    }
+
+    @GET
+    @Path ("/stash-time")
+    @RequiresPermissions ("system|comp_control")
+    public Map<String, StashRunTimeInfo> getStashTimesForPlacement(@QueryParam ("placement") String placement) {
+        return Strings.isNullOrEmpty(placement) ? _compactionControlSource.getAllStashTimes() : _compactionControlSource.getStashTimesForPlacement(placement);
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
@@ -11,6 +11,7 @@ import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.datacenter.api.DataCenter;
 import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.Change;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.Coordinate;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.api.FacadeOptions;
@@ -34,6 +35,7 @@ import com.bazaarvoice.emodb.web.jersey.params.SecondsParam;
 import com.bazaarvoice.emodb.web.jersey.params.TimeUUIDParam;
 import com.bazaarvoice.emodb.web.jersey.params.TimestampParam;
 import com.bazaarvoice.emodb.web.resources.SuccessResponse;
+import com.bazaarvoice.emodb.web.resources.compactioncontrol.CompactionControlResource1;
 import com.bazaarvoice.emodb.web.throttling.ThrottleConcurrentRequests;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Function;
@@ -111,10 +113,17 @@ public class DataStoreResource1 {
 
     private final DataStore _dataStore;
     private final DataStoreAsync _dataStoreAsync;
+    private final CompactionControlSource _compactionControlSource;
 
-    public DataStoreResource1(DataStore dataStore, DataStoreAsync dataStoreAsync) {
+    public DataStoreResource1(DataStore dataStore, DataStoreAsync dataStoreAsync, CompactionControlSource compactionControlSource) {
         _dataStore = dataStore;
         _dataStoreAsync = dataStoreAsync;
+        _compactionControlSource = compactionControlSource;
+    }
+
+    @Path ("_compcontrol")
+    public CompactionControlResource1 getCompactionControlResource() {
+        return new CompactionControlResource1(_compactionControlSource);
     }
 
     @GET

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.web.scanner;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Objects;
@@ -20,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * POJO to hold the options for how a scan and upload operation is configured.
  */
+@JsonIgnoreProperties (ignoreUnknown = true)
 public class ScanOptions {
 
     private final static int DEFAULT_MAX_CONCURRENT_SUB_RANGE_SCANS = 4;

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploader.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploader.java
@@ -1,6 +1,9 @@
 package com.bazaarvoice.emodb.web.scanner;
 
+import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.plugin.stash.StashStateListener;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.compactioncontrol.DelegateCompactionControl;
 import com.bazaarvoice.emodb.sor.core.DataTools;
 import com.bazaarvoice.emodb.sor.db.ScanRange;
 import com.bazaarvoice.emodb.sor.db.ScanRangeSplits;
@@ -9,6 +12,7 @@ import com.bazaarvoice.emodb.web.scanner.control.ScanWorkflow;
 import com.bazaarvoice.emodb.web.scanner.scanstatus.ScanRangeStatus;
 import com.bazaarvoice.emodb.web.scanner.scanstatus.ScanStatus;
 import com.bazaarvoice.emodb.web.scanner.scanstatus.ScanStatusDAO;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.HashMultimap;
@@ -19,43 +23,56 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Entry point for uploading JSON representations of a placement to a file system, such as S3.
  * The actual uploading takes place asynchronously the following classes:
- *
+ * <p/>
  * <ul>
- *     <li>
- *         {@link com.bazaarvoice.emodb.web.scanner.control.ScanUploadMonitor}: monitors all active uploads and schedules
- *         new token ranges for uploading as they become available.</li>
- *     </li>
- *     <li>
- *         {@link com.bazaarvoice.emodb.web.scanner.control.DistributedScanRangeMonitor}: listens for token ranges
- *         available for scanning and scans and uploads them locally.
- *     </li>
+ * <li>
+ * {@link com.bazaarvoice.emodb.web.scanner.control.ScanUploadMonitor}: monitors all active uploads and schedules
+ * new token ranges for uploading as they become available.</li>
+ * </li>
+ * <li>
+ * {@link com.bazaarvoice.emodb.web.scanner.control.DistributedScanRangeMonitor}: listens for token ranges
+ * available for scanning and scans and uploads them locally.
+ * </li>
  * </ul>
  */
 public class ScanUploader {
 
     private static final Logger _log = LoggerFactory.getLogger(ScanUploader.class);
 
+    private long _compactionControlBufferTimeInMillis = Duration.ofMinutes(1).toMillis();
+
     private final DataTools _dataTools;
     private final ScanWorkflow _scanWorkflow;
     private final ScanStatusDAO _scanStatusDAO;
     private final StashStateListener _stashStateListener;
+    private final CompactionControlSource _compactionControlSource;
+    private final DataCenters _dataCenters;
 
     @Inject
     public ScanUploader(DataTools dataTools, ScanWorkflow scanWorkflow, ScanStatusDAO scanStatusDAO,
-                        StashStateListener stashStateListener) {
+                        StashStateListener stashStateListener, @DelegateCompactionControl CompactionControlSource compactionControlSource, DataCenters dataCenters) {
         _dataTools = checkNotNull(dataTools, "dataTools");
         _scanWorkflow = checkNotNull(scanWorkflow, "scanWorkflow");
         _scanStatusDAO = checkNotNull(scanStatusDAO, "scanStatusDAO");
         _stashStateListener = checkNotNull(stashStateListener, "stashStateListener");
+        _compactionControlSource = checkNotNull(compactionControlSource, "compactionControlSource");
+        _dataCenters = checkNotNull(dataCenters, "dataCenters");
+    }
+
+    @VisibleForTesting
+    public void setCompactionControlBufferTimeInMillis(long compactionControlBufferTimeInMillis) {
+        _compactionControlBufferTimeInMillis = compactionControlBufferTimeInMillis;
     }
 
     public ScanAndUploadBuilder scanAndUpload(String scanId, ScanOptions options) {
@@ -95,9 +112,10 @@ public class ScanUploader {
                 }
                 status = createNewScanFromExistingScan(_scanId, _options, existingStatus);
             }
+            status.setCompactionControlBufferTimeInMillis(_compactionControlBufferTimeInMillis);
 
             if (!_dryRun) {
-                startScanUpload(_scanId, status);
+                startScanUpload(_scanId, status, _options.getPlacements());
             }
 
             return status;
@@ -165,34 +183,60 @@ public class ScanUploader {
                 ImmutableList.of(), ImmutableList.of());
     }
 
-    private void startScanUpload(String scanId, ScanStatus status) {
-        boolean scanCreated = false;
-
+    private void startScanUpload(String scanId, ScanStatus status, Set<String> placements) {
         try {
-            // Create the scan
-            _scanStatusDAO.updateScanStatus(status);
-            scanCreated = true;
-
-            // Notify the workflow that the scan can be started
-            _scanWorkflow.scanStatusUpdated(scanId);
-
-            // Send notification that the scan has started
-            _stashStateListener.stashStarted(status.asPluginStashMetadata());
+            // compaction control timestamp = stash start time + 1 minute buffer time. This is needed to allow the setting time to trickle the request to the DataStore.
+            // Setting the time in the future takes care of the issue of there being any in-flight compactions
+            // Note: the same compaction control timestamp with 1 minute buffer time is also considered during the multiscan deltas/compactions resolving.
+            long compactionControlTime = status.getCompactionControlTime().getTime();
+            // expired time for now is designed to be 10 hours from the compaction control time.
+            long expireTime = compactionControlTime + Duration.ofHours(10).toMillis();
+            // Update the scan start time in Zookeeper in all data centers.
+            _compactionControlSource.updateStashTime(scanId, compactionControlTime, Lists.newArrayList(status.getOptions().getPlacements()), expireTime, _dataCenters.getSelf().getName());
         } catch (Exception e) {
-            _log.error("Failed to start scan and upload for scan {}", scanId, e);
-
-            if (scanCreated) {
-                // The scan was not properly started; cancel the scan
-                try {
-                    _scanStatusDAO.setCanceled(scanId);
-                } catch (Exception e2) {
-                    // Don't mask the original exception but log it
-                    _log.error("Failed to mark unsuccessfully started scan as canceled: [id={}]", scanId, e2);
-                }
-            }
-
+            _log.error("Failed to update the stash time for scan {}", scanId, e);
             throw Throwables.propagate(e);
         }
+
+        // spawn a thread and do the below asynchronously as we would have to wait for a minute to continue to scan and we don't to include that delay in here for responding.
+        new Thread(() ->
+        {
+            boolean scanCreated = false;
+
+            try {
+                // We would like to wait 1 minute here to continue to scan to make sure scan don't miss any deltas that are written before the compaction control time.
+                Thread.sleep(_compactionControlBufferTimeInMillis);
+
+                // Create the scan
+                _scanStatusDAO.updateScanStatus(status);
+                scanCreated = true;
+
+                // Notify the workflow that the scan can be started
+                _scanWorkflow.scanStatusUpdated(scanId);
+
+                // Send notification that the scan has started
+                _stashStateListener.stashStarted(status.asPluginStashMetadata());
+            } catch (Exception e) {
+                _log.error("Failed to start scan and upload for scan {}", scanId, e);
+
+                // Delete the entry of the scan start time in Zookeeper.
+                try {
+                    _compactionControlSource.deleteStashTime(scanId, _dataCenters.getSelf().getName());
+                } catch (Exception ex) {
+                    _log.error("Failed to delete the stash time for scan {}", scanId, ex);
+                }
+
+                if (scanCreated) {
+                    // The scan was not properly started; cancel the scan
+                    try {
+                        _scanStatusDAO.setCanceled(scanId);
+                    } catch (Exception e2) {
+                        // Don't mask the original exception but log it
+                        _log.error("Failed to mark unsuccessfully started scan as canceled: [id={}]", scanId, e2);
+                    }
+                }
+            }
+        }).start();
     }
 
     /**
@@ -229,5 +273,11 @@ public class ScanUploader {
         // Notify the workflow the scan status was updated
         _scanWorkflow.scanStatusUpdated(id);
 
+        try {
+            // Delete the entry of the scan start time in Zookeeper.
+            _compactionControlSource.deleteStashTime(id, _dataCenters.getSelf().getName());
+        } catch (Exception e) {
+            _log.error("Failed to delete the stash time for scan {}", id, e);
+        }
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/DistributedScanRangeMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/DistributedScanRangeMonitor.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.web.scanner.control;
 
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.sor.db.ScanRange;
+import com.bazaarvoice.emodb.table.db.TableSet;
 import com.bazaarvoice.emodb.web.scanner.rangescan.RangeScanUploader;
 import com.bazaarvoice.emodb.web.scanner.rangescan.RangeScanUploaderResult;
 import com.bazaarvoice.emodb.web.scanner.scanstatus.ScanRangeStatus;
@@ -332,7 +333,7 @@ public class DistributedScanRangeMonitor implements Managed {
             _scanStatusDAO.setScanRangeTaskActive(scanId, taskId, new Date());
 
             // Perform the range scan
-            result = _rangeScanUploader.scanAndUpload(scanId, taskId, status.getOptions(), placement, range);
+            result = _rangeScanUploader.scanAndUpload(scanId, taskId, status.getOptions(), placement, range, status.getCompactionControlTime());
 
             _log.info("Completed scan range task: {}", task);
         } catch (Throwable t) {

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/ScanUploadMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/ScanUploadMonitor.java
@@ -6,7 +6,10 @@ import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ManagedGuavaService;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
+import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.plugin.stash.StashStateListener;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.compactioncontrol.DelegateCompactionControl;
 import com.bazaarvoice.emodb.sor.core.DataTools;
 import com.bazaarvoice.emodb.web.scanner.ScannerZooKeeper;
 import com.bazaarvoice.emodb.web.scanner.notifications.ScanCountListener;
@@ -35,13 +38,13 @@ public class ScanUploadMonitor extends LeaderService {
                              final ScanWriterGenerator scanWriterGenerator,
                              final StashStateListener stashStateListener, final ScanCountListener scanCountListener,
                              final DataTools dataTools, LifeCycleRegistry lifecycle, LeaderServiceTask leaderServiceTask,
-                             MetricRegistry metricRegistry) {
+                             MetricRegistry metricRegistry, @DelegateCompactionControl CompactionControlSource compactionControlSource, DataCenters dataCenters) {
         super(curator, LEADER_DIR, selfHostAndPort.toString(), SERVICE_NAME, 1, TimeUnit.MINUTES,
                 new Supplier<Service>() {
                     @Override
                     public Service get() {
-                        return new LocalScanUploadMonitor(scanWorkflow, scanStatusDAO, scanWriterGenerator,
-                                stashStateListener, scanCountListener, dataTools);
+                        return new LocalScanUploadMonitor(scanWorkflow, scanStatusDAO,
+                                scanWriterGenerator, stashStateListener, scanCountListener, dataTools, compactionControlSource, dataCenters);
                     }
                 });
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/rangescan/RangeScanUploader.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/rangescan/RangeScanUploader.java
@@ -1,9 +1,11 @@
 package com.bazaarvoice.emodb.web.scanner.rangescan;
 
 import com.bazaarvoice.emodb.sor.db.ScanRange;
+import com.bazaarvoice.emodb.table.db.TableSet;
 import com.bazaarvoice.emodb.web.scanner.ScanOptions;
 
 import java.io.IOException;
+import java.util.Date;
 
 /**
  * Defines the interface for scanning and uploading a scan range.
@@ -17,7 +19,8 @@ public interface RangeScanUploader {
      * @param scanOptions The options associated with the scan operation
      * @param placement The placement to scan
      * @param scanRange The range to be scanned and uploaded
+     * @param compactionControlTime The compaction control time for this scan operation.
      */
-    RangeScanUploaderResult scanAndUpload(String scanId, int taskId, ScanOptions scanOptions, String placement, ScanRange scanRange)
+    RangeScanUploaderResult scanAndUpload(String scanId, int taskId, ScanOptions scanOptions, String placement, ScanRange scanRange, Date compactionControlTime)
             throws IOException, InterruptedException;
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scanstatus/ScanStatus.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scanstatus/ScanStatus.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Sets;
 
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -31,6 +32,9 @@ public class ScanStatus {
     private final List<ScanRangeStatus> _completeScanRanges;
     private final Date _startTime;
     private Date _completeTime;
+
+    @JsonProperty("compactionControlBufferTimeInMillis")
+    private long _compactionControlBufferTimeInMillis = Duration.ofMinutes(1).toMillis();
 
     public ScanStatus(String scanId, ScanOptions options, boolean tableSnapshotCreated, boolean canceled,
                       Date startTime,
@@ -105,6 +109,20 @@ public class ScanStatus {
 
     public void setCompleteTime(Date completeTime) {
         _completeTime = completeTime;
+    }
+
+    public long getCompactionControlBufferTimeInMillis() {
+        return _compactionControlBufferTimeInMillis;
+    }
+
+    public void setCompactionControlBufferTimeInMillis(long compactionControlBufferTimeInMillis) {
+        _compactionControlBufferTimeInMillis = compactionControlBufferTimeInMillis;
+    }
+
+    @JsonIgnore
+    public Date getCompactionControlTime() {
+        // Adding compactionControlBuffer time to the start time to give us the compaction control time. (setting the time in the future takes care of the issue of there being any in-flight compactions)
+        return new Date(_startTime.getTime() + getCompactionControlBufferTimeInMillis());
     }
 
     @JsonIgnore

--- a/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitorTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitorTest.java
@@ -1,0 +1,49 @@
+package com.bazaarvoice.emodb.web.compactioncontrol;
+
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSource;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableList;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+
+import static org.mockito.Mockito.mock;
+
+public class CompactionControlMonitorTest {
+
+    @Test
+    public void testExpiredTimestampsAreDeleted() {
+
+        long timestamp1 = System.currentTimeMillis();
+        long timestamp2 = System.currentTimeMillis() + Duration.ofHours(1).toMillis();
+        long timestamp3 = System.currentTimeMillis() + Duration.ofHours(2).toMillis();
+
+        long expiredTimestamp1 = timestamp1 + Duration.ofHours(10).toMillis();
+        long expiredTimestamp2 = timestamp2 + Duration.ofHours(10).toMillis();
+        long expiredTimestamp3 = timestamp3 + Duration.ofHours(10).toMillis();
+
+        CompactionControlSource compactionControlSource = new InMemoryCompactionControlSource();
+        compactionControlSource.updateStashTime("dc1-1", timestamp1, ImmutableList.of("placement-1"), expiredTimestamp1, "dc1");
+        compactionControlSource.updateStashTime("dc1-2", timestamp2, ImmutableList.of("placement-1"), expiredTimestamp2, "dc1");
+        compactionControlSource.updateStashTime("dc1-3", timestamp3, ImmutableList.of("placement-1"), expiredTimestamp3, "dc1");
+
+        CompactionControlMonitor compactionControlMonitor = new CompactionControlMonitor(compactionControlSource, mock(Clock.class), new MetricRegistry());
+
+        compactionControlMonitor.deleteExpiredStashTimes(timestamp1 + Duration.ofMinutes(10).toMillis());
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 3);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("dc1-1"), true);
+
+        compactionControlMonitor.deleteExpiredStashTimes(expiredTimestamp1 + Duration.ofMinutes(1).toMillis());
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 2);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("dc1-1"), false);
+
+        compactionControlMonitor.deleteExpiredStashTimes(expiredTimestamp3 + Duration.ofMinutes(1).toMillis());
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 0);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("dc1-2"), false);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("dc1-3"), false);
+    }
+
+}

--- a/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/ScanOperationsTimeUpdateTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/ScanOperationsTimeUpdateTest.java
@@ -1,0 +1,196 @@
+package com.bazaarvoice.emodb.web.compactioncontrol;
+
+import com.bazaarvoice.emodb.common.api.impl.LimitCounter;
+import com.bazaarvoice.emodb.datacenter.api.DataCenter;
+import com.bazaarvoice.emodb.datacenter.api.DataCenters;
+import com.bazaarvoice.emodb.plugin.stash.StashStateListener;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
+import com.bazaarvoice.emodb.sor.api.ReadConsistency;
+import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSource;
+import com.bazaarvoice.emodb.sor.core.DataTools;
+import com.bazaarvoice.emodb.sor.db.Key;
+import com.bazaarvoice.emodb.sor.db.MultiTableScanOptions;
+import com.bazaarvoice.emodb.sor.db.MultiTableScanResult;
+import com.bazaarvoice.emodb.sor.db.Record;
+import com.bazaarvoice.emodb.sor.db.ScanRange;
+import com.bazaarvoice.emodb.sor.db.ScanRangeSplits;
+import com.bazaarvoice.emodb.table.db.Table;
+import com.bazaarvoice.emodb.table.db.TableSet;
+import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxStorage;
+import com.bazaarvoice.emodb.web.scanner.ScanDestination;
+import com.bazaarvoice.emodb.web.scanner.ScanOptions;
+import com.bazaarvoice.emodb.web.scanner.ScanUploader;
+import com.bazaarvoice.emodb.web.scanner.control.InMemoryScanWorkflow;
+import com.bazaarvoice.emodb.web.scanner.control.ScanWorkflow;
+import com.bazaarvoice.emodb.web.scanner.scanstatus.InMemoryScanStatusDAO;
+import com.bazaarvoice.emodb.web.scanner.scanstatus.ScanStatus;
+import com.bazaarvoice.emodb.web.scanner.scanstatus.ScanStatusDAO;
+import com.google.common.base.Optional;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Iterator;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ScanOperationsTimeUpdateTest {
+
+    @Test
+    public void testTimeIsUpdatedWhenScanStartsAndItsDeletedAfterScanIsFinished()
+            throws Exception {
+        StashStateListener stashStateListener = mock(StashStateListener.class);
+        DataCenters dataCenters = mock(DataCenters.class);
+        DataCenter dataCenter1 = mockDataCenter("us-east", "http://emodb.cert.us-east-1.nexus.bazaarvoice.com:8081", "http://emodb.cert.us-east-1.nexus.bazaarvoice.com:8080");
+        when(dataCenters.getSelf()).thenReturn(dataCenter1);
+        when(dataCenters.getAll()).thenReturn(ImmutableList.of(dataCenter1));
+        ScanWorkflow scanWorkflow = new InMemoryScanWorkflow();
+        ScanStatusDAO scanStatusDAO = new InMemoryScanStatusDAO();
+        ScanOptions scanOptions = new ScanOptions("placement1").addDestination(ScanDestination.to(new URI("s3://testbucket/test/path")));
+
+        CompactionControlSource compactionControlSource = new InMemoryCompactionControlSource();
+
+        // start the scan
+        ScanUploader scanUploader = new ScanUploader(getDataTools(), scanWorkflow, scanStatusDAO, stashStateListener, compactionControlSource, dataCenters);
+        // the default in code is 1 minute for compaction control buffer time, but we don't want to wait that long in the test, so set to a smaller value.
+        scanUploader.setCompactionControlBufferTimeInMillis(Duration.millis(1).getMillis());
+        scanUploader.scanAndUpload("test1", scanOptions).start();
+        // sleeping for 1 sec just to be certain that the thread was executed in scanAndUpload process.
+        Thread.sleep(Duration.standardSeconds(1).getMillis());
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 1);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("test1"), true);
+
+        // cancel the scan
+        scanUploader.cancel("test1");
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 0);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("test1"), false);
+    }
+
+    @Test
+    public void testTimeEntryDoNotExistIfScanFailsWithAnException()
+            throws Exception {
+        StashStateListener stashStateListener = mock(StashStateListener.class);
+        DataCenters dataCenters = mock(DataCenters.class);
+        DataCenter dataCenter1 = mockDataCenter("us-east", "http://emodb.cert.us-east-1.nexus.bazaarvoice.com:8081", "http://emodb.cert.us-east-1.nexus.bazaarvoice.com:8080");
+        when(dataCenters.getSelf()).thenReturn(dataCenter1);
+        when(dataCenters.getAll()).thenReturn(ImmutableList.of(dataCenter1));
+        ScanWorkflow scanWorkflow = new InMemoryScanWorkflow();
+        ScanOptions scanOptions = new ScanOptions("placement1").addDestination(ScanDestination.to(new URI("s3://testbucket/test/path")));
+
+        ScanStatusDAO scanStatusDAO = mock(ScanStatusDAO.class);
+        doThrow(Exception.class).when(scanStatusDAO).updateScanStatus(any(ScanStatus.class));
+
+        CompactionControlSource compactionControlSource = new InMemoryCompactionControlSource();
+
+        // start the scan which will throw an exception
+        ScanUploader scanUploader = new ScanUploader(getDataTools(), scanWorkflow, scanStatusDAO, stashStateListener, compactionControlSource, dataCenters);
+        // the default in code is 1 minute for compaction control buffer time, but we don't want to wait that long in the test, so set to a smaller value.
+        scanUploader.setCompactionControlBufferTimeInMillis(Duration.millis(1).getMillis());
+        try {
+            scanUploader.scanAndUpload("test1", scanOptions).start();
+        } catch (Exception e) {
+            // expected as the exception is propagated.
+        }
+        // sleeping for 1 sec just to be certain that the thread was executed in scanAndUpload process.
+        Thread.sleep(Duration.standardSeconds(1).getMillis());
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 0);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("test1"), false);
+    }
+
+    /***
+     * helper methods
+     ***/
+    private DataCenter mockDataCenter(String name, String adminUri, String serviceUri) {
+        DataCenter dc = mock(DataCenter.class);
+        when(dc.getName()).thenReturn(name);
+        when(dc.getAdminUri()).thenReturn(URI.create(adminUri));
+        when(dc.getServiceUri()).thenReturn(URI.create(serviceUri));
+        return dc;
+    }
+
+    /**
+     * Simulates creating 20 tables, each with 160 rows spread evenly across 8 shards.
+     */
+    private Iterator<MultiTableScanResult> createMockScanResults() {
+        return new AbstractIterator<MultiTableScanResult>() {
+            private int shard = 0;
+            private long tableUuid = 0;
+            private int row = -1;
+
+            @Override
+            protected MultiTableScanResult computeNext() {
+                if (++row == 20) {
+                    // Start a new table
+                    row = 0;
+                    if (++tableUuid == 20) {
+                        // Start a new shard
+                        tableUuid = 0;
+                        if (++shard == 8) {
+                            // All 8 shards written
+                            return endOfData();
+                        }
+                    }
+                }
+
+                String keyString = key(shard, row);
+                Record record = mock(Record.class);
+                Key key = mock(Key.class);
+                when(key.getKey()).thenReturn(keyString);
+                Table table = mock(Table.class);
+                when(table.getName()).thenReturn(format("table%02d", tableUuid));
+                when(key.getTable()).thenReturn(table);
+                when(record.getKey()).thenReturn(key);
+                when(table.getOptions()).thenReturn(new TableOptionsBuilder().setPlacement("placement1").build());
+                return new MultiTableScanResult(AstyanaxStorage.getRowKeyRaw(shard, tableUuid, keyString), shard, tableUuid, false, record);
+            }
+        };
+    }
+
+    private String key(int shard, int row) {
+        return format("%02d%02d", shard, row);
+    }
+
+    private DataTools getDataTools() {
+        // Mock out a DataTools that will return scan results spread consistently across 8 shards
+        DataTools dataTools = mock(DataTools.class);
+        when(dataTools.getTablePlacements(true, true)).thenReturn(ImmutableList.of("placement1"));
+        when(dataTools.getScanRangeSplits(eq("placement1"), anyInt(), eq(Optional.<ScanRange>absent()))).thenReturn(
+                ScanRangeSplits.builder()
+                        .addScanRange("dummy", "dummy", ScanRange.all())
+                        .build());
+        when(dataTools.multiTableScan(any(MultiTableScanOptions.class), any(TableSet.class), any(LimitCounter.class), any(ReadConsistency.class), any(DateTime.class)))
+                .thenReturn(createMockScanResults());
+        when(dataTools.toContent(any(MultiTableScanResult.class), any(ReadConsistency.class), eq(false)))
+                .thenAnswer(new Answer<Map<String, Object>>() {
+                    @Override
+                    public Map<String, Object> answer(InvocationOnMock invocation)
+                            throws Throwable {
+                        MultiTableScanResult result = (MultiTableScanResult) invocation.getArguments()[0];
+                        return ImmutableMap.<String, Object>builder()
+                                .put(Intrinsic.ID, result.getRecord().getKey().getKey())
+                                .put(Intrinsic.TABLE, format("table%02d", result.getTableUuid()))
+                                .put(Intrinsic.DELETED, Boolean.FALSE)
+                                .put(Intrinsic.VERSION, 1)
+                                .build();
+                    }
+                });
+
+        return dataTools;
+    }
+}

--- a/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
@@ -14,6 +14,7 @@ import com.bazaarvoice.emodb.job.service.DefaultJobService;
 import com.bazaarvoice.emodb.queue.api.QueueService;
 import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
@@ -84,7 +85,7 @@ public class PurgeTest {
                 1, Duration.ZERO, 100, Duration.standardHours(1));
 
         _store = new InMemoryDataStore(new MetricRegistry());
-        _dataStoreResource = new DataStoreResource1(_store, new DefaultDataStoreAsync(_store, _service, _jobHandlerRegistry));
+        _dataStoreResource = new DataStoreResource1(_store, new DefaultDataStoreAsync(_store, _service, _jobHandlerRegistry), mock(CompactionControlSource.class));
 
     }
 


### PR DESCRIPTION
The goal of this PR is to make stash a snapshot of EmoDB at a particular time.
The implementation steps are as below:
** We store the stash start timestamp entry using the zookeeper when the stash starts, and delete the entry when the stash ends.
** Compaction process is updated to delay the deletion of deltas after compaction deltas are created if there is any running stash.
** Stash multiscan reads will only pick up the deltas before it's stash run time.
** There is also a Monitor task in place to delete any stash time entries as required.
