### PR TITLE
Swap out concurrency limits for rate limiting in blocked delta migration

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultMigratorTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultMigratorTools.java
@@ -21,12 +21,14 @@ public class DefaultMigratorTools implements MigratorTools {
         _migratorWriterDao = checkNotNull(migratorWriterDAO, "migratorWriterDao");
     }
 
-    public void writeRows(String placement, Iterator<MigrationScanResult> results, int maxConcurrentWrites) {
+    @Override
+    public void writeRows(String placement, Iterator<MigrationScanResult> results, int maxWritesPerSecond) {
         checkNotNull(placement, "placement");
         checkNotNull(results, "rows");
-        _migratorWriterDao.writeRows(placement, results, maxConcurrentWrites);
+        _migratorWriterDao.writeRows(placement, results, maxWritesPerSecond);
     }
 
+    @Override
     public Iterator<MigrationScanResult> readRows(String placement, ScanRange scanRange) {
         checkNotNull(placement, "placement");
         checkNotNull(scanRange, scanRange);

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MigratorTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MigratorTools.java
@@ -9,7 +9,7 @@ import java.util.Iterator;
 // interface to migrate deltas from old tables to new tables with blocking
 public interface MigratorTools {
 
-    void writeRows(String placement, Iterator<MigrationScanResult> results, int maxConcurrentWrites);
+    void writeRows(String placement, Iterator<MigrationScanResult> results, int maxWritesPerSecond);
 
     Iterator<MigrationScanResult> readRows(String placement, ScanRange scanRange);
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/MigratorWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/MigratorWriterDAO.java
@@ -4,5 +4,5 @@ import java.util.Iterator;
 
 public interface MigratorWriterDAO {
 
-    void writeRows(String placement, Iterator<MigrationScanResult> results, int maxConcurrentWrites);
+    void writeRows(String placement, Iterator<MigrationScanResult> results, int maxWritesPerSecond);
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
@@ -20,7 +20,6 @@ import com.datastax.driver.core.*;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.RateLimiter;
@@ -270,16 +269,18 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
         BatchStatement statement = new BatchStatement(BatchStatement.Type.LOGGED);
         AtomicReference<Throwable> error = new AtomicReference<>();
         RateLimiter rateLimiter = RateLimiter.create(maxWritesPerSecond);
-        List<ResultSetFuture> resultSetFutures = Lists.newArrayList();
+        Phaser phaser = new Phaser();
         ByteBuffer lastRowKey = null;
         int currentStatementSize = 0;
         FutureCallback<ResultSet> callback = new FutureCallback<ResultSet>() {
             @Override
             public void onSuccess(@Nullable ResultSet result) {
+                phaser.arriveAndDeregister();
             }
 
             @Override
             public void onFailure(Throwable t) {
+                phaser.arriveAndDeregister();
                 error.compareAndSet(null, t);
             }
         };
@@ -303,11 +304,9 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
             if ((lastRowKey != null && !rowKey.equals(lastRowKey)) || currentStatementSize > MAX_STATEMENT_SIZE) {
 
                 rateLimiter.acquire();
+                phaser.register();
 
-                ResultSetFuture resultSetFuture = session.executeAsync(statement);
-                Futures.addCallback(resultSetFuture, callback);
-                resultSetFutures.add(resultSetFuture);
-
+                Futures.addCallback(session.executeAsync(statement), callback);
                 statement = new BatchStatement(BatchStatement.Type.LOGGED);
                 currentStatementSize = 0;
             }
@@ -322,12 +321,8 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
         }
 
         rateLimiter.acquire();
-        ResultSetFuture future = session.executeAsync(statement);
-        Futures.addCallback(future, callback);
-        resultSetFutures.add(future);
-
-        resultSetFutures.forEach(Futures::getUnchecked);
-
+        Futures.addCallback(session.executeAsync(statement), callback);
+        phaser.arriveAndAwaitAdvance();
         checkError(error);
 
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
@@ -321,6 +321,7 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
         }
 
         rateLimiter.acquire();
+        phaser.register();
         Futures.addCallback(session.executeAsync(statement), callback);
         phaser.arriveAndAwaitAdvance();
         checkError(error);

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
@@ -22,6 +22,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 
@@ -256,7 +257,7 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
     }
 
     @Override
-    public void writeRows(String placementName, Iterator<MigrationScanResult> iterator, int maxConcurrentWrites) {
+    public void writeRows(String placementName, Iterator<MigrationScanResult> iterator, int maxWritesPerSecond) {
 
         if (!iterator.hasNext()) {
             return;
@@ -265,19 +266,17 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
         DeltaPlacement placement = (DeltaPlacement) _placementCache.get(placementName);
         Session session = placement.getKeyspace().getCqlSession();
         BatchStatement statement = new BatchStatement(BatchStatement.Type.LOGGED);
-        final Semaphore semaphore = new Semaphore(maxConcurrentWrites);
         AtomicReference<Throwable> error = new AtomicReference<>();
+        RateLimiter rateLimiter = RateLimiter.create(1000);
         ByteBuffer lastRowKey = null;
         int currentStatementSize = 0;
         FutureCallback<ResultSet> callback = new FutureCallback<ResultSet>() {
             @Override
             public void onSuccess(@Nullable ResultSet result) {
-                semaphore.release();
             }
 
             @Override
             public void onFailure(Throwable t) {
-                semaphore.release();
                 error.compareAndSet(null, t);
             }
         };
@@ -300,7 +299,7 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
             // execute statement if we have encountered a new C* wide row OR if statement has become too large
             if ((lastRowKey != null && !rowKey.equals(lastRowKey)) || currentStatementSize > MAX_STATEMENT_SIZE) {
 
-                semaphore.acquireUninterruptibly();
+                rateLimiter.acquire();
                 Futures.addCallback(session.executeAsync(statement), callback);
                 statement = new BatchStatement(BatchStatement.Type.LOGGED);
                 currentStatementSize = 0;
@@ -315,9 +314,9 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
 
         }
 
-        semaphore.acquireUninterruptibly();
+        rateLimiter.acquire();
         Futures.addCallback(session.executeAsync(statement), callback);
-        semaphore.acquireUninterruptibly(maxConcurrentWrites);
+        rateLimiter.acquire((int) rateLimiter.getRate());
         checkError(error);
 
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
@@ -487,7 +487,7 @@ public class InMemoryDataReaderDAO implements DataReaderDAO, DataWriterDAO, Migr
     }
 
     @Override
-    public void writeRows(String placement, Iterator<MigrationScanResult> results, int maxConcurrentWrites) {
+    public void writeRows(String placement, Iterator<MigrationScanResult> results, int maxWritesPerSecond) {
         throw new UnsupportedOperationException();
     }
 

--- a/web-local/config-migrator.yaml
+++ b/web-local/config-migrator.yaml
@@ -7,7 +7,8 @@ cluster: local_default
 
 deltaMigrator:
   migrateStatusTablePlacement: "app_global:migration"
-  maxConcurrentWrites: 500
+  migrateApiKey:    "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"
+  maxWritesPerSecond: 1000
 #  pendingReadRangeQueueName: pendingQueue
 #  completeReadRangeQueueName: completeQueue
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/BlockMigratorResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/BlockMigratorResource1.java
@@ -32,7 +32,7 @@ public class BlockMigratorResource1 {
             response = SuccessResponse.class
     )
     public MigratorStatus migrate(@PathParam("placement") String placement,
-                                  @QueryParam("maxConcurrentWrites") int maxConcurrentWrites) {
+                                  @QueryParam("maxWritesPerSecond") int maxWritesPerSecond) {
 
         if (_deltaMigrator.getStatus(placement) != null) {
             throw new WebApplicationException(
@@ -42,7 +42,7 @@ public class BlockMigratorResource1 {
                             .build());
         }
 
-        return _deltaMigrator.migratePlacement(placement, maxConcurrentWrites);
+        return _deltaMigrator.migratePlacement(placement, maxWritesPerSecond);
 
     }
 
@@ -99,8 +99,8 @@ public class BlockMigratorResource1 {
     @POST
     @Path ("migrate/{placement}/throttle")
     public MigratorStatus throttleMigration(@PathParam ("placement") String placement,
-                                            @QueryParam ("maxConcurrentWrites") int maxConcurrentWrites) {
-        checkArgument(maxConcurrentWrites > 0, "maxConcurrentWrites is required");
+                                            @QueryParam ("maxWritesPerSecond") int maxWritesPerSecond) {
+        checkArgument(maxWritesPerSecond > 0, "maxWritesPerSecond is required");
 
         MigratorStatus migratorStatus = _deltaMigrator.getStatus(placement);
         if (migratorStatus == null) {
@@ -111,7 +111,7 @@ public class BlockMigratorResource1 {
                             .build());
         }
 
-        _deltaMigrator.throttle(placement, maxConcurrentWrites);
+        _deltaMigrator.throttle(placement, maxWritesPerSecond);
 
         return _deltaMigrator.getStatus(placement);
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DistributedMigratorRangeMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DistributedMigratorRangeMonitor.java
@@ -289,7 +289,7 @@ public class DistributedMigratorRangeMonitor implements Managed {
 
             _statusDAO.setMigratorRangeTaskActive(migrationId, taskId, new Date());
 
-            result = _rangeMigrator.migrate(taskId, status.getOptions(), placement, range, _statusDAO.getMaxConcurrentWrites(migrationId));
+            result = _rangeMigrator.migrate(taskId, status.getOptions(), placement, range, _statusDAO.getMaxWritesPerSecond(migrationId));
 
 
             _log.info("Completed migration range task: {}", task);

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorModule.java
@@ -42,7 +42,7 @@ public class MigratorModule extends PrivateModule {
         _config = config.getDeltaMigrator().get();
 
         checkArgument(_config.getReadThreadCount() > 0, "Read thread count must be at least 1");
-        checkArgument(_config.getMaxWritesPerSecond() > 0, "Max concurrent writes must be at least 1");
+        checkArgument(_config.getMaxWritesPerSecond() > 0, "Max writes per second must be at least 1");
     }
 
     @Override

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorModule.java
@@ -42,7 +42,7 @@ public class MigratorModule extends PrivateModule {
         _config = config.getDeltaMigrator().get();
 
         checkArgument(_config.getReadThreadCount() > 0, "Read thread count must be at least 1");
-        checkArgument(_config.getMaxConcurrentWrites() > 0, "Max concurrent writes must be at least 1");
+        checkArgument(_config.getMaxWritesPerSecond() > 0, "Max concurrent writes must be at least 1");
     }
 
     @Override
@@ -63,8 +63,8 @@ public class MigratorModule extends PrivateModule {
                 .toInstance(_config.getPendingMigrationRangeQueueName());
         bind(new TypeLiteral<Optional<String>>(){}).annotatedWith(Names.named("completeMigrationRangeQueueName"))
                 .toInstance(_config.getCompleteMigrationRangeQueueName());
-        bind(Integer.class).annotatedWith(Names.named("maxConcurrentWrites"))
-                .toInstance(_config.getMaxConcurrentWrites());
+        bind(Integer.class).annotatedWith(Names.named("maxWritesPerSecond"))
+                .toInstance(_config.getMaxWritesPerSecond());
 
         bind(MigratorMonitor.class).asEagerSingleton();
         bind(DistributedMigratorRangeMonitor.class).asEagerSingleton();

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/config/MigratorConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/config/MigratorConfiguration.java
@@ -14,7 +14,7 @@ public class MigratorConfiguration {
     private static final int DEFAULT_READ_THREAD_COUNT = 8;
     private static final String DEFAULT_MIGRATE_STATUS_TABLE = "__system_migrate";
     private static final String DEFAULT_MIGRATE_STATUS_TABLE_PLACEMENT = "app_global:migration";
-    private static final int DEFAULT_MAX_CONCURRENT_WRITES = 500;
+    private static final int DEFAULT_MAX_WRITES_PER_SECOND = 1000;
 
     // If using EmoDB queues, the API key to use
     @Valid
@@ -42,8 +42,8 @@ public class MigratorConfiguration {
 
     @Valid
     @NotNull
-    @JsonProperty ("maxConcurrentWrites")
-    private int _maxConcurrentWrites = DEFAULT_MAX_CONCURRENT_WRITES;
+    @JsonProperty ("maxWritesPerSecond")
+    private int _maxWritesPerSecond = DEFAULT_MAX_WRITES_PER_SECOND;
 
     @Valid
     @NotNull
@@ -107,7 +107,7 @@ public class MigratorConfiguration {
         return this;
     }
 
-    public int getMaxConcurrentWrites() {
-        return _maxConcurrentWrites;
+    public int getMaxWritesPerSecond() {
+        return _maxWritesPerSecond;
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatus.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatus.java
@@ -5,8 +5,6 @@ import com.bazaarvoice.emodb.web.scanner.scanstatus.ScanRangeStatus;
 import com.bazaarvoice.emodb.web.scanner.scanstatus.ScanStatus;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 import java.util.Date;
@@ -14,13 +12,13 @@ import java.util.List;
 
 public class MigratorStatus extends ScanStatus {
 
-    private int _maxConcurrentWrites;
+    private int _maxWritesPerSecond;
 
-    public MigratorStatus(ScanStatus scanStatus, int maxConcurrentWrites) {
+    public MigratorStatus(ScanStatus scanStatus, int maxWritesPerSecond) {
         this(scanStatus.getScanId(), scanStatus.getOptions(), scanStatus.isCanceled(),
                 scanStatus.getStartTime(), scanStatus.getPendingScanRanges(),
                 scanStatus.getActiveScanRanges(), scanStatus.getCompleteScanRanges(),
-                scanStatus.getCompleteTime(), maxConcurrentWrites);
+                scanStatus.getCompleteTime(), maxWritesPerSecond);
     }
 
     @JsonCreator
@@ -32,16 +30,16 @@ public class MigratorStatus extends ScanStatus {
                       @JsonProperty ("activeScanRanges") List<ScanRangeStatus> activeMigrationRanges,
                       @JsonProperty ("completeScanRanges") List<ScanRangeStatus> completeMigrationRanges,
                       @JsonProperty ("completeTime") @Nullable Date completeTime,
-                      @JsonProperty ("maxConcurrentWrites") int maxConcurrentWrites) {
+                      @JsonProperty ("maxWritesPerSecond") int maxWritesPerSecond) {
         super(scanId, options, false, canceled, startTime, pendingMigrationRanges, activeMigrationRanges, completeMigrationRanges, completeTime);
-        _maxConcurrentWrites = maxConcurrentWrites;
+        _maxWritesPerSecond = maxWritesPerSecond;
     }
 
-    public int getMaxConcurrentWrites() {
-        return _maxConcurrentWrites;
+    public int getMaxWritesPerSecond() {
+        return _maxWritesPerSecond;
     }
 
-    public void setMaxConcurrentWrites(int maxConcurrentWrites) {
-        _maxConcurrentWrites = maxConcurrentWrites;
+    public void setMaxWritesPerSecond(int maxWritesPerSecond) {
+        _maxWritesPerSecond = maxWritesPerSecond;
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatusDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatusDAO.java
@@ -79,7 +79,7 @@ public class MigratorStatusDAO {
                         .put("canceled", false)
                         .put("startTime", status.getStartTime().getTime())
                         .put("completeTime", status.getCompleteTime() != null ? status.getCompleteTime().getTime() : null)
-                        .put("maxConcurrentWrites", status.getMaxConcurrentWrites())
+                        .put("maxWritesPerSecond", status.getMaxWritesPerSecond())
                         .build(),
                 new AuditBuilder().setLocalHost().setComment("Starting migration").build());
     }
@@ -131,7 +131,7 @@ public class MigratorStatusDAO {
         ScanOptions options = JsonHelper.convert(map.get("options"), ScanOptions.class);
         Long completeTs = (Long) map.get("completeTime");
         Date completeTime = completeTs != null ? new Date(completeTs) : null;
-        int maxConcurrentWrites = (Integer) map.get("maxConcurrentWrites");
+        int maxWritesPerSecond = (Integer) map.get("maxWritesPerSecond");
 
         //noinspection unchecked
         Map<String, Object> ranges = (Map<String, Object>) map.get("ranges");
@@ -177,7 +177,7 @@ public class MigratorStatusDAO {
         Date startTime = new Date((Long) map.get("startTime"));
 
         return new MigratorStatus(Intrinsic.getId(map), options, canceled, startTime, pendingMigrationRanges, activeMigrationRanges,
-                completeMigrationRanges, completeTime, maxConcurrentWrites);
+                completeMigrationRanges, completeTime, maxWritesPerSecond);
     }
 
     public void setMigratorRangeTaskQueued(String migrationId, int taskId, Date queuedTime) {
@@ -281,16 +281,16 @@ public class MigratorStatusDAO {
                 new AuditBuilder().setLocalHost().setComment("Canceling migration").build());
     }
 
-    public void setMaxConcurrentWrites(String migrationId, int maxConcurrentWrites) {
+    public void setMaxWritesPerSecond(String migrationId, int maxWritesPerSecond) {
         _dataStore.update(getTable(), migrationId, TimeUUIDs.newUUID(),
                 Deltas.mapBuilder()
-        .put("maxConcurrentWrites", maxConcurrentWrites).build(),
-                new AuditBuilder().setLocalHost().setComment("modifying maxConcurrentWrites").build());
+        .put("maxWritesPerSecond", maxWritesPerSecond).build(),
+                new AuditBuilder().setLocalHost().setComment("modifying maxWritesPerSecond").build());
     }
 
-    public int getMaxConcurrentWrites(String migrationId) {
+    public int getMaxWritesPerSecond(String migrationId) {
         Map<String, Object> status = _dataStore.get(getTable(), migrationId);
-        return (int) status.get("maxConcurrentWrites");
+        return (int) status.get("maxWritesPerSecond");
     }
 
     private String toRangeKey(int taskId) {


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

In the current version of the blocked delta migrator, throttling functionality is provided through the ability to specify the maximum amount of concurrent writes per token range. This has proven to be largely ineffective in slowing down load on Cassandra. This PR swaps the old throttling model out for one that throttles by limiting the maximum number of writes per second per token range.

## How to Test and Verify

1. Check out this PR
2. Run start-migrator-role-local.sh
3. Run a migration with and obsere that you than throttle by providing the query parameter maxWritesPerSecond

## Risk

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

The only risk introduced by this change is that the rate limiter does not work as expected and therefore allows C* to be overloaded.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
