### PR TITLE
Fixed concurrent modification issue on cached row groups

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/cql/CachingRowGroupIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/cql/CachingRowGroupIterator.java
@@ -1,12 +1,12 @@
 package com.bazaarvoice.emodb.sor.db.cql;
 
 import com.datastax.driver.core.Row;
-import com.google.common.base.Predicates;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
+import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.util.Iterator;
 import java.util.List;
@@ -109,7 +109,7 @@ public class CachingRowGroupIterator extends AbstractIterator<Iterable<Row>> {
                     // the backend.  Start by dereferencing all of the remaining cached row groups that can no
                     // longer be used, though keep the current row group to signal future iterations to reload
                     // remaining rows.
-                    Iterators.removeIf(_softGroupsIterator, Predicates.alwaysTrue());
+                    _softGroupsIterator.forEachRemaining(Reference::clear);
 
                     _sourceIterator = rowGroup.reloadRowsAfter(_lastCacheRow);
                     return getNextFromSourceIterator();

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/db/cql/CachingRowGroupIteratorTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/db/cql/CachingRowGroupIteratorTest.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.sor.db.cql;
 
 import com.datastax.driver.core.Row;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Table;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -14,8 +15,10 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -89,6 +92,8 @@ public class CachingRowGroupIteratorTest {
         assertTrue(iterator.hasNext());
         // Get the rows from the row group
         Iterable<Row> rows = iterator.next();
+        // Create an iterator but from the iterable but delay iteratoring over it for now
+        Iterator<Row> delayedRowIterator = rows.iterator();
         assertTrue(groupsEqual(rows, row("a", "1", "1"), row("a", "2", "2"), row("a", "3", "3"),
                 row("a", "4", "4"), row("a", "5", "5"), row("a", "6", "6"), row("a", "7", "7"), row("a", "8", "8")));
         // Last 6 rows should have been put in the soft cache
@@ -107,6 +112,10 @@ public class CachingRowGroupIteratorTest {
 
         // This time rows 5 through 8 should have come from a reload
         assertTrue(groupsEqual(_reloadedRows, row("a", "5", "5"), row("a", "6", "6"), row("a", "7", "7"), row("a", "8", "8")));
+
+        // Verify the delayed iterable can still be traversed and return correct results
+        assertTrue(groupsEqual(ImmutableList.copyOf(delayedRowIterator), row("a", "1", "1"), row("a", "2", "2"), row("a", "3", "3"),
+                row("a", "4", "4"), row("a", "5", "5"), row("a", "6", "6"), row("a", "7", "7"), row("a", "8", "8")));
     }
 
     private class CachingRowGroupIteratorWithMockSoftReferences extends CachingRowGroupIterator {
@@ -119,10 +128,12 @@ public class CachingRowGroupIteratorTest {
         protected SoftReference<List<Row>> softlyReferenced(List<Row> rows) {
             //noinspection unchecked
             SoftReference<List<Row>> ref = mock(SoftReference.class);
+            final AtomicReference<List<Row>> rowsRef = new AtomicReference<>(rows);
             // Record this list was returned in a soft reference, keyed by the first record
             _softReferences.put(rows.get(0).getString(0), rows.get(0).getString(1), ref);
             // By default the reference will return the rows.  Callers can reset the mock to override this behavior.
-            when(ref.get()).thenReturn(rows);
+            when(ref.get()).thenAnswer(ignore -> rowsRef.get());
+            doAnswer(ignore -> { rowsRef.set(null); return null; }).when(ref).clear();
             return ref;
         }
     }


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Fixed a bug which could lead to concurrent modification exceptions if soft references in cache groups were removed from memory.  The fix is to clear the references but not modify the underlying iterable.

## How to Test and Verify

Not really testable locally due to the unpredictability of Java memory management.  Unit test has been updated to recreate the scenario.

## Risk

This is a low risk update.  The difference between the modified and unmodified code is nearly identical, since in both cases the rows being removed/deferenced would no longer be read from anyway.


### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
