### PR TITLE
Make the migration throttling rate more responsive

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
@@ -73,7 +73,7 @@ public class DataStoreConfiguration {
     */
     @Valid
     @NotNull
-    @JsonProperty
+    @JsonProperty("deltaBlockSizeInKb")
     private int _deltaBlockSizeInKb = 64;
 
     @Valid

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DeltaMigrator.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DeltaMigrator.java
@@ -31,20 +31,24 @@ public class DeltaMigrator {
     private final MigratorStatusDAO _statusDAO;
     private final ScanWorkflow _workflow;
     private final int _defaultMaxWritesPerSecond;
+    private final int _migratorSplitSize;
 
     @Inject
     public DeltaMigrator(DataTools dataTools, MigratorStatusDAO statusDAO, ScanWorkflow workflow,
-                         @Named ("maxWritesPerSecond") Integer maxWritesPerSecond) {
+                         @Named ("maxWritesPerSecond") Integer maxWritesPerSecond, @MigratorSplitSize int migratorSplitSize) {
         _dataTools = checkNotNull(dataTools, "dataTools");
         _statusDAO = checkNotNull(statusDAO, "statusDAO");
         _workflow = checkNotNull(workflow, "workflow");
         _defaultMaxWritesPerSecond = maxWritesPerSecond;
+        _migratorSplitSize = migratorSplitSize;
 
     }
 
     public MigratorStatus migratePlacement(String placement, int maxWritesPerSecond) {
         ScanOptions options = new ScanOptions(placement)
-                .setScanByAZ(true);
+                .setScanByAZ(true)
+                .setRangeScanSplitSize(_migratorSplitSize);
+
         MigratorPlan plan = createPlan(placement, options);
         MigratorStatus status = plan.toMigratorStatus(maxWritesPerSecond > 0 ? maxWritesPerSecond: _defaultMaxWritesPerSecond);
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DistributedMigratorRangeMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DistributedMigratorRangeMonitor.java
@@ -289,7 +289,7 @@ public class DistributedMigratorRangeMonitor implements Managed {
 
             _statusDAO.setMigratorRangeTaskActive(migrationId, taskId, new Date());
 
-            result = _rangeMigrator.migrate(taskId, status.getOptions(), placement, range, _statusDAO.getMaxWritesPerSecond(migrationId));
+            result = _rangeMigrator.migrate(taskId, status.getOptions(), placement, range, _statusDAO, migrationId);
 
 
             _log.info("Completed migration range task: {}", task);

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DistributedMigratorRangeMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DistributedMigratorRangeMonitor.java
@@ -289,7 +289,7 @@ public class DistributedMigratorRangeMonitor implements Managed {
 
             _statusDAO.setMigratorRangeTaskActive(migrationId, taskId, new Date());
 
-            result = _rangeMigrator.migrate(taskId, status.getOptions(), placement, range, _statusDAO, migrationId);
+            result = _rangeMigrator.migrate(taskId, status.getOptions(), placement, range, migrationId);
 
 
             _log.info("Completed migration range task: {}", task);

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/LocalRangeMigrator.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/LocalRangeMigrator.java
@@ -59,7 +59,7 @@ public class LocalRangeMigrator {
             while (System.currentTimeMillis() - startTime < options.getMaxRangeScanTime().getMillis() && results.hasNext()) {
 
                 Iterator<MigrationScanResult> batchIterator = Iterators.limit(results, BATCH_SIZE);
-                _migratorTools.writeRows(placement, results, maxWritesPerSecond);
+                _migratorTools.writeRows(placement, batchIterator, maxWritesPerSecond);
 
             }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorModule.java
@@ -43,6 +43,8 @@ public class MigratorModule extends PrivateModule {
 
         checkArgument(_config.getReadThreadCount() > 0, "Read thread count must be at least 1");
         checkArgument(_config.getMaxWritesPerSecond() > 0, "Max writes per second must be at least 1");
+        checkArgument(_config.getMigratorSplitSize() > 0, "Migrator split size must be at least 1");
+
     }
 
     @Override
@@ -65,6 +67,8 @@ public class MigratorModule extends PrivateModule {
                 .toInstance(_config.getCompleteMigrationRangeQueueName());
         bind(Integer.class).annotatedWith(Names.named("maxWritesPerSecond"))
                 .toInstance(_config.getMaxWritesPerSecond());
+
+        bind(Integer.class).annotatedWith(MigratorSplitSize.class).toInstance(_config.getMigratorSplitSize());
 
         bind(MigratorMonitor.class).asEagerSingleton();
         bind(DistributedMigratorRangeMonitor.class).asEagerSingleton();

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorModule.java
@@ -53,6 +53,7 @@ public class MigratorModule extends PrivateModule {
 
         bind(DeltaMigrator.class).asEagerSingleton();
         bind(MigratorStatusDAO.class).asEagerSingleton();
+        bind(MigratorRateLimiter.class).to(MigratorStatusDAO.class);
         bind(LocalRangeMigrator.class).asEagerSingleton();
 
         bind(ScanWorkflow.class).toProvider(QueueScanWorkflowProvider.class).asEagerSingleton();

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorRateLimiter.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorRateLimiter.java
@@ -1,0 +1,7 @@
+package com.bazaarvoice.emodb.web.migrator;
+
+public interface MigratorRateLimiter {
+    int getMaxWritesPerSecond(String migrationId);
+
+    void setMaxWritesPerSecond(String migrationId, int maxWritesPerSecond);
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorRateLimiter.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorRateLimiter.java
@@ -2,6 +2,4 @@ package com.bazaarvoice.emodb.web.migrator;
 
 public interface MigratorRateLimiter {
     int getMaxWritesPerSecond(String migrationId);
-
-    void setMaxWritesPerSecond(String migrationId, int maxWritesPerSecond);
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorSplitSize.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/MigratorSplitSize.java
@@ -1,0 +1,16 @@
+package com.bazaarvoice.emodb.web.migrator;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface MigratorSplitSize {
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/config/MigratorConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/config/MigratorConfiguration.java
@@ -15,6 +15,7 @@ public class MigratorConfiguration {
     private static final String DEFAULT_MIGRATE_STATUS_TABLE = "__system_migrate";
     private static final String DEFAULT_MIGRATE_STATUS_TABLE_PLACEMENT = "app_global:migration";
     private static final int DEFAULT_MAX_WRITES_PER_SECOND = 1000;
+    private static final int DEFAULT_MIGRATOR_SPLIT_SIZE = 1000000;
 
     // If using EmoDB queues, the API key to use
     @Valid
@@ -44,6 +45,12 @@ public class MigratorConfiguration {
     @NotNull
     @JsonProperty ("maxWritesPerSecond")
     private int _maxWritesPerSecond = DEFAULT_MAX_WRITES_PER_SECOND;
+
+
+    @Valid
+    @NotNull
+    @JsonProperty ("migratorSplitSize")
+    private int _migratorSplitSize = DEFAULT_MIGRATOR_SPLIT_SIZE;
 
     @Valid
     @NotNull
@@ -107,7 +114,19 @@ public class MigratorConfiguration {
         return this;
     }
 
+    public int setMaxWritesPerSecond() {
+        return _maxWritesPerSecond;
+    }
+
     public int getMaxWritesPerSecond() {
         return _maxWritesPerSecond;
+    }
+
+    public int setMigratorSplitSize() {
+        return _migratorSplitSize;
+    }
+
+    public int getMigratorSplitSize() {
+        return _migratorSplitSize;
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatusDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatusDAO.java
@@ -282,7 +282,6 @@ public class MigratorStatusDAO implements MigratorRateLimiter {
                 new AuditBuilder().setLocalHost().setComment("Canceling migration").build());
     }
 
-    @Override
     public void setMaxWritesPerSecond(String migrationId, int maxWritesPerSecond) {
         _dataStore.update(getTable(), migrationId, TimeUUIDs.newUUID(),
                 Deltas.mapBuilder()

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatusDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatusDAO.java
@@ -8,6 +8,7 @@ import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.db.ScanRange;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
 import com.bazaarvoice.emodb.sor.delta.MapDeltaBuilder;
+import com.bazaarvoice.emodb.web.migrator.MigratorRateLimiter;
 import com.bazaarvoice.emodb.web.scanner.ScanOptions;
 import com.bazaarvoice.emodb.web.scanner.scanstatus.*;
 import com.google.common.base.Optional;
@@ -20,7 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-public class MigratorStatusDAO {
+public class MigratorStatusDAO implements MigratorRateLimiter {
 
     private final DataStore _dataStore;
     private final String _tableName;
@@ -281,6 +282,7 @@ public class MigratorStatusDAO {
                 new AuditBuilder().setLocalHost().setComment("Canceling migration").build());
     }
 
+    @Override
     public void setMaxWritesPerSecond(String migrationId, int maxWritesPerSecond) {
         _dataStore.update(getTable(), migrationId, TimeUUIDs.newUUID(),
                 Deltas.mapBuilder()
@@ -288,6 +290,7 @@ public class MigratorStatusDAO {
                 new AuditBuilder().setLocalHost().setComment("modifying maxWritesPerSecond").build());
     }
 
+    @Override
     public int getMaxWritesPerSecond(String migrationId) {
         Map<String, Object> status = _dataStore.get(getTable(), migrationId);
         return (int) status.get("maxWritesPerSecond");


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

During testing of the delta migration, I observed an issue where throttling can take an extremely long time to actually go in to effect. This is because the rate of writes per second is only checked by the system before every new split of 1 million records, which can be prohibitively long if the write rate was set extremely low. In order to fix this, I divided each split into batches equal to WRITE_RATE * 60. This batch size means that approximately every minute, the system will finish a batch and check for a new write rate before beginning a new batch. 

## How to Test and Verify

1. Check out this PR
2. Run start-migrator-role-local.sh
3. Run a migration with and attempt to throttle using the throttling endpoint.

Unfortunately, it is extremely difficult to prove this PR's effectiveness without running this on a system that can connect an analytics service (ex. Datadog) that can show the write rate slowing and speeding up.

## Risk

### Level 

`Medium`

### Required Testing

`Manual`

### Risk Summary

Further testing should be done to ensure that data integrity is still preserved, even though the scope of this change is small.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
