### PR TITLE
Streaming improvements for splits and scans

### DIFF
--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/TableAuthIdentityManagerDAO.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/identity/TableAuthIdentityManagerDAO.java
@@ -319,7 +319,7 @@ public class TableAuthIdentityManagerDAO<T extends AuthIdentity> implements Auth
         if (identity == null) {
             // This should be rare, but if the record was not found or was stale in the index table then scan for it.
 
-            Iterator<Map<String, Object>> entries = _dataStore.scan(_identityTableName, null, Long.MAX_VALUE, ReadConsistency.STRONG);
+            Iterator<Map<String, Object>> entries = _dataStore.scan(_identityTableName, null, Long.MAX_VALUE, false, ReadConsistency.STRONG);
             while (entries.hasNext() && identity == null) {
                 Map<String, Object> entry = entries.next();
                 T potentialIdentity = convertDataStoreEntryToIdentity(entry);

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/TablePermissionManagerDAO.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/permissions/TablePermissionManagerDAO.java
@@ -134,7 +134,7 @@ public class TablePermissionManagerDAO implements PermissionManager {
         validateTable();
 
         return () -> {
-            Iterator<Map<String, Object>> records = _dataStore.scan(_tableName, null, Long.MAX_VALUE, ReadConsistency.STRONG);
+            Iterator<Map<String, Object>> records = _dataStore.scan(_tableName, null, Long.MAX_VALUE, false, ReadConsistency.STRONG);
             return StreamSupport.stream(Spliterators.spliteratorUnknownSize(records, 0), false)
                     .map(record -> Maps.immutableEntry(Intrinsic.getId(record), extractPermissionsFromRecord(record)))
                     .iterator();

--- a/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/TableRoleManagerDAO.java
+++ b/auth/auth-store/src/main/java/com/bazaarvoice/emodb/auth/role/TableRoleManagerDAO.java
@@ -129,7 +129,7 @@ public class TableRoleManagerDAO implements RoleManager {
     public Iterator<Role> getAll() {
         validateTables();
 
-        Iterator<Map<String, Object>> records = _dataStore.scan(_roleTableName, null, Integer.MAX_VALUE, ReadConsistency.STRONG);
+        Iterator<Map<String, Object>> records = _dataStore.scan(_roleTableName, null, Integer.MAX_VALUE, false, ReadConsistency.STRONG);
 
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(records, 0), false)
                 .map(this::convertRecordToRole)

--- a/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/io/EmoFileSystem.java
+++ b/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/io/EmoFileSystem.java
@@ -232,7 +232,7 @@ public class EmoFileSystem extends FileSystem implements EmoInputSplittable {
                     // Get the DataStore and begin streaming the split's rows.
                     _dataStore = HadoopDataStoreManager.getInstance().getDataStore(location, _apiKey, _metricRegistry);
                     Iterable<Map<String, Object>> rows =
-                            DataStoreStreaming.getSplit(_dataStore, table, split, ReadConsistency.STRONG);
+                            DataStoreStreaming.getSplit(_dataStore, table, split, false, ReadConsistency.STRONG);
                     return rows.iterator();
                 } catch (Exception e) {
                     close();
@@ -318,7 +318,7 @@ public class EmoFileSystem extends FileSystem implements EmoInputSplittable {
                 CloseableDataStore dataStore = HadoopDataStoreManager.getInstance().getDataStore(_uri, _apiKey, _metricRegistry);
                 _closer.register(dataStore);
 
-                _rows = DataStoreStreaming.getSplit(dataStore, table, split, ReadConsistency.STRONG).iterator();
+                _rows = DataStoreStreaming.getSplit(dataStore, table, split, false, ReadConsistency.STRONG).iterator();
             }
 
             _buffer.clear();

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/AuthDataStore.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/AuthDataStore.java
@@ -123,7 +123,7 @@ public interface AuthDataStore {
      * event that the connection to the EmoDB server is lost while streaming results.
      */
     Iterator<Map<String, Object>> scan(@Credential String apiKey, String table, @Nullable String fromKeyExclusive,
-                                       long limit, ReadConsistency consistency);
+                                       long limit, boolean includeDeletes, ReadConsistency consistency);
 
     /**
      * Returns a list of split identifiers that can be used to scan all records in the specified table in parallel using
@@ -143,7 +143,8 @@ public interface AuthDataStore {
      * event that the connection to the EmoDB server is lost while streaming results.
      */
     Iterator<Map<String, Object>> getSplit(@Credential String apiKey, String table, String split,
-                                           @Nullable String fromKeyExclusive, long limit, ReadConsistency consistency);
+                                           @Nullable String fromKeyExclusive, long limit, boolean includeDeletes,
+                                           ReadConsistency consistency);
 
     /**
      * Retrieves records from the specified list of coordinates. The records will *not* be returned in the order it was

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/DataStore.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/DataStore.java
@@ -126,7 +126,7 @@ public interface DataStore {
      * {@code com.bazaarvoice.emodb.sor.client.DataStoreStreaming} class which will restart the iterator in the
      * event that the connection to the EmoDB server is lost while streaming results.
      */
-    Iterator<Map<String, Object>> scan(String table, @Nullable String fromKeyExclusive, long limit, ReadConsistency consistency);
+    Iterator<Map<String, Object>> scan(String table, @Nullable String fromKeyExclusive, long limit, boolean includeDeletes, ReadConsistency consistency);
 
     /**
      * Returns a list of split identifiers that can be used to scan all records in the specified table in parallel using
@@ -145,7 +145,7 @@ public interface DataStore {
      * {@code com.bazaarvoice.emodb.sor.client.DataStoreStreaming} class which will restart the iterator in the
      * event that the connection to the EmoDB server is lost while streaming results.
      */
-    Iterator<Map<String, Object>> getSplit(String table, String split, @Nullable String fromKeyExclusive, long limit, ReadConsistency consistency);
+    Iterator<Map<String, Object>> getSplit(String table, String split, @Nullable String fromKeyExclusive, long limit, boolean includeDeletes, ReadConsistency consistency);
 
     /**
      * Retrieves records from the specified list of coordinates. The records will *not* be returned in the order it was

--- a/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/DataStoreAuthenticatorProxy.java
+++ b/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/DataStoreAuthenticatorProxy.java
@@ -150,13 +150,13 @@ class DataStoreAuthenticatorProxy implements DataStore {
     }
 
     @Override
-    public Iterator<Map<String, Object>> scan(String table, @Nullable String fromKeyExclusive, long limit, ReadConsistency consistency) {
-        return _authDataStore.scan(_apiKey, table, fromKeyExclusive, limit, consistency);
+    public Iterator<Map<String, Object>> scan(String table, @Nullable String fromKeyExclusive, long limit, boolean includeDeletes, ReadConsistency consistency) {
+        return _authDataStore.scan(_apiKey, table, fromKeyExclusive, limit, includeDeletes, consistency);
     }
 
     @Override
-    public Iterator<Map<String, Object>> getSplit(String table, String split, @Nullable String fromKeyExclusive, long limit, ReadConsistency consistency) {
-        return _authDataStore.getSplit(_apiKey, table, split, fromKeyExclusive, limit, consistency);
+    public Iterator<Map<String, Object>> getSplit(String table, String split, @Nullable String fromKeyExclusive, long limit, boolean includeDeletes, ReadConsistency consistency) {
+        return _authDataStore.getSplit(_apiKey, table, split, fromKeyExclusive, limit, includeDeletes, consistency);
     }
 
     @Override

--- a/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/DataStoreClient.java
+++ b/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/DataStoreClient.java
@@ -343,7 +343,7 @@ public class DataStoreClient implements AuthDataStore {
 
     @Override
     public Iterator<Map<String, Object>> scan(String apiKey, String table, @Nullable String fromKeyExclusive,
-                                              long limit, ReadConsistency consistency) {
+                                              long limit, boolean includeDeletes, ReadConsistency consistency) {
         checkNotNull(table, "table");
         checkArgument(limit > 0, "Limit must be >0");
         checkNotNull(consistency, "consistency");
@@ -352,6 +352,7 @@ public class DataStoreClient implements AuthDataStore {
                     .segment(table)
                     .queryParam("from", optional(fromKeyExclusive))
                     .queryParam("limit", limit)
+                    .queryParam("includeDeletes", includeDeletes)
                     .queryParam("consistency", consistency)
                     .build();
             return _client.resource(uri)
@@ -383,7 +384,7 @@ public class DataStoreClient implements AuthDataStore {
 
     @Override
     public Iterator<Map<String, Object>> getSplit(String apiKey, String table, String split, @Nullable String fromKeyExclusive,
-                                                  long limit, ReadConsistency consistency) {
+                                                  long limit, boolean includeDeletes, ReadConsistency consistency) {
         checkNotNull(table, "table");
         checkNotNull(split, "split");
         checkArgument(limit > 0, "Limit must be >0");
@@ -393,6 +394,7 @@ public class DataStoreClient implements AuthDataStore {
                     .segment("_split", table, split)
                     .queryParam("from", optional(fromKeyExclusive))
                     .queryParam("limit", limit)
+                    .queryParam("includeDeletes", includeDeletes)
                     .queryParam("consistency", consistency)
                     .build();
             return _client.resource(uri)

--- a/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/DataStoreStreaming.java
+++ b/sor-client-common/src/main/java/com/bazaarvoice/emodb/sor/client/DataStoreStreaming.java
@@ -39,8 +39,9 @@ public abstract class DataStoreStreaming {
      */
     public static Iterable<Map<String, Object>> scan(DataStore dataStore,
                                                      String table,
+                                                     boolean includeDeletes,
                                                      ReadConsistency consistency) {
-        return scan(dataStore, table, null, Long.MAX_VALUE, consistency);
+        return scan(dataStore, table, null, Long.MAX_VALUE, includeDeletes, consistency);
     }
 
     /**
@@ -49,8 +50,9 @@ public abstract class DataStoreStreaming {
     public static Iterable<Map<String, Object>> getSplit(DataStore dataStore,
                                                          String table,
                                                          String split,
+                                                         boolean includeDeletes,
                                                          ReadConsistency consistency) {
-        return getSplit(dataStore, table, split, null, Long.MAX_VALUE, consistency);
+        return getSplit(dataStore, table, split, null, Long.MAX_VALUE, includeDeletes, consistency);
     }
 
     /**
@@ -84,12 +86,13 @@ public abstract class DataStoreStreaming {
                                                      final String table,
                                                      final @Nullable String fromKeyExclusive,
                                                      final long limit,
+                                                     final boolean includeDeletes,
                                                      final ReadConsistency consistency) {
         return RestartingStreamingIterator.stream(fromKeyExclusive, limit,
                 new StreamingIteratorSupplier<Map<String, Object>, String>() {
                     @Override
                     public Iterator<Map<String, Object>> get(String fromToken, long limit) {
-                        return dataStore.scan(table, fromToken, limit, consistency);
+                        return dataStore.scan(table, fromToken, limit, includeDeletes, consistency);
                     }
 
                     @Override
@@ -110,12 +113,13 @@ public abstract class DataStoreStreaming {
                                                          final String split,
                                                          final @Nullable String fromKeyExclusive,
                                                          final long limit,
+                                                         final boolean includeDeletes,
                                                          final ReadConsistency consistency) {
         return RestartingStreamingIterator.stream(fromKeyExclusive, limit,
                 new StreamingIteratorSupplier<Map<String, Object>, String>() {
                     @Override
                     public Iterator<Map<String, Object>> get(String fromToken, long limit) {
-                        return dataStore.getSplit(table, split, fromToken, limit, consistency);
+                        return dataStore.getSplit(table, split, fromToken, limit, includeDeletes, consistency);
                     }
 
                     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreProviderProxy.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreProviderProxy.java
@@ -121,8 +121,8 @@ public class DataStoreProviderProxy implements DataStore {
     }
 
     @Override
-    public Iterator<Map<String, Object>> scan(String table, @Nullable String fromKeyExclusive, long limit, ReadConsistency consistency) {
-        return _local.get().scan(table, fromKeyExclusive, limit, consistency);
+    public Iterator<Map<String, Object>> scan(String table, @Nullable String fromKeyExclusive, long limit, boolean includeDeletes, ReadConsistency consistency) {
+        return _local.get().scan(table, fromKeyExclusive, limit,  includeDeletes, consistency);
     }
 
     @Override
@@ -131,8 +131,8 @@ public class DataStoreProviderProxy implements DataStore {
     }
 
     @Override
-    public Iterator<Map<String, Object>> getSplit(String table, String split, @Nullable String fromKeyExclusive, long limit, ReadConsistency consistency) {
-        return _local.get().getSplit(table, split, fromKeyExclusive, limit, consistency);
+    public Iterator<Map<String, Object>> getSplit(String table, String split, @Nullable String fromKeyExclusive, long limit, boolean includeDeletes, ReadConsistency consistency) {
+        return _local.get().getSplit(table, split, fromKeyExclusive, limit, includeDeletes, consistency);
     }
 
     @Override

--- a/web/src/main/java/com/bazaarvoice/emodb/web/jersey/FilteredJsonStreamingOutput.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/jersey/FilteredJsonStreamingOutput.java
@@ -1,0 +1,84 @@
+package com.bazaarvoice.emodb.web.jersey;
+
+import com.bazaarvoice.emodb.common.json.JsonHelper;
+import com.google.common.base.Charsets;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.PeekingIterator;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Iterator;
+
+/**
+ * Custom JSON stream writer which filters items from the source iterator and injects whitespace into the returned
+ * array at regular intervals of filtered content.  Once the provided maximum length of the filtered content has
+ * been written it will stop.
+ */
+abstract public class FilteredJsonStreamingOutput<T> implements StreamingOutput {
+
+    private final Iterator<T> _iterator;
+    private final long _limit;
+
+    public FilteredJsonStreamingOutput(Iterator<T> iterator, long limit) {
+        // Force the first item to be read before streaming results, so if there are any errors they are thrown before
+        // writing any content
+        PeekingIterator<T> peekingIterator = Iterators.peekingIterator(iterator);
+        if (peekingIterator.hasNext()) {
+            peekingIterator.peek();
+        }
+
+        _iterator = peekingIterator;
+        _limit = Math.max(limit, 0);
+    }
+
+    abstract public boolean include(T value);
+
+    @Override
+    public void write(OutputStream out) throws IOException, WebApplicationException {
+        // The JSON writer may try to close the stream after each entry.  To protect against this use a "safe"
+        // output stream which will ignore calls by the JSON writer to close.
+        OutputStream safeOut = asNonClosingOutputStream(out);
+
+        safeOut.write("[".getBytes(Charsets.UTF_8));
+        byte[] sep = null;
+        long nextWhitespaceTime = Long.MAX_VALUE;
+        long remaining = _limit;
+
+        while (_iterator.hasNext() && remaining != 0) {
+            T value = _iterator.next();
+            if (include(value)) {
+                if (sep == null) {
+                    // first value written
+                    sep = ",".getBytes(Charsets.UTF_8);
+                } else {
+                    safeOut.write(sep);
+                }
+                JsonHelper.writeJson(safeOut, value);
+                nextWhitespaceTime = Long.MAX_VALUE;
+                remaining -= 1;
+            } else {
+                // Target writing whitespace every 100ms to keep the stream alive
+                if (nextWhitespaceTime == Long.MAX_VALUE) {
+                    nextWhitespaceTime = System.currentTimeMillis() + 100;
+                } else if (System.currentTimeMillis() >= nextWhitespaceTime) {
+                    safeOut.write(" ".getBytes(Charsets.UTF_8));
+                    nextWhitespaceTime = System.currentTimeMillis() + 100;
+                }
+            }
+        }
+
+        safeOut.write("]".getBytes(Charsets.UTF_8));
+    }
+
+    private OutputStream asNonClosingOutputStream(OutputStream out) {
+        return new FilterOutputStream(out) {
+            @Override
+            public void close() throws IOException {
+                // Keep stream open
+            }
+        };
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/jersey/FilteredJsonStreamingOutput.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/jersey/FilteredJsonStreamingOutput.java
@@ -44,7 +44,7 @@ abstract public class FilteredJsonStreamingOutput<T> implements StreamingOutput 
 
         safeOut.write("[".getBytes(Charsets.UTF_8));
         byte[] sep = null;
-        long nextWhitespaceTime = Long.MAX_VALUE;
+        long lastWriteTime = 0;
         long remaining = _limit;
 
         while (_iterator.hasNext() && remaining != 0) {
@@ -57,15 +57,13 @@ abstract public class FilteredJsonStreamingOutput<T> implements StreamingOutput 
                     safeOut.write(sep);
                 }
                 JsonHelper.writeJson(safeOut, value);
-                nextWhitespaceTime = Long.MAX_VALUE;
+                lastWriteTime = System.currentTimeMillis();
                 remaining -= 1;
             } else {
                 // Target writing whitespace every 100ms to keep the stream alive
-                if (nextWhitespaceTime == Long.MAX_VALUE) {
-                    nextWhitespaceTime = System.currentTimeMillis() + 100;
-                } else if (System.currentTimeMillis() >= nextWhitespaceTime) {
+                if (System.currentTimeMillis() >= lastWriteTime + 100) {
                     safeOut.write(" ".getBytes(Charsets.UTF_8));
-                    nextWhitespaceTime = System.currentTimeMillis() + 100;
+                    lastWriteTime = System.currentTimeMillis();
                 }
             }
         }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatusDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatusDAO.java
@@ -58,7 +58,7 @@ public class MigratorStatusDAO {
 
     public Iterator<MigratorStatus> list(@Nullable String fromIdExclusive, long limit) {
         return Iterators.transform(
-                _dataStore.scan(getTable(), fromIdExclusive, limit, ReadConsistency.STRONG),
+                _dataStore.scan(getTable(), fromIdExclusive, limit, false, ReadConsistency.STRONG),
                         map -> fromMap(map));
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/report/db/EmoTableAllTablesReportDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/report/db/EmoTableAllTablesReportDAO.java
@@ -286,7 +286,7 @@ public class EmoTableAllTablesReportDAO implements AllTablesReportDAO {
                         _limit = Long.MAX_VALUE;
                     }
 
-                    _batch = _dataStore.scan(reportTable, _from, _limit, ReadConsistency.STRONG);
+                    _batch = _dataStore.scan(reportTable, _from, _limit, false, ReadConsistency.STRONG);
                     if (!_batch.hasNext()) {
                         return endOfData();
                     }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
@@ -386,10 +386,11 @@ public class DataStoreResource1 {
         if (includeDeletes.get()) {
             unfilteredContent = _dataStore.scan(table, Strings.emptyToNull(fromKeyExclusive), limit.get(), true, consistency.get());
             return streamingIterator(unfilteredContent, debug);
+        } else {
+            // Can't pass limit parameter to the back-end since we may exclude deleted content.  Get all records and self-limit.
+            unfilteredContent = _dataStore.scan(table, Strings.emptyToNull(fromKeyExclusive), Long.MAX_VALUE, true, consistency.get());
+            return deletedContentFilteringStream(unfilteredContent, limit.get());
         }
-        // Can't pass limit parameter to the back-end since we may exclude deleted content.  Get all records and self-limit.
-        unfilteredContent = _dataStore.scan(table, Strings.emptyToNull(fromKeyExclusive), Long.MAX_VALUE, true, consistency.get());
-        return deletedContentFilteringStream(unfilteredContent, limit.get());
     }
 
     /**
@@ -433,10 +434,11 @@ public class DataStoreResource1 {
         if (includeDeletes.get()) {
             unfilteredContent = _dataStore.getSplit(table, split, Strings.emptyToNull(key), limit.get(), true, consistency.get());
             return streamingIterator(unfilteredContent, debug);
+        } else {
+            // Can't pass limit parameter to the back-end since we may exclude deleted content.  Get all records and self-limit.
+            unfilteredContent = _dataStore.getSplit(table, split, Strings.emptyToNull(key), Long.MAX_VALUE, true, consistency.get());
+            return deletedContentFilteringStream(unfilteredContent, limit.get());
         }
-        // Can't pass limit parameter to the back-end since we may exclude deleted content.  Get all records and self-limit.
-        unfilteredContent = _dataStore.getSplit(table, split, Strings.emptyToNull(key), Long.MAX_VALUE, true, consistency.get());
-        return deletedContentFilteringStream(unfilteredContent, limit.get());
     }
 
     /**

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scanstatus/DataStoreScanStatusDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scanstatus/DataStoreScanStatusDAO.java
@@ -69,7 +69,7 @@ public class DataStoreScanStatusDAO implements ScanStatusDAO {
     @Override
     public Iterator<ScanStatus> list(@Nullable String fromIdExclusive, long limit) {
         return Iterators.transform(
-                _dataStore.scan(getTable(), fromIdExclusive, limit, ReadConsistency.STRONG),
+                _dataStore.scan(getTable(), fromIdExclusive, limit, false, ReadConsistency.STRONG),
                 new Function<Map<String, Object>, ScanStatus>() {
                     @Override
                     public ScanStatus apply(Map<String, Object> map) {


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

There are two API for streaming table records from Emo: scan and getSplit.  Both of these filter out deleted documents to the caller; that is, documents whose most recent delta indicates a deletion.  When deletes are sporadic this isn't a problem.  However, consider the extreme case of a table with 10M documents, all of which are deleted by their most recent delta.  When an API call is made to Emo to get a scan or split for this table Emo will traverse all 10M documents in the case of scan, or the full split size in the case of a split, iterating to the first undeleted document.  Note that the user provided "limit" parameter doesn't matter; even with a limit of 1 the entire table will be scanned before determining there are no results.  This scan can take minutes and more, causing client timeouts.

This PR makes two changes:

1. It allows the caller to explicitly set as part of the API whether a scan or split should include deleted documents.  This is false by default for backwards compatibility.
2. When returning a scan or split with many deleted documents Emo will inject whitespace into the JSON array stream intermittently to keep the connection alive.  Because the whitespace is inserted between documents it should still be readable by any compliant JSON parser.

As a bonus this same process is also being used when getting a list of tables from the API.  This way if a user only has permission to read a small subset of tables the response won't block until the first readable table is scanned.

## How to Test and Verify

1. Check out this PR
2. Create a table and write multiple records to the table.
3. Delete several records
3. To a scan and split on the table, both with and without the "includeDeletes" parameter, and verify the results are consistent.

## Risk

This is a fairly low-risk change.  The biggest risk is if some JSON parser implementation chokes on the whitespace (which it shouldn't).  It's possible with buffering the whitespace solution may not work it all cases, but if it doesn't then the outcome is unchanged from present.

### Level 

`Medium`

### Required Testing

`Manual`

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
