### PR TITLE
Additional timers and metrics for fanout and subscription caching

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/db/generic/CachingSubscriptionDAO.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/db/generic/CachingSubscriptionDAO.java
@@ -11,6 +11,7 @@ import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import com.google.common.base.Objects;
 import com.google.common.base.Ticker;
 import com.google.common.cache.CacheBuilder;
@@ -96,6 +97,8 @@ public class CachingSubscriptionDAO implements SubscriptionDAO {
     private final LoadingCache<String, Map<String, OwnedSubscription>> _legacyCache;
     private final CacheHandle _legacyCacheHandle;
     private final Meter _invalidationEventMeter;
+    private final Timer _reloadAllSubscriptionsTimer;
+    private final Meter _subscriptionsReloaded;
     private final CachingMode _cachingMode;
 
     @Inject
@@ -108,6 +111,8 @@ public class CachingSubscriptionDAO implements SubscriptionDAO {
         _cachingMode = checkNotNull(cachingMode, "cachingMode");
 
         Ticker ticker = ClockTicker.getTicker(clock);
+        _reloadAllSubscriptionsTimer = metricRegistry.timer(MetricRegistry.name("bv.emodb.databus", "CachingSubscriptionDAO", "reload-all-subscriptions"));
+        _subscriptionsReloaded = metricRegistry.meter(MetricRegistry.name("bv.emodb.databus", "CachingSubscriptionDAO", "subscriptions-reloaded"));
 
         // The all subscription cache is only used to track the set of all subscriptions and only has a single value.
         _allSubscriptionsCache = CacheBuilder.newBuilder()
@@ -117,20 +122,24 @@ public class CachingSubscriptionDAO implements SubscriptionDAO {
                 .build(new CacheLoader<String, List<OwnedSubscription>>() {
                     @Override
                     public List<OwnedSubscription> load(String key) throws Exception {
-                        assert SUBSCRIPTIONS.equals(key) : "All subscriptions cache should only be accessed by a single key";
+                        try (Timer.Context ignore = _reloadAllSubscriptionsTimer.time()) {
+                            assert SUBSCRIPTIONS.equals(key) : "All subscriptions cache should only be accessed by a single key";
 
-                        Iterable<String> subscriptionNames = _delegate.getAllSubscriptionNames();
-                        ImmutableList.Builder<OwnedSubscription> subscriptions = ImmutableList.builder();
+                            Iterable<String> subscriptionNames = _delegate.getAllSubscriptionNames();
+                            ImmutableList.Builder<OwnedSubscription> subscriptionsBuilder = ImmutableList.builder();
 
-                        for (String name : subscriptionNames) {
-                            // As much as possible take advantage of already cached subscriptions
-                            OwnedSubscription subscription = getSubscription(name);
-                            if (subscription != null) {
-                                subscriptions.add(subscription);
+                            for (String name : subscriptionNames) {
+                                // As much as possible take advantage of already cached subscriptions
+                                OwnedSubscription subscription = getSubscription(name);
+                                if (subscription != null) {
+                                    subscriptionsBuilder.add(subscription);
+                                }
                             }
-                        }
 
-                        return subscriptions.build();
+                            List<OwnedSubscription> subscriptions = subscriptionsBuilder.build();
+                            _subscriptionsReloaded.mark(subscriptions.size());
+                            return subscriptions;
+                        }
                     }
                 });
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Adding timers and metrics for fanout and subscription caching.

## How to Test and Verify

1. Check out this PR
2. Run Emo, make subscriptions, perform some updates
3. Verify metrics are updated

## Risk

### Level 

`Low` Only change is metrics.

### Required Testing

`Smoke`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
