### PR TITLE
Remove write rate spikes from migration

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultMigratorTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultMigratorTools.java
@@ -4,6 +4,7 @@ import com.bazaarvoice.emodb.sor.db.MigrationScanResult;
 import com.bazaarvoice.emodb.sor.db.MigratorReaderDAO;
 import com.bazaarvoice.emodb.sor.db.MigratorWriterDAO;
 import com.bazaarvoice.emodb.sor.db.ScanRange;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
 
 import java.util.Iterator;
@@ -22,10 +23,10 @@ public class DefaultMigratorTools implements MigratorTools {
     }
 
     @Override
-    public void writeRows(String placement, Iterator<MigrationScanResult> results, int maxWritesPerSecond) {
+    public void writeRows(String placement, Iterator<MigrationScanResult> results, RateLimiter rateLimiter) {
         checkNotNull(placement, "placement");
         checkNotNull(results, "rows");
-        _migratorWriterDao.writeRows(placement, results, maxWritesPerSecond);
+        _migratorWriterDao.writeRows(placement, results, rateLimiter);
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MigratorTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MigratorTools.java
@@ -3,13 +3,14 @@ package com.bazaarvoice.emodb.sor.core;
 
 import com.bazaarvoice.emodb.sor.db.MigrationScanResult;
 import com.bazaarvoice.emodb.sor.db.ScanRange;
+import com.google.common.util.concurrent.RateLimiter;
 
 import java.util.Iterator;
 
 // interface to migrate deltas from old tables to new tables with blocking
 public interface MigratorTools {
 
-    void writeRows(String placement, Iterator<MigrationScanResult> results, int maxWritesPerSecond);
+    void writeRows(String placement, Iterator<MigrationScanResult> results, RateLimiter rateLimiter);
 
     Iterator<MigrationScanResult> readRows(String placement, ScanRange scanRange);
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DAOUtils.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DAOUtils.java
@@ -8,17 +8,24 @@ import com.google.inject.Inject;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class DAOUtils {
 
     private final int _prefixLength;
     private final int _deltaBlockSize;
     private final byte[] _singleBlockBytes;
+    private final int _maxBlocks;
 
     @Inject
     public DAOUtils(@PrefixLength  int prefixLength, @BlockSize int deltaBlockSize) {
+        checkArgument(prefixLength > 0, "Prefix length must be greater than 0");
+        checkArgument(deltaBlockSize > 0, "Delta block size must be greater than 0");
+
         _prefixLength = prefixLength;
         _deltaBlockSize = deltaBlockSize;
         _singleBlockBytes = String.format("%0" + prefixLength + "X", 1).getBytes();
+        _maxBlocks = (int) Math.pow(16, _prefixLength) - 1;
     }
 
     public List<ByteBuffer> getDeltaBlocks(ByteBuffer encodedDelta) {
@@ -45,7 +52,7 @@ public class DAOUtils {
             numBlocks++;
         }
 
-        assert numBlocks < Math.pow(16, _deltaBlockSize);
+        checkArgument(numBlocks <= _maxBlocks, "Delta is too large, as it has exceeded to maximum number of blocks");
 
         byte[] blockBytes = numBlocks == 1 ? _singleBlockBytes : String.format("%0" + _prefixLength + "X", numBlocks).getBytes();
         for (int i = encodedDelta.position(); i < blockBytes.length ; i++) {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DAOUtils.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DAOUtils.java
@@ -25,6 +25,8 @@ public class DAOUtils {
         _prefixLength = prefixLength;
         _deltaBlockSize = deltaBlockSize;
         _singleBlockBytes = String.format("%0" + prefixLength + "X", 1).getBytes();
+
+        // this is the maximum number that can be using hexidecimal using the # of digits equal to prefix length
         _maxBlocks = (int) Math.pow(16, _prefixLength) - 1;
     }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/MigratorWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/MigratorWriterDAO.java
@@ -1,8 +1,10 @@
 package com.bazaarvoice.emodb.sor.db;
 
+import com.google.common.util.concurrent.RateLimiter;
+
 import java.util.Iterator;
 
 public interface MigratorWriterDAO {
 
-    void writeRows(String placement, Iterator<MigrationScanResult> results, int maxWritesPerSecond);
+    void writeRows(String placement, Iterator<MigrationScanResult> results, RateLimiter rateLimiter);
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
@@ -258,7 +258,7 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
     }
 
     @Override
-    public void writeRows(String placementName, Iterator<MigrationScanResult> iterator, int maxWritesPerSecond) {
+    public void writeRows(String placementName, Iterator<MigrationScanResult> iterator, RateLimiter rateLimiter) {
 
         if (!iterator.hasNext()) {
             return;
@@ -268,7 +268,6 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
         Session session = placement.getKeyspace().getCqlSession();
         BatchStatement statement = new BatchStatement(BatchStatement.Type.LOGGED);
         AtomicReference<Throwable> error = new AtomicReference<>();
-        RateLimiter rateLimiter = RateLimiter.create(maxWritesPerSecond);
         Phaser phaser = new Phaser();
         ByteBuffer lastRowKey = null;
         int currentStatementSize = 0;

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
+import com.google.common.util.concurrent.RateLimiter;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.joda.time.DateTime;
@@ -487,7 +488,7 @@ public class InMemoryDataReaderDAO implements DataReaderDAO, DataWriterDAO, Migr
     }
 
     @Override
-    public void writeRows(String placement, Iterator<MigrationScanResult> results, int maxWritesPerSecond) {
+    public void writeRows(String placement, Iterator<MigrationScanResult> results, RateLimiter rateLimiter) {
         throw new UnsupportedOperationException();
     }
 

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -55,6 +55,7 @@ dataCenter:
 
 systemOfRecord:
   migrationPhase: PRE_MIGRATION
+  deltaBlockSizeInKb: 8
   stashRoot: s3://emodb-us-east-1/stash/ci
 
   # Optional property - to exclude the tables satisfying the condition from the daily Stash run.

--- a/web-local/config-migrator.yaml
+++ b/web-local/config-migrator.yaml
@@ -36,6 +36,8 @@ dataCenter:
 
 
 systemOfRecord:
+  migrationPhase: DOUBLE_WRITE_LEGACY_READ
+  deltaBlockSizeInKb: 8
   stashRoot: s3://emodb-us-east-1/stash/ci
   # Where does the SoR store system information such as table definitions?
   systemTablePlacement: app_global:sys


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Currently, when migrating delta's, there exists a spike in the write rate to Cassandra once every minute. This occurs because every minute a new batch is written, and given a new rate limiter. The spike occurs when one batch finishes and a new one begins. When this happens, the rate doubles because the system can take advantage of permits from both the new and old rate limiters during the same second.

This PR fixes this issue by using the same rate limiter across batches, which prevents the situation detailed above from occurring.

Additionally, I noticed an issue in the DAOUtils class where the check for if a delta is too large was miscalculated, which i fixed.

## How to Test and Verify

1. Check out this PR
2. Run start-migrator-role-local.sh
3. Run a migration and attempt to throttle using the throttling endpoint.

Unfortunately, it is extremely difficult to prove this PR's effectiveness without running this on a system that can connect an analytics service (ex. Datadog) that can show the write rate staying consistent.

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

This is extremely low risk, as its scope is small and is unrelated to data consistency.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
