### PR TITLE
Updated streaming JSON response to remove buffering issues

### DIFF
--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/jersey/Unbuffered.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/jersey/Unbuffered.java
@@ -1,0 +1,11 @@
+package com.bazaarvoice.emodb.common.dropwizard.jersey;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Unbuffered {
+}

--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/jersey/UnbufferedStreamFilter.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/jersey/UnbufferedStreamFilter.java
@@ -1,0 +1,76 @@
+package com.bazaarvoice.emodb.common.dropwizard.jersey;
+
+import com.google.common.base.Stopwatch;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This filter is intended for responses which return a continuous stream of data but at a potentially slow rate.
+ * The filtered output stream ensures the response is flushed every 100ms.  This is not done asynchronously but is
+ * analyzed as the response is written.  Therefore to achieve the full benefit of this filter the resource should
+ * continuously write to the stream, such as with non-entity breaking whitespace, so there will always be data in the
+ * buffer to flush.
+ */
+public class UnbufferedStreamFilter implements Filter {
+
+    public final static String UNBUFFERED_HEADER = "X-BV-Unbuffered";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // Do nothing
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletResponse wrappedResponse = new HttpServletResponseWrapper((HttpServletResponse) response) {
+            @Override
+            public ServletOutputStream getOutputStream() throws IOException {
+                if (((HttpServletResponse) getResponse()).getHeader(UNBUFFERED_HEADER) == null) {
+                    return getResponse().getOutputStream();
+                }
+
+                return new ServletOutputStream() {
+                    Stopwatch flushStopwatch = Stopwatch.createStarted();
+
+                    @Override
+                    public void write(int b) throws IOException {
+                        getResponse().getOutputStream().write(b);
+                        maybeFlush();
+                    }
+
+                    @Override
+                    public void write(byte[] b, int off, int len) throws IOException {
+                        getResponse().getOutputStream().write(b, off, len);
+                        maybeFlush();
+                    }
+
+                    private void maybeFlush() throws IOException {
+                        if (flushStopwatch.elapsed(TimeUnit.MILLISECONDS) >= 100) {
+                            getResponse().flushBuffer();
+                            flushStopwatch.reset().start();
+                        }
+                    }
+                };
+            }
+        };
+
+        chain.doFilter(request, wrappedResponse);
+    }
+
+    @Override
+    public void destroy() {
+        // Do nothing
+    }
+}

--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/jersey/UnbufferedStreamResourceFilterFactory.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/jersey/UnbufferedStreamResourceFilterFactory.java
@@ -1,0 +1,43 @@
+package com.bazaarvoice.emodb.common.dropwizard.jersey;
+
+import com.google.common.collect.ImmutableList;
+import com.sun.jersey.api.model.AbstractMethod;
+import com.sun.jersey.spi.container.ContainerRequest;
+import com.sun.jersey.spi.container.ContainerRequestFilter;
+import com.sun.jersey.spi.container.ContainerResponse;
+import com.sun.jersey.spi.container.ContainerResponseFilter;
+import com.sun.jersey.spi.container.ResourceFilter;
+import com.sun.jersey.spi.container.ResourceFilterFactory;
+
+import java.util.List;
+
+/**
+ * Resource filter factory ensures that each resource annotated with {@link Unbuffered} will receive the header
+ * necessary for {@link UnbufferedStreamFilter} to serve the content unbuffered.
+ */
+public class UnbufferedStreamResourceFilterFactory implements ResourceFilterFactory, ResourceFilter, ContainerResponseFilter {
+
+    @Override
+    public List<ResourceFilter> create(AbstractMethod am) {
+        if (am.getResource().getAnnotation(Unbuffered.class) != null || am.getAnnotation(Unbuffered.class) != null) {
+            return ImmutableList.of(this);
+        }
+        return ImmutableList.of();
+    }
+
+    @Override
+    public ContainerRequestFilter getRequestFilter() {
+        return null;
+    }
+
+    @Override
+    public ContainerResponseFilter getResponseFilter() {
+        return this;
+    }
+
+    @Override
+    public ContainerResponse filter(ContainerRequest request, ContainerResponse response) {
+        response.getHttpHeaders().putSingle(UnbufferedStreamFilter.UNBUFFERED_HEADER, "true");
+        return response;
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -6,6 +6,8 @@ import com.bazaarvoice.emodb.cachemgr.invalidate.InvalidationService;
 import com.bazaarvoice.emodb.common.dropwizard.discovery.ManagedRegistration;
 import com.bazaarvoice.emodb.common.dropwizard.discovery.ResourceRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.jersey.ServerErrorResponseMetricsFilter;
+import com.bazaarvoice.emodb.common.dropwizard.jersey.UnbufferedStreamFilter;
+import com.bazaarvoice.emodb.common.dropwizard.jersey.UnbufferedStreamResourceFilterFactory;
 import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
 import com.bazaarvoice.emodb.common.dropwizard.metrics.EmoGarbageCollectorMetricSet;
 import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
@@ -192,6 +194,11 @@ public class EmoService extends Application<EmoConfiguration> {
         for (Class mapperType : ExceptionMappers.getMapperTypes()) {
             environment.jersey().register(mapperType);
         }
+
+        // Configure support for streaming JSON responses without long delays due to buffering
+        //noinspection unchecked
+        environment.jersey().getResourceConfig().getResourceFilterFactories().add(new UnbufferedStreamResourceFilterFactory());
+        environment.getApplicationContext().addFilter(new FilterHolder(new UnbufferedStreamFilter()), "/*", EnumSet.of(DispatcherType.REQUEST));
 
         // Create all the major EmoDB components using Guice.  Note: This code is organized such that almost all
         // initialization is complete before we register with Ostrich so we don't start receiving inbound requests

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.web.resources.sor;
 import com.bazaarvoice.emodb.auth.jersey.Authenticated;
 import com.bazaarvoice.emodb.auth.jersey.Subject;
 import com.bazaarvoice.emodb.common.api.UnauthorizedException;
+import com.bazaarvoice.emodb.common.dropwizard.jersey.Unbuffered;
 import com.bazaarvoice.emodb.common.json.JsonStreamingArrayParser;
 import com.bazaarvoice.emodb.common.json.LoggingIterator;
 import com.bazaarvoice.emodb.common.json.OrderedJson;
@@ -115,6 +116,7 @@ public class DataStoreResource1 {
     @GET
     @Path ("_table")
     @Timed (name = "bv.emodb.sor.DataStoreResource1.listTables", absolute = true)
+    @Unbuffered
     @ApiOperation (value = "Returns all the existing tables",
             notes = "Returns a Iterator of Table",
             response = Table.class
@@ -366,6 +368,7 @@ public class DataStoreResource1 {
     @GET
     @Path ("{table}")
     @RequiresPermissions ("sor|read|{table}")
+    @Unbuffered
     @Timed (name = "bv.emodb.sor.DataStoreResource1.scan", absolute = true)
     @ApiOperation (value = "Retrieves a list of content items in a particular table.",
             notes = "Retrieves a list of content items in a particular table.  To retrieve <em>all</em> items in a table set the\n" +
@@ -416,6 +419,7 @@ public class DataStoreResource1 {
     @Path ("_split/{table}/{split}")
     @RequiresPermissions ("sor|read|{table}")
     @ThrottleConcurrentRequests (maxRequests = 550)
+    @Unbuffered
     @Timed (name = "bv.emodb.sor.DataStoreResource1.getSplit", absolute = true)
     @ApiOperation (value = "Retrieves a list of content items in a particular table split.",
             notes = "Retrieves a list of content items in a particular table split.",


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

In https://github.com/bazaarvoice/emodb/pull/145 streaming DataStore responses were updated to inject whitespace in the response to handle large pauses caused by swaths of deleted content.  This turned out to be ineffective, however, since the response content was buffered for the first 32K.  This PR updates those streaming endpoints to regularly flush the response buffer, thereby truly providing a continuous stream of data.

## How to Test and Verify

Should just be regression checks.

## Risk

This is a low risk change.  The effects of the additional buffer flush calls will need to be evaluated at scale, but it should have nominal effect.

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
