### PR TITLE
Added tools for partitioned leadership election

### DIFF
--- a/common/dropwizard/pom.xml
+++ b/common/dropwizard/pom.xml
@@ -23,6 +23,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.bazaarvoice.emodb</groupId>
+            <artifactId>emodb-common-zookeeper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.bazaarvoice.curator</groupId>
             <artifactId>recipes</artifactId>
         </dependency>

--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/leader/LeaderServiceTask.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/leader/LeaderServiceTask.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.common.dropwizard.leader;
 
 import com.bazaarvoice.curator.recipes.leader.LeaderService;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
+import com.bazaarvoice.emodb.common.zookeeper.leader.PartitionedLeaderService;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -46,6 +47,13 @@ public class LeaderServiceTask extends Task {
                 unregister(name, leaderService);
             }
         }, MoreExecutors.sameThreadExecutor());
+    }
+
+    public void register(final String name, final PartitionedLeaderService partitionedLeaderService) {
+        int partition = 0;
+        for (LeaderService leaderService : partitionedLeaderService.getPartitionLeaderServices()) {
+            register(String.format("%s-%d", name, partition++), leaderService);
+        }
     }
 
     public void unregister(String name, LeaderService leaderService) {

--- a/common/zookeeper/pom.xml
+++ b/common/zookeeper/pom.xml
@@ -36,6 +36,11 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>com.bazaarvoice.curator</groupId>
+            <artifactId>test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/LoggingPartitionedService.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/LoggingPartitionedService.java
@@ -1,0 +1,83 @@
+package com.bazaarvoice.emodb.common.zookeeper.leader;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.AbstractService;
+import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.dropwizard.lifecycle.Managed;
+import org.apache.curator.framework.CuratorFramework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.time.Clock;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Sample implementation of a {@link PartitionedLeaderService}.  This service does nothing but log when leadership
+ * is gained or lost and maintain a metric of how many partitions it is currently leading.  Useful for testing.
+ */
+public class LoggingPartitionedService extends PartitionedLeaderService implements Managed {
+
+    private final Logger _log = LoggerFactory.getLogger(getClass());
+
+    private final String _serviceName;
+    private final AtomicInteger _ownedPartitions;
+
+    public LoggingPartitionedService(CuratorFramework curator, String leaderPath, String instanceId, String serviceName,
+                                     int numPartitions, long reacquireDelay, long repartitionDelay, TimeUnit delayUnit,
+                                     MetricRegistry metricRegistry, @Nullable Clock clock) {
+        super(curator, leaderPath, instanceId, serviceName, numPartitions, reacquireDelay, repartitionDelay, delayUnit, clock);
+        setServiceFactory(this::createServiceForPartition);
+        
+        _serviceName = serviceName;
+        _ownedPartitions = new AtomicInteger(0);
+        metricRegistry.register(
+                MetricRegistry.name("bv.emodb.LoggingPartitionedService", serviceName),
+                (Gauge) _ownedPartitions::intValue);
+    }
+
+    private Service createServiceForPartition(final int partition) {
+        return new AbstractService() {
+            private ExecutorService _service;
+            private CountDownLatch _latch = new CountDownLatch(1);
+
+            @Override
+            protected void doStart() {
+                _service = Executors.newSingleThreadExecutor(
+                        new ThreadFactoryBuilder().setNameFormat(String.format("%s-%d-%%d", _serviceName, partition)).build());
+                _service.submit(() -> {
+                    _log.info("{}-{}: Service started", _serviceName, partition);
+                    _ownedPartitions.incrementAndGet();
+                    try {
+                        while (!_service.isShutdown()) {
+                            try {
+                                _latch.await(5, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                if (!_service.isShutdown()) {
+                                    _log.info("{}-{}: Service thread interrupted prior to shutdown", _serviceName, partition);
+                                }
+                            }
+                        }
+                    } finally {
+                        _log.info("{}-{}: Service terminating", _serviceName, partition);
+                        _ownedPartitions.decrementAndGet();
+                    }
+                });
+                notifyStarted();
+            }
+
+            @Override
+            protected void doStop() {
+                _latch.countDown();
+                _service.shutdown();
+                notifyStopped();
+            }
+        };
+    }
+}

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderService.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderService.java
@@ -1,0 +1,310 @@
+package com.bazaarvoice.emodb.common.zookeeper.leader;
+
+import com.bazaarvoice.curator.recipes.leader.LeaderService;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.SettableFuture;
+import io.dropwizard.lifecycle.Managed;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.utils.ZKPaths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * There are circumstances where a service has multiple partitions and it is desirable to balance the workers for these
+ * partitions across the cluster.  {@link LeaderService} works for a single partition but doesn't allow for balancing
+ * leadership for multiple related leaders such as in our partitioned case.  This class uses multiple LeaderServices
+ * and makes a best effort to balance leadership across the cluster.
+ */
+public class PartitionedLeaderService implements Managed {
+
+    private static final Logger _log = LoggerFactory.getLogger(PartitionedLeaderService.class);
+
+    private static final String LEADER_PATH_PATTERN = "partition-%03d";
+
+    private final CuratorFramework _curator;
+    private final String _basePath;
+    private final String _instanceId;
+    private final String _serviceName;
+    private final int _numPartitions;
+    private final long _reacquireDelay;
+    private final long _repartitionDelay;
+    private final TimeUnit _delayUnit;
+    private final Clock _clock;
+    private final List<PartitionLeader> _partitionLeaders;
+
+    private PartitionedServiceSupplier _serviceFactory;
+    private PathChildrenCache _participantsCache;
+    private volatile int _maxPartitionsLeader;
+
+    public PartitionedLeaderService(CuratorFramework curator, String leaderPath, String instanceId, String serviceName,
+                                    int numPartitions, long reacquireDelay, long repartitionDelay, TimeUnit delayUnit,
+                                    PartitionedServiceSupplier serviceFactory, @Nullable Clock clock) {
+        this(curator, leaderPath, instanceId, serviceName, numPartitions, reacquireDelay, repartitionDelay, delayUnit, clock);
+        setServiceFactory(serviceFactory);
+    }
+
+    /**
+     * Constructor for subclasses.  The subclasses should call {@link #setServiceFactory(PartitionedServiceSupplier)}
+     * in their constructor.
+     */
+    protected PartitionedLeaderService(CuratorFramework curator, String leaderPath, String instanceId, String serviceName,
+                                                  int numPartitions, long reacquireDelay, long repartitionDelay, TimeUnit delayUnit,
+                                                  @Nullable Clock clock) {
+        _curator = curator;
+        _basePath = leaderPath;
+        _instanceId = instanceId;
+        _serviceName = serviceName;
+        _numPartitions = numPartitions;
+        _reacquireDelay = reacquireDelay;
+        _repartitionDelay = repartitionDelay;
+        _delayUnit = delayUnit;
+        _clock = Optional.ofNullable(clock).orElse(Clock.systemUTC());
+
+        _partitionLeaders = Lists.newArrayListWithCapacity(_numPartitions);
+        for (int partition = 0; partition < _numPartitions; partition++) {
+            _partitionLeaders.add(new PartitionLeader(partition));
+        }
+    }
+
+    final protected void setServiceFactory(PartitionedServiceSupplier serviceFactory) {
+        checkNotNull(serviceFactory, "serviceFactory");
+        if (_serviceFactory != null) {
+            throw new IllegalStateException("Service factory has already been set");
+        }
+        _serviceFactory = serviceFactory;
+    }
+
+    @Override
+    public void start() throws Exception {
+        if (_serviceFactory == null) {
+            throw new IllegalStateException("Cannot start service without first providing a service factory");
+        }
+        
+        String participantsPath = ZKPaths.makePath(_basePath, String.format(LEADER_PATH_PATTERN, 0));
+
+        // Watch the participants for partition 0 to determine how many potential leaders there are total
+        _participantsCache = new PathChildrenCache(_curator, participantsPath, true);
+        _participantsCache.getListenable().addListener((ignore1, ignore2) -> participantsUpdated(false));
+        _participantsCache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
+        participantsUpdated(true);
+        
+        List<Future<Void>> futures = Lists.newArrayListWithCapacity(_numPartitions);
+
+        for (PartitionLeader partitionLeader : _partitionLeaders) {
+            futures.add(partitionLeader.startAsync());
+        }
+
+        for (Future<Void> future : futures) {
+            future.get();
+        }
+    }
+
+    @Override
+    public void stop() throws Exception {
+        _participantsCache.close();
+
+        List<Future<Void>> futures = Lists.newArrayListWithCapacity(_numPartitions);
+        for (PartitionLeader partitionLeader : _partitionLeaders) {
+            futures.add(partitionLeader.stopAsync());
+        }
+
+        for (Future<Void> future : futures) {
+            future.get();
+        }
+    }
+
+    /**
+     * Returns the underlying leader services for each partition.  The services are guaranteed to be returned
+     * ordered by partition number.
+     */
+    public List<LeaderService> getPartitionLeaderServices() {
+        return _partitionLeaders.stream()
+                .map(PartitionLeader::getLeaderService)
+                .collect(Collectors.toList());
+    }
+
+    private synchronized void participantsUpdated(boolean initialUpdate) {
+        List<String> participantInstanceIds = _participantsCache.getCurrentData().stream()
+                .map(participant -> new String(participant.getData(), Charsets.UTF_8))
+                .sorted()
+                .collect(Collectors.toList());
+
+        if (participantInstanceIds.isEmpty()) {
+            // On the initial update there may be no participants if this is the only instance in the cluster.
+            // This is because the cache is started before the leader services.  For all but the initial update
+            // this should never happen since this instance at minimum is a participant.
+            if (!initialUpdate) {
+                _log.warn("Participant cache returned no participants");
+            }
+            participantInstanceIds = ImmutableList.of(_instanceId);
+        }
+
+        // If the partitions cannot be split evenly among the participants then the following uses the sorted
+        // participant instance IDs to deterministically allocate which instances get the extras.
+        int numParticipants = participantInstanceIds.size();
+        _maxPartitionsLeader = _numPartitions / numParticipants;
+        if (participantInstanceIds.indexOf(_instanceId) < _numPartitions % numParticipants) {
+            _maxPartitionsLeader += 1;
+        }
+
+        //
+        List<Integer> leadingPartitions = getLeadingPartitions();
+        int excessLeadership = leadingPartitions.size() - _maxPartitionsLeader;
+
+        while (excessLeadership > 0 && !leadingPartitions.isEmpty()) {
+            // This service owns more that it should given the new topology.  Voluntarily release the excess.
+            int leadingPartitionsIndex = (int) Math.floor(Math.random() * leadingPartitions.size());
+            int partitionToRelease = leadingPartitions.remove(leadingPartitionsIndex);
+            PartitionLeader partitionLeader = _partitionLeaders.get(partitionToRelease);
+
+            if (partitionLeader.relinquishLeadership()) {
+                excessLeadership -= 1;
+            }
+        }
+    }
+
+    public List<Integer> getLeadingPartitions() {
+        List<Integer> leadingPartitions = Lists.newArrayListWithCapacity(_numPartitions);
+        for (PartitionLeader partitionLeader : _partitionLeaders) {
+            if (partitionLeader.hasLeadership()) {
+                leadingPartitions.add(partitionLeader._partition);
+            }
+        }
+        return leadingPartitions;
+    }
+
+    /**
+     * Inner class to maintain leadership information about a single partition.
+     */
+    private class PartitionLeader {
+
+        private final int _partition;
+        private final LeaderService _leaderService;
+        private final SettableFuture<Void> _startedFuture = SettableFuture.create();
+        private final SettableFuture<Void> _terminatedFuture = SettableFuture.create();
+        private Instant _partitionReacquireTimeout = Instant.EPOCH;
+        private int _partitionReacquireRejections = 0;
+
+        PartitionLeader(int partition) {
+            _partition = partition;
+
+            String leaderPath = ZKPaths.makePath(_basePath, String.format(LEADER_PATH_PATTERN, partition));
+
+            _leaderService = new LeaderService(_curator, leaderPath, _instanceId, _serviceName,
+                    _reacquireDelay, _delayUnit, this::leadershipAcquired);
+
+            _leaderService.addListener(new Service.Listener() {
+                @Override
+                public void running() {
+                    _startedFuture.set(null);
+                }
+
+                @Override
+                public void terminated(Service.State from) {
+                    _terminatedFuture.set(null);
+                }
+            }, MoreExecutors.sameThreadExecutor());
+        }
+
+        Future<Void> startAsync() {
+            _leaderService.startAsync();
+            return _startedFuture;
+        }
+
+        Future<Void> stopAsync() {
+            _leaderService.stopAsync();
+            return _terminatedFuture;
+        }
+
+        Service leadershipAcquired() {
+            synchronized(PartitionedLeaderService.this) {
+                List<Integer> leadingPartitions = getLeadingPartitions();
+                //noinspection SuspiciousMethodCalls
+                leadingPartitions.remove((Object) _partition);
+
+                if (leadingPartitions.size() < _maxPartitionsLeader || _partitionReacquireRejections >= 3) {
+                    if (_partitionReacquireRejections >= 3) {
+                        _log.warn("Accepting leadership of partition {} for {} because no other server became leader after {} rejections",
+                                _partition, _serviceName, _partitionReacquireRejections);
+                    } else {
+                        _log.debug("Accepting leadership of partition {} for {}", _partition, _serviceName);
+                    }
+
+                    _partitionReacquireTimeout = Instant.EPOCH;
+                    _partitionReacquireRejections = 0;
+
+                    return _serviceFactory.createForPartition(_partition);
+                } else {
+                    if (_clock.instant().isAfter(_partitionReacquireTimeout)) {
+                        _log.info("Rejecting leadership of partition {} for {}, already own partitions {}",
+                                _partition, _serviceName, leadingPartitions);
+                        _partitionReacquireTimeout = _clock.instant().plusMillis(_delayUnit.toMillis(_repartitionDelay));
+                        _partitionReacquireRejections += 1;
+                    } else {
+                        _log.info("Rejecting leadership of partition {} for {} while in partition reacquire delay",
+                                _partition, _serviceName, leadingPartitions);
+                    }
+
+                    // Return a service which will immediately relinquish leadership
+                    return new RelinquishService();
+                }
+            }
+        }
+
+        boolean hasLeadership() {
+            if (!_leaderService.isRunning() || !_leaderService.hasLeadership()) {
+                return false;
+            }
+            // It's possible we technically have leadership but are in the process of giving it up because we already
+            // are leading the maximum number of partitions.  Verify that this isn't a rejected service.
+            Service delegateService = _leaderService.getCurrentDelegateService().orNull();
+            return delegateService == null || !(delegateService instanceof RelinquishService);
+        }
+        
+        boolean relinquishLeadership() {
+            if (hasLeadership()) {
+                // Release leadership by stopping the delegate service, but do not stop the leadership service itself
+                Service delegateService = _leaderService.getCurrentDelegateService().orNull();
+                if (delegateService != null) {
+                    _log.info("Relinquishing leadership of partition {} for {}", _partition, _serviceName);
+                    delegateService.stopAsync();
+                }
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        LeaderService getLeaderService() {
+            return _leaderService;
+        }
+    }
+
+    /**
+     * Service implementation which immediately returns having taken no action.  Used when the LeaderService gives
+     * a partition leadership when the total number of partitions already lead is at the maximum.
+     */
+    private static class RelinquishService extends AbstractExecutionThreadService {
+        @Override
+        protected void run() throws Exception {
+            // Do nothing
+        }
+    }
+}

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedServiceSupplier.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedServiceSupplier.java
@@ -1,0 +1,12 @@
+package com.bazaarvoice.emodb.common.zookeeper.leader;
+
+import com.google.common.util.concurrent.Service;
+
+/**
+ * Interface used by {@link PartitionedLeaderService} to get the service for handling a partition.
+ * Partition numbers are guaranteed to be in the range [0..numPartitions-1]
+ */
+public interface PartitionedServiceSupplier {
+
+    Service createForPartition(int partition);
+}

--- a/common/zookeeper/src/test/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderServiceTest.java
+++ b/common/zookeeper/src/test/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderServiceTest.java
@@ -44,7 +44,7 @@ public class PartitionedLeaderServiceTest {
             curator.start();
             
             PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/single", "instance0",
-                    "test-service", 3, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                    "test-service", 3, 1, 5000, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
 
             service.start();
 
@@ -77,7 +77,7 @@ public class PartitionedLeaderServiceTest {
                 curators.add(curator);
 
                 PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/multi", "instance" + i,
-                        "test-service", 10, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                        "test-service", 10, 1, 5000, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
                 service.start();
                 services.add(service);
             }
@@ -132,7 +132,7 @@ public class PartitionedLeaderServiceTest {
                 curators.add(curator);
 
                 PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/relinquish", "instance" + i,
-                        "test-service", 2, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                        "test-service", 2, 1, 5000, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
                 services.add(service);
             }
 

--- a/common/zookeeper/src/test/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderServiceTest.java
+++ b/common/zookeeper/src/test/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderServiceTest.java
@@ -1,0 +1,232 @@
+package com.bazaarvoice.emodb.common.zookeeper.leader;
+
+import com.bazaarvoice.curator.recipes.leader.LeaderService;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.Service;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.test.TestingServer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class PartitionedLeaderServiceTest {
+
+    private TestingServer _zookeeper;
+
+    @BeforeClass
+    private void setupZookeeper() throws Exception {
+        _zookeeper = new TestingServer();
+    }
+
+    @AfterClass
+    private void teardownZookeeper() throws Exception {
+        _zookeeper.close();
+    }
+
+    @Test
+    public void testSingleServer() throws Exception {
+        try (CuratorFramework curator = CuratorFrameworkFactory.newClient(_zookeeper.getConnectString(), new RetryNTimes(1, 10))) {
+            curator.start();
+            
+            PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/single", "instance0",
+                    "test-service", 3, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+
+            service.start();
+
+            List<LeaderService> leaderServices = service.getPartitionLeaderServices();
+            assertEquals(leaderServices.size(), 3, "Wrong number of services for the provided number of partitions");
+
+            // Give it 5 seconds to attain leadership on all 3 partitions
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            Set<Integer> leadPartitions = getLeadPartitions(service);
+
+            while (leadPartitions.size() != 3 && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+                leadPartitions = getLeadPartitions(service);
+            }
+
+            assertEquals(leadPartitions, ImmutableSet.of(0, 1, 2));
+            service.stop();
+        }
+    }
+
+    @Test
+    public void testMultiServer() throws Exception {
+        List<CuratorFramework> curators = Lists.newArrayListWithCapacity(3);
+
+        try {
+            List<PartitionedLeaderService> services = Lists.newArrayListWithCapacity(3);
+            for (int i=0; i < 3; i++) {
+                CuratorFramework curator = CuratorFrameworkFactory.newClient(_zookeeper.getConnectString(), new RetryNTimes(1, 10));
+                curator.start();
+                curators.add(curator);
+
+                PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/multi", "instance" + i,
+                        "test-service", 10, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                service.start();
+                services.add(service);
+            }
+
+
+            // Give it 5 seconds for leadership to be balanced.  With 10 partitions and 3 services this should
+            // be [4, 3, 3] since the first instance has the lowest instance ID.
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            List<Set<Integer>> leadPartitions = ImmutableList.of();
+
+            while (!leadPartitions.stream().map(Set::size).collect(Collectors.toList()).equals(ImmutableList.of(4, 3, 3)) && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+                leadPartitions = services.stream()
+                        .map(this::getLeadPartitions)
+                        .collect(Collectors.toList());
+            }
+
+            Set<Integer> unclaimedPartitions = Sets.newLinkedHashSet();
+            for (int i=0; i < 10; i++) {
+                unclaimedPartitions.add(i);
+            }
+
+            assertEquals(leadPartitions.size(), 3, "There should be three sets of partitions of leadership");
+            assertEquals(leadPartitions.get(0).size(), 4);
+            assertTrue(Sets.intersection(leadPartitions.get(0), unclaimedPartitions).equals(leadPartitions.get(0)));
+            unclaimedPartitions.removeAll(leadPartitions.get(0));
+            assertEquals(leadPartitions.get(1).size(), 3);
+            assertTrue(Sets.intersection(leadPartitions.get(1), unclaimedPartitions).equals(leadPartitions.get(1)));
+            unclaimedPartitions.removeAll(leadPartitions.get(1));
+            assertEquals(leadPartitions.get(2).size(), 3);
+            assertEquals(leadPartitions.get(2), unclaimedPartitions);
+
+            for (PartitionedLeaderService service : services) {
+                service.stop();
+            }
+        } finally {
+            for (CuratorFramework curator : curators) {
+                curator.close();
+            }
+        }
+    }
+
+    @Test
+    public void testRelinquish() throws Exception {
+        List<CuratorFramework> curators = Lists.newArrayListWithCapacity(2);
+
+        try {
+            List<PartitionedLeaderService> services = Lists.newArrayListWithCapacity(2);
+            for (int i=0; i < 2; i++) {
+                CuratorFramework curator = CuratorFrameworkFactory.newClient(_zookeeper.getConnectString(), new RetryNTimes(1, 10));
+                curator.start();
+                curators.add(curator);
+
+                PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/relinquish", "instance" + i,
+                        "test-service", 2, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                services.add(service);
+            }
+
+            // Start only the first service
+            services.get(0).start();
+
+            // Wait up to 5 seconds for the service to acquire leadership for both partitions
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            while (getLeadPartitions(services.get(0)).size() != 2 && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+            }
+
+            assertEquals(getLeadPartitions(services.get(0)).size(), 2, "Service should have acquired leadership for both partitions");
+
+            // Now start the second service
+            services.get(1).start();
+
+            // Wait for the first service to relinquish one partition and for the second service to acquire it
+            stopwatch.reset().start();
+            Set<Integer> leadPartitions0 = ImmutableSet.of();
+            Set<Integer> leadPartitions1 = ImmutableSet.of();
+
+            while ((leadPartitions0.size() != 1 || leadPartitions1.size() != 1) && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+                leadPartitions0 = getLeadPartitions(services.get(0));
+                leadPartitions1 = getLeadPartitions(services.get(1));
+            }
+
+            Set<Integer> leadPartitions = Sets.newLinkedHashSet();
+            assertEquals(leadPartitions0.size(), 1);
+            leadPartitions.addAll(leadPartitions0);
+            assertEquals(leadPartitions1.size(), 1);
+            leadPartitions.addAll(leadPartitions1);
+            assertEquals(leadPartitions, ImmutableSet.of(0, 1));
+
+            // Finally, kill the first service completely
+            services.get(0).stop();
+
+            // Wait for the second service to lead both partitions
+            stopwatch.reset().start();
+            leadPartitions1 = ImmutableSet.of();
+
+            while (!leadPartitions1.equals(ImmutableSet.of(0, 1)) && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+                leadPartitions1 = getLeadPartitions(services.get(1));
+            }
+
+            assertEquals(leadPartitions1, ImmutableSet.of(0, 1));
+
+            for (PartitionedLeaderService service : services) {
+                service.stop();
+            }
+        } finally {
+            for (CuratorFramework curator : curators) {
+                curator.close();
+            }
+        }
+    }
+
+    private Set<Integer> getLeadPartitions(PartitionedLeaderService partitionedLeaderService) {
+        Set<Integer> leadPartitions = Sets.newLinkedHashSet();
+
+        for (Integer partition : partitionedLeaderService.getLeadingPartitions()) {
+            // Don't just take the service's word for it; double check that the service is actually in the execution body
+            Service uncastDelegate = partitionedLeaderService.getPartitionLeaderServices().get(partition).getCurrentDelegateService().orNull();
+            TestLeaderService delegate = uncastDelegate != null && uncastDelegate instanceof TestLeaderService ?
+                    (TestLeaderService) uncastDelegate : null;
+            if (delegate != null && delegate.inBody) {
+                leadPartitions.add(delegate.partition);
+            }
+        }
+
+        return leadPartitions;
+    }
+
+    private class TestLeaderService extends AbstractExecutionThreadService {
+
+        final int partition;
+        volatile boolean inBody;
+
+        public TestLeaderService(int partition) {
+            this.partition = partition;
+        }
+
+        @Override
+        protected void run() throws Exception {
+            inBody = true;
+            try {
+                while (isRunning()) {
+                    Thread.sleep(10);
+                }
+            } finally {
+                inBody = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

As EmoDB use has grown in-house we're finding the master and inbound replication fanout services are unable to fanout fast enough to keep up with long periods of high-sustained writes.  This new level of write traffic is projected to become the norm, so there needs to be a way to fanout faster.

While we investigate longer-term solutions, such as improvements to the fanout process itself, shorter-term solution is to partition and distribute fanout across the entire cluster instead of limiting it to a single server determined by leadership election.  In order for this solution to work, however, EmoDB would need a leadership election recipe which evenly distributes the partitioned leadership across the cluster.  Otherwise a single cluster may become leader for every partition and become a bottleneck.

This PR provides a recipe for distributed leadership election for a partitioned service.  Features include:

- Best-effort even distribution of partition leaders across the cluster
- Dynamically re-allocating leadership as the size of the cluster changes
- Integration with LeaderTask to provide insights and management for leadership election  
- Fail-safe acceptance of leadership in out-of-bounds situations to ensure no partition is starved of leadership

## How to Test and Verify

While this PR includes the recipe it isn't actually in use anywhere yet.  The only way to verify is to run the unit tests.  If correctness-testing is an issue we can add a partitioned dummy service, such as the included `LoggingPartitionedService` just to verify that the process is working without adding any overhead to EmoDB.

## Risk

None.  As yet this PR does not introduce any live code.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
