### PR TITLE
Make rangeScanSplitSize and maxRangeScanTime configurable

### DIFF
--- a/web-local/config-scantest.yaml
+++ b/web-local/config-scantest.yaml
@@ -236,6 +236,14 @@ scanner:
     enableCloudWatchMetrics: false
     stashStateListeners:
       - class: com.bazaarvoice.emodb.plugin.stash.LoggingStashStateListener
+  scheduledScans:
+      default:
+        dailyScanTime: 18:00-6:00      # 6pm Central
+        maxRangeConcurrency: 4
+        requestRequired: false
+        maxRangeScanTime: 10m
+        placements:
+          - "ugc_global:ugc"
 
 # Configure the HTTP server that listens for inbound requests
 server:

--- a/web-local/config-scantest.yaml
+++ b/web-local/config-scantest.yaml
@@ -238,10 +238,10 @@ scanner:
       - class: com.bazaarvoice.emodb.plugin.stash.LoggingStashStateListener
   scheduledScans:
       default:
-        dailyScanTime: 18:00-6:00      # 6pm Central
+        dailyScanTime: 18:00-06:00      # 6pm Central
         maxRangeConcurrency: 4
         requestRequired: false
-        maxRangeScanTime: 10m
+#        maxRangeScanTime: PT10M
         placements:
           - "ugc_global:ugc"
 

--- a/web-local/pom.xml
+++ b/web-local/pom.xml
@@ -257,12 +257,58 @@
             <build>
                 <defaultGoal>verify</defaultGoal>
                 <plugins>
+                    <plugin>
+                        <groupId>com.bazaarvoice.emodb</groupId>
+                        <artifactId>emodb-sdk</artifactId>
+                        <version>${project.version}</version>
+                        <executions>
+                            <execution>
+                                <id>start-emodb-main</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <healthCheckPort>8081</healthCheckPort>
+                                    <cassandraRpcPort>9160</cassandraRpcPort>
+                                    <emoConfigurationFile>${project.basedir}/config-local.yaml</emoConfigurationFile>
+                                    <ddlConfigurationFile>${project.basedir}/config-ddl-local.yaml</ddlConfigurationFile>
+                                    <cassandraDir>${project.build.directory}/cassandra</cassandraDir>
+                                    <emoDir>emodb</emoDir>
+                                    <autoStartCassandra>false</autoStartCassandra>
+                                    <autoStartZookeeper>true</autoStartZookeeper>
+                                    <autoStartEmo>true</autoStartEmo>
+                                    <emoLogFile>${project.basedir}/target/emodb.log</emoLogFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-emodb-main</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                                <configuration>
+                                    <healthCheckPort>8081</healthCheckPort>
+                                    <cassandraRpcPort>9160</cassandraRpcPort>
+                                    <emoConfigurationFile>${project.basedir}/config-local.yaml</emoConfigurationFile>
+                                    <ddlConfigurationFile>${project.basedir}/config-ddl-local.yaml</ddlConfigurationFile>
+                                    <cassandraDir>${project.build.directory}/cassandra</cassandraDir>
+                                    <emoDir>emodb</emoDir>
+                                    <autoStartCassandra>false</autoStartCassandra>
+                                    <autoStartZookeeper>true</autoStartZookeeper>
+                                    <autoStartEmo>true</autoStartEmo>
+                                    <emoLogFile>${project.basedir}/target/emodb.log</emoLogFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <!-- Run the server using Jetty -->
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
                         <executions>
                             <execution>
+                                <id>start-emodb-scanner</id>
                                 <phase>integration-test</phase>
                                 <goals>
                                     <goal>java</goal>

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
@@ -260,7 +260,7 @@ public class ScanUploadModule extends PrivateModule {
             checkArgument(scheduledScanConfig.getMaxRangeConcurrency().isPresent(), "Max range concurrency not set");
             checkArgument(scheduledScanConfig.getScanByAZ().isPresent(), "Scan by availability zone is not set");
             checkArgument(scheduledScanConfig.getRangeScanSplitSize() > 0, "Max range scan split size must be > 0");
-            checkArgument(scheduledScanConfig.getMaxRangeScanTime().isLongerThan(Duration.ZERO), "Duration must be longer than zero");
+            checkArgument(scheduledScanConfig.getMaxRangeScanTime().toStandardDuration().isLongerThan(Duration.ZERO), "Duration must be longer than zero");
 
             ScanDestination destination = ScanDestination.to(dataStore.getStashRoot());
             DateTimeFormatter scanIdFormatter = DateTimeFormat.forPattern(scheduledScanConfig.getScanId().get()).withZoneUTC();
@@ -282,7 +282,7 @@ public class ScanUploadModule extends PrivateModule {
                     scheduledScanConfig.getScanByAZ().get(),
                     scheduledScanConfig.isRequestRequired(),
                     scheduledScanConfig.getRangeScanSplitSize(),
-                    scheduledScanConfig.getMaxRangeScanTime()));
+                    scheduledScanConfig.getMaxRangeScanTime().toStandardDuration()));
         }
 
         return scheduledScanUploads.build();

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
@@ -88,6 +88,7 @@ import com.google.inject.name.Names;
 import com.sun.jersey.api.client.Client;
 import io.dropwizard.setup.Environment;
 import org.apache.curator.framework.CuratorFramework;
+import org.joda.time.Duration;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.LoggerFactory;
@@ -257,6 +258,9 @@ public class ScanUploadModule extends PrivateModule {
             checkArgument(!scheduledScanConfig.getPlacements().isEmpty(), "Scheduled scan must contain at least one placement");
             checkArgument(scheduledScanConfig.getScanId().isPresent(), "Scan ID not set");
             checkArgument(scheduledScanConfig.getMaxRangeConcurrency().isPresent(), "Max range concurrency not set");
+            checkArgument(scheduledScanConfig.getScanByAZ().isPresent(), "Scan by availability zone is not set");
+            checkArgument(scheduledScanConfig.getRangeScanSplitSize() > 0, "Max range scan split size must be > 0");
+            checkArgument(scheduledScanConfig.getMaxRangeScanTime().isLongerThan(Duration.ZERO), "Duration must be longer than zero");
 
             ScanDestination destination = ScanDestination.to(dataStore.getStashRoot());
             DateTimeFormatter scanIdFormatter = DateTimeFormat.forPattern(scheduledScanConfig.getScanId().get()).withZoneUTC();
@@ -276,7 +280,9 @@ public class ScanUploadModule extends PrivateModule {
                     scheduledScanConfig.getPlacements(),
                     scheduledScanConfig.getMaxRangeConcurrency().get(),
                     scheduledScanConfig.getScanByAZ().get(),
-                    scheduledScanConfig.isRequestRequired()));
+                    scheduledScanConfig.isRequestRequired(),
+                    scheduledScanConfig.getRangeScanSplitSize(),
+                    scheduledScanConfig.getMaxRangeScanTime()));
         }
 
         return scheduledScanUploads.build();

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScheduledScanConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScheduledScanConfiguration.java
@@ -3,8 +3,7 @@ package com.bazaarvoice.emodb.web.scanner.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import org.joda.time.Duration;
-import org.joda.time.format.ISOPeriodFormat;
+import org.joda.time.Period;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -75,7 +74,7 @@ public class ScheduledScanConfiguration {
     @Valid
     @NotNull
     @JsonProperty ("maxRangeScanTime")
-    private String _maxRangeScanTime = "PT10M";
+    private Period _maxRangeScanTime = new Period("PT10M");
 
     public Optional<String> getDailyScanTime() {
         return _dailyScanTime;
@@ -149,12 +148,12 @@ public class ScheduledScanConfiguration {
         return this;
     }
 
-    public Duration getMaxRangeScanTime() {
-        return ISOPeriodFormat.standard().parsePeriod(_maxRangeScanTime).toStandardDuration();
+    public Period getMaxRangeScanTime() {
+        return _maxRangeScanTime;
     }
 
-    public ScheduledScanConfiguration setMaxRangeScanTime(Duration maxRangeScanTime) {
-        _maxRangeScanTime = maxRangeScanTime.toPeriod().toString();
+    public ScheduledScanConfiguration setMaxRangeScanTime(Period maxRangeScanTime) {
+        _maxRangeScanTime = maxRangeScanTime;
         return this;
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScheduledScanConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScheduledScanConfiguration.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.web.scanner.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import io.dropwizard.util.Duration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -61,6 +62,19 @@ public class ScheduledScanConfiguration {
     @NotNull
     @JsonProperty ("requestRequired")
     private boolean _requestRequired = false;
+
+    // Flag to indicate the maximum number of rows to scan in a single range scan task.
+    @Valid
+    @NotNull
+    @JsonProperty ("rangeScanSplitSize")
+    private int _rangeScanSplitSize = 1000000;
+
+    // Flag to indicate the maximum time a range scan can run before it is automatically stopped and remaining work
+    // split to a new task
+    @Valid
+    @NotNull
+    @JsonProperty ("maxRangeScanTime")
+    private Duration _maxRangeScanTime = Duration.minutes(10);
 
     public Optional<String> getDailyScanTime() {
         return _dailyScanTime;
@@ -122,6 +136,24 @@ public class ScheduledScanConfiguration {
 
     public ScheduledScanConfiguration setRequestRequired(boolean requestRequired) {
         _requestRequired = requestRequired;
+        return this;
+    }
+
+    public int getRangeScanSplitSize() {
+        return _rangeScanSplitSize;
+    }
+
+    public ScheduledScanConfiguration setRangeScanSplitSize(int rangeScanSplitSize) {
+        _rangeScanSplitSize = rangeScanSplitSize;
+        return this;
+    }
+
+    public org.joda.time.Duration getMaxRangeScanTime() {
+        return org.joda.time.Duration.millis(_maxRangeScanTime.toMilliseconds());
+    }
+
+    public ScheduledScanConfiguration setMaxRangeScanTime(Duration maxRangeScanTime) {
+        _maxRangeScanTime = maxRangeScanTime;
         return this;
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScheduledScanConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/config/ScheduledScanConfiguration.java
@@ -3,7 +3,8 @@ package com.bazaarvoice.emodb.web.scanner.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import io.dropwizard.util.Duration;
+import org.joda.time.Duration;
+import org.joda.time.format.ISOPeriodFormat;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -74,7 +75,7 @@ public class ScheduledScanConfiguration {
     @Valid
     @NotNull
     @JsonProperty ("maxRangeScanTime")
-    private Duration _maxRangeScanTime = Duration.minutes(10);
+    private String _maxRangeScanTime = "PT10M";
 
     public Optional<String> getDailyScanTime() {
         return _dailyScanTime;
@@ -148,12 +149,12 @@ public class ScheduledScanConfiguration {
         return this;
     }
 
-    public org.joda.time.Duration getMaxRangeScanTime() {
-        return org.joda.time.Duration.millis(_maxRangeScanTime.toMilliseconds());
+    public Duration getMaxRangeScanTime() {
+        return ISOPeriodFormat.standard().parsePeriod(_maxRangeScanTime).toStandardDuration();
     }
 
     public ScheduledScanConfiguration setMaxRangeScanTime(Duration maxRangeScanTime) {
-        _maxRangeScanTime = maxRangeScanTime;
+        _maxRangeScanTime = maxRangeScanTime.toPeriod().toString();
         return this;
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/resource/StashResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/resource/StashResource1.java
@@ -16,6 +16,8 @@ import io.dropwizard.jersey.params.DateTimeParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.format.ISOPeriodFormat;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -59,6 +61,8 @@ public class StashResource1 {
                                 @QueryParam ("byAZ") @DefaultValue ("true") Boolean byAZ,
                                 @QueryParam ("maxConcurrency") @DefaultValue ("4") Integer maxConcurrency,
                                 @QueryParam ("compactionEnabled") @DefaultValue ("false") Boolean compactionEnabled,
+                                @QueryParam ("rangeScanSplitSize") @DefaultValue("1000000") Integer rangeScanSplitSize,
+                                @QueryParam ("maxRangeScanTime") @DefaultValue("PT10M") String maxRangeScanTime,
                                 @QueryParam ("dryRun") @DefaultValue ("false") Boolean dryRun) {
 
         checkArgument(!placements.isEmpty(), "Placement is required");
@@ -86,7 +90,9 @@ public class StashResource1 {
                 .addDestinations(destinations)
                 .setScanByAZ(byAZ)
                 .setMaxConcurrentSubRangeScans(maxConcurrency)
-                .setCompactionEnabled(compactionEnabled);
+                .setCompactionEnabled(compactionEnabled)
+                .setRangeScanSplitSize(rangeScanSplitSize)
+                .setMaxRangeScanTime(ISOPeriodFormat.standard().parsePeriod(maxRangeScanTime).toStandardDuration());
 
         return _scanUploader.scanAndUpload(id, options, dryRun);
     }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScanUploadSchedulingService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScanUploadSchedulingService.java
@@ -269,7 +269,9 @@ public class ScanUploadSchedulingService extends LeaderService {
             ScanOptions scanOptions = new ScanOptions(scheduledScan.getPlacements())
                     .addDestination(destination)
                     .setMaxConcurrentSubRangeScans(scheduledScan.getMaxRangeConcurrency())
-                    .setScanByAZ(scheduledScan.isScanByAZ());
+                    .setScanByAZ(scheduledScan.isScanByAZ())
+                    .setRangeScanSplitSize(scheduledScan.getMaxRangeScanSplitSize())
+                    .setMaxRangeScanTime(scheduledScan.getMaxRangeScanTime());
 
             _log.info("Starting scheduled scan and upload to {} for time {}", destination, scheduledTime);
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScheduledDailyScanUpload.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScheduledDailyScanUpload.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.web.scanner.scheduling;
 import com.bazaarvoice.emodb.web.scanner.ScanDestination;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
@@ -23,12 +24,15 @@ public class ScheduledDailyScanUpload {
     private final List<String> _placements;
     private final int _maxRangeConcurrency;
     private final boolean _scanByAZ;
-    private final boolean requestRequired;
+    private final boolean _requestRequired;
+    private final int _maxRangeScanSplitSize;
+    private final Duration _maxRangeScanTime;
 
     public ScheduledDailyScanUpload(String id, String timeOfDay, DateTimeFormatter scanIdFormat,
                                     ScanDestination rootDestination, DateTimeFormatter directoryFormat,
                                     List<String> placements, int maxRangeConcurrency,
-                                    boolean scanByAZ, boolean requestRequired) {
+                                    boolean scanByAZ, boolean requestRequired,
+                                    int maxRangeScanSplitSize, Duration maxRangeScanTime) {
         _id = id;
         _timeOfDay = timeOfDay;
         _scanIdFormat = scanIdFormat;
@@ -37,7 +41,9 @@ public class ScheduledDailyScanUpload {
         _placements = placements;
         _maxRangeConcurrency = maxRangeConcurrency;
         _scanByAZ = scanByAZ;
-        this.requestRequired = requestRequired;
+        _requestRequired = requestRequired;
+        _maxRangeScanSplitSize = maxRangeScanSplitSize;
+        _maxRangeScanTime = maxRangeScanTime;
     }
 
     public String getId() {
@@ -72,8 +78,16 @@ public class ScheduledDailyScanUpload {
         return _scanByAZ;
     }
 
+    public int getMaxRangeScanSplitSize() {
+        return _maxRangeScanSplitSize;
+    }
+
+    public Duration getMaxRangeScanTime() {
+        return _maxRangeScanTime;
+    }
+
     public boolean isRequestRequired() {
-        return requestRequired;
+        return _requestRequired;
     }
 
     /**

--- a/web/src/test/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScanUploadSchedulingServiceTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScanUploadSchedulingServiceTest.java
@@ -104,11 +104,11 @@ public class ScanUploadSchedulingServiceTest {
         ScheduledDailyScanUpload pastScanUpload =
                 new ScheduledDailyScanUpload("daily", pastTimeOfDay, DateTimeFormat.forPattern("'past'-yyyyMMddHHmmss").withZoneUTC(),
                         ScanDestination.discard(), DateTimeFormat.forPattern("yyyyMMddHHmmss").withZoneUTC(),
-                        ImmutableList.of("placement1"), 1, true, false);
+                        ImmutableList.of("placement1"), 1, true, false, 1000000, Duration.standardMinutes(10));
         ScheduledDailyScanUpload futureScanUpload =
                 new ScheduledDailyScanUpload("daily", futureTimeOfDay, DateTimeFormat.forPattern("'future'-yyyyMMddHHmmss").withZoneUTC(),
                         ScanDestination.discard(),DateTimeFormat.forPattern("yyyyMMddHHmmss").withZoneUTC(),
-                        ImmutableList.of("placement2"), 1, true, false);
+                        ImmutableList.of("placement2"), 1, true, false, 1000000, Duration.standardMinutes(10));
 
         List<ScheduledDailyScanUpload> scheduledScans = ImmutableList.of(pastScanUpload, futureScanUpload);
 
@@ -168,7 +168,7 @@ public class ScanUploadSchedulingServiceTest {
             scheduledScans.add(
                     new ScheduledDailyScanUpload("daily", timeOfDay, DateTimeFormat.forPattern("'test'-yyyyMMddHHmmss").withZoneUTC(),
                             ScanDestination.discard(), DateTimeFormat.forPattern("yyyyMMddHHmmss").withZoneUTC(),
-                            ImmutableList.of("placement1"), 1, true, false));
+                            ImmutableList.of("placement1"), 1, true, false, 1000000, Duration.standardMinutes(10)));
         }
 
         ScanUploadSchedulingService.DelegateSchedulingService service =
@@ -208,7 +208,7 @@ public class ScanUploadSchedulingServiceTest {
         ScheduledDailyScanUpload scanUpload =
                 new ScheduledDailyScanUpload("daily", timeOfDay, DateTimeFormat.forPattern("'test'-yyyyMMddHHmmss").withZoneUTC(),
                         destination, DateTimeFormat.forPattern("yyyyMMddHHmmss").withZoneUTC(),
-                        ImmutableList.of("placement1"), 1, true, false);
+                        ImmutableList.of("placement1"), 1, true, false, 1000000, Duration.standardMinutes(10));
 
         ScanUploader scanUploader = mock(ScanUploader.class);
         StashRequestManager stashRequestManager = mock(StashRequestManager.class);
@@ -248,7 +248,7 @@ public class ScanUploadSchedulingServiceTest {
         ScheduledDailyScanUpload scanUpload =
                 new ScheduledDailyScanUpload("daily", timeOfDay, DateTimeFormat.forPattern("'test'-yyyyMMddHHmmss").withZoneUTC(),
                         destination, DateTimeFormat.forPattern("yyyyMMddHHmmss").withZoneUTC(),
-                        ImmutableList.of("placement1"), 1, true, false);
+                        ImmutableList.of("placement1"), 1, true, false, 1000000, Duration.standardMinutes(10));
 
         String expectedScanId = DateTimeFormat.forPattern("'test'-yyyyMMddHHmmss").withZoneUTC().print(now);
 
@@ -292,7 +292,7 @@ public class ScanUploadSchedulingServiceTest {
 
         ScheduledDailyScanUpload upload = new ScheduledDailyScanUpload(
                 "daily", startTime, DateTimeFormat.longDateTime(), ScanDestination.discard(), DateTimeFormat.longDateTime(),
-                ImmutableList.of("catalog_global:cat"), 5, true, false);
+                ImmutableList.of("catalog_global:cat"), 5, true, false, 1000000, Duration.standardMinutes(10));
 
         ScanParticipationService service = new ScanParticipationService(
                 ImmutableList.of(upload), stashStateListener, lifecycle, clock);
@@ -348,11 +348,11 @@ public class ScanUploadSchedulingServiceTest {
         ScheduledDailyScanUpload pastScanUpload =
                 new ScheduledDailyScanUpload("past", pastTimeOfDay, DateTimeFormat.forPattern("'past'-yyyyMMddHHmmss").withZoneUTC(),
                         ScanDestination.discard(), DateTimeFormat.forPattern("yyyyMMddHHmmss").withZoneUTC(),
-                        ImmutableList.of("placement1"), 1, true, true);
+                        ImmutableList.of("placement1"), 1, true, true, 1000000, Duration.standardMinutes(10));
         ScheduledDailyScanUpload futureScanUpload =
                 new ScheduledDailyScanUpload("future", futureTimeOfDay, DateTimeFormat.forPattern("'future'-yyyyMMddHHmmss").withZoneUTC(),
                         ScanDestination.discard(),DateTimeFormat.forPattern("yyyyMMddHHmmss").withZoneUTC(),
-                        ImmutableList.of("placement2"), 1, true, true);
+                        ImmutableList.of("placement2"), 1, true, true, 1000000, Duration.standardMinutes(10));
 
         List<ScheduledDailyScanUpload> scheduledScans = ImmutableList.of(pastScanUpload, futureScanUpload);
 

--- a/web/src/test/java/com/bazaarvoice/emodb/web/scanner/scheduling/StashRequestManagerTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/scanner/scheduling/StashRequestManagerTest.java
@@ -8,6 +8,7 @@ import com.bazaarvoice.emodb.web.scanner.scanstatus.StashRequestDAO;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.ISODateTimeFormat;
 import org.testng.annotations.BeforeMethod;
@@ -37,10 +38,10 @@ public class StashRequestManagerTest {
         List<ScheduledDailyScanUpload> scanUploads = ImmutableList.of(
                 new ScheduledDailyScanUpload("always", "00:00Z", DateTimeFormat.forPattern("'always'-yyyy-MM-dd-HH-mm-ss"),
                         ScanDestination.discard(), DateTimeFormat.forPattern("'dest'-yyyy-MM-dd-HH-mm-ss"),
-                        ImmutableList.of("ugc_global:ugc"), 4, true, false),
+                        ImmutableList.of("ugc_global:ugc"), 4, true, false, 1000000, Duration.standardMinutes(10)),
                 new ScheduledDailyScanUpload("byrequest", "12:00Z", DateTimeFormat.forPattern("'byrequest'-yyyy-MM-dd-HH-mm-ss"),
                         ScanDestination.discard(), DateTimeFormat.forPattern("'dest'-yyyy-MM-dd-HH-mm-ss"),
-                        ImmutableList.of("ugc_global:ugc"), 4, true, true)
+                        ImmutableList.of("ugc_global:ugc"), 4, true, true, 1000000, Duration.standardMinutes(10))
         );
 
         _stashRequestManager = new StashRequestManager(_stashRequestDAO, scanUploads, _clock);


### PR DESCRIPTION
## Github Issue #
None

## What Are We Doing Here?

Stash has an existing internal ability to configure both the size of its splits and the maximum time it spends on a split. However, these values have not been externally configurable via the main api endpoint or the .yaml configuration for scheduled stashes. 

Additionally, I modified the local stash script to be able to be run without having an existing emo web instance running. For me personally, this makes things much easier to test, but I will happily remove it if anybody disagrees.

## How to Test and Verify

1. Start Stash using web-local/start-stash-role.sh
2. Use the Stash API on port 8780 to verify the new query parameters work as expected.
3. Open the stash configuration and modify the existing values for these new parameters and verify they work as expected.

Note: The yaml format for duration and the REST format for duration are different. I did this in order to stay consistent with the formats for the existing duration values in both interfaces.

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

This is incredibly low risk, as it is essentially just a few extra getters and setters.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
