### PR TITLE
Create deterministic pool of table mutexes

### DIFF
--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -216,7 +216,7 @@ public class BlobStoreModule extends PrivateModule {
     Optional<TableMutexManager> provideTableMutexManager(DataCenterConfiguration dataCenterConfiguration, @BlobStoreZooKeeper CuratorFramework curator) {
         // We only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            return Optional.of(new TableMutexManager(curator, "locks/tables", "/lock/table-partitions"));
+            return Optional.of(new TableMutexManager(curator, "/lock/tables", "/lock/table-partitions"));
         }
         return Optional.absent();
     }

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -214,12 +214,16 @@ public class BlobStoreModule extends PrivateModule {
     }
     
     @Provides @Singleton
-    Optional<Mutex> provideMutex(DataCenterConfiguration dataCenterConfiguration, @BlobStoreZooKeeper CuratorFramework curator) {
+    Optional<Mutex>[] provideMutexes(DataCenterConfiguration dataCenterConfiguration, @BlobStoreZooKeeper CuratorFramework curator) {
         // We only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            return Optional.<Mutex>of(new CuratorMutex(curator, "/lock/tables"));
+            Optional<Mutex>[] mutexes = new Optional[256];
+            for (int i = 0; i < mutexes.length; i++) {
+                mutexes[i] = Optional.<Mutex>of(new CuratorMutex(curator, "/lock/tables/" + i));
+            }
+            return mutexes;
         }
-        return Optional.absent();
+        return new Optional[] { Optional.absent() };
     }
 
 

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -216,7 +216,7 @@ public class BlobStoreModule extends PrivateModule {
     Optional<TableMutexManager> provideTableMutexManager(DataCenterConfiguration dataCenterConfiguration, @BlobStoreZooKeeper CuratorFramework curator) {
         // We only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            return Optional.of(new TableMutexManager(curator, "/lock/tables"));
+            return Optional.of(new TableMutexManager(curator, "locks/tables", "/lock/table-partitions"));
         }
         return Optional.absent();
     }

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -32,7 +32,6 @@ import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.api.KeyspaceDiscovery;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.table.db.ClusterInfo;
-import com.bazaarvoice.emodb.table.db.Mutex;
 import com.bazaarvoice.emodb.table.db.ShardsPerTable;
 import com.bazaarvoice.emodb.table.db.TableChangesEnabled;
 import com.bazaarvoice.emodb.table.db.TableDAO;
@@ -69,7 +68,7 @@ import com.bazaarvoice.emodb.table.db.consistency.HintsPollerManager;
 import com.bazaarvoice.emodb.table.db.consistency.MinLagConsistencyTimeProvider;
 import com.bazaarvoice.emodb.table.db.consistency.MinLagDurationTask;
 import com.bazaarvoice.emodb.table.db.consistency.MinLagDurationValues;
-import com.bazaarvoice.emodb.table.db.curator.CuratorMutex;
+import com.bazaarvoice.emodb.table.db.curator.TableMutexManager;
 import com.bazaarvoice.emodb.table.db.generic.CachingTableDAO;
 import com.bazaarvoice.emodb.table.db.generic.CachingTableDAODelegate;
 import com.bazaarvoice.emodb.table.db.generic.CachingTableDAORegistry;
@@ -212,18 +211,14 @@ public class BlobStoreModule extends PrivateModule {
             return new BlobStoreProviderProxy(localBlobStoreProvider, systemBlobStoreProvider);
         }
     }
-    
+
     @Provides @Singleton
-    Optional<Mutex>[] provideMutexes(DataCenterConfiguration dataCenterConfiguration, @BlobStoreZooKeeper CuratorFramework curator) {
+    Optional<TableMutexManager> provideTableMutexManager(DataCenterConfiguration dataCenterConfiguration, @BlobStoreZooKeeper CuratorFramework curator) {
         // We only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            Optional<Mutex>[] mutexes = new Optional[256];
-            for (int i = 0; i < mutexes.length; i++) {
-                mutexes[i] = Optional.<Mutex>of(new CuratorMutex(curator, "/lock/tables/" + i));
-            }
-            return mutexes;
+            return Optional.of(new TableMutexManager(curator, "/lock/tables"));
         }
-        return new Optional[] { Optional.absent() };
+        return Optional.absent();
     }
 
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -257,12 +257,16 @@ public class DataStoreModule extends PrivateModule {
     }
 
     @Provides @Singleton
-    Optional<Mutex> provideMutex(DataCenterConfiguration dataCenterConfiguration, @DataStoreZooKeeper CuratorFramework curator) {
+    Optional<Mutex>[] provideMutexes(DataCenterConfiguration dataCenterConfiguration, @DataStoreZooKeeper CuratorFramework curator) {
         // We only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            return Optional.<Mutex>of(new CuratorMutex(curator, "/lock/tables"));
+            Optional<Mutex>[] mutexes = new Optional[256];
+            for (int i = 0; i < mutexes.length; i++) {
+                mutexes[i] = Optional.<Mutex>of(new CuratorMutex(curator, "/lock/tables/" + i));
+            }
+            return mutexes;
         }
-        return Optional.absent();
+        return new Optional[] { Optional.absent() };
     }
 
     @Provides @Singleton

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -260,7 +260,7 @@ public class DataStoreModule extends PrivateModule {
     Optional<TableMutexManager> provideTableMutexManager(DataCenterConfiguration dataCenterConfiguration, @DataStoreZooKeeper CuratorFramework curator) {
         // We only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            return Optional.of(new TableMutexManager(curator, "locks/tables", "/lock/table-partitions"));
+            return Optional.of(new TableMutexManager(curator, "/lock/tables", "/lock/table-partitions"));
         }
         return Optional.absent();
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -260,7 +260,7 @@ public class DataStoreModule extends PrivateModule {
     Optional<TableMutexManager> provideTableMutexManager(DataCenterConfiguration dataCenterConfiguration, @DataStoreZooKeeper CuratorFramework curator) {
         // We only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            return Optional.of(new TableMutexManager(curator, "/lock/tables"));
+            return Optional.of(new TableMutexManager(curator, "locks/tables", "/lock/table-partitions"));
         }
         return Optional.absent();
     }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/MaintenanceSchedulerManager.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/MaintenanceSchedulerManager.java
@@ -8,8 +8,8 @@ import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
 import com.bazaarvoice.emodb.common.zookeeper.store.GuavaServiceController;
 import com.bazaarvoice.emodb.common.zookeeper.store.ValueStore;
-import com.bazaarvoice.emodb.table.db.Mutex;
 import com.bazaarvoice.emodb.table.db.TableChangesEnabled;
+import com.bazaarvoice.emodb.table.db.curator.TableMutexManager;
 import com.bazaarvoice.emodb.table.db.generic.CachingTableDAORegistry;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
@@ -28,7 +28,7 @@ public class MaintenanceSchedulerManager {
     @Inject
     public MaintenanceSchedulerManager(LifeCycleRegistry lifeCycle,
                                        final MaintenanceDAO tableDao,
-                                       final Optional<Mutex> metadataMutex,
+                                       final Optional<TableMutexManager> tableMutexManager,
                                        @CurrentDataCenter final String selfDataCenter,
                                        @CachingTableDAORegistry final CacheRegistry cacheRegistry,
                                        @Maintenance final CuratorFramework curator,
@@ -41,7 +41,7 @@ public class MaintenanceSchedulerManager {
         final Supplier<Service> maintenanceServiceFactory = new Supplier<Service>() {
             @Override
             public Service get() {
-                return new MaintenanceScheduler(tableDao, metadataMutex, selfDataCenter, cacheRegistry, moveTableTask);
+                return new MaintenanceScheduler(tableDao, tableMutexManager, selfDataCenter, cacheRegistry, moveTableTask);
             }
         };
 

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/CuratorMutex.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/CuratorMutex.java
@@ -33,8 +33,7 @@ public class CuratorMutex implements Mutex {
         }
     }
 
-    // temporarily public for table mutex migration
-    public InterProcessMutex acquire(Duration acquireTimeout) {
+    private InterProcessMutex acquire(Duration acquireTimeout) {
         InterProcessMutex mutex = new InterProcessMutex(_curatorFramework, _path);
         try {
             if (!mutex.acquire(acquireTimeout.getMillis(), TimeUnit.MILLISECONDS)) {
@@ -46,8 +45,7 @@ public class CuratorMutex implements Mutex {
         return mutex;
     }
     
-    // temporarily public for table mutex migration
-    public void release(InterProcessMutex mutex) {
+    private void release(InterProcessMutex mutex) {
         try {
             mutex.release();
         } catch (Exception e) {

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/CuratorMutex.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/CuratorMutex.java
@@ -33,7 +33,8 @@ public class CuratorMutex implements Mutex {
         }
     }
 
-    private InterProcessMutex acquire(Duration acquireTimeout) {
+    // temporarily public for table mutex migration
+    public InterProcessMutex acquire(Duration acquireTimeout) {
         InterProcessMutex mutex = new InterProcessMutex(_curatorFramework, _path);
         try {
             if (!mutex.acquire(acquireTimeout.getMillis(), TimeUnit.MILLISECONDS)) {
@@ -44,8 +45,9 @@ public class CuratorMutex implements Mutex {
         }
         return mutex;
     }
-
-    private void release(InterProcessMutex mutex) {
+    
+    // temporarily public for table mutex migration
+    public void release(InterProcessMutex mutex) {
         try {
             mutex.release();
         } catch (Exception e) {

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
@@ -25,11 +25,11 @@ public class TableMutexManager {
 
     public void runWithLockForTable(Runnable runnable, Duration acquireTimeout, String table) {
 
-        InterProcessMutex mutex = _oldMutex.acquire(acquireTimeout);
 
-        _mutexes[Math.abs(Hashing.murmur3_128().hashString(table, Charsets.UTF_8).asInt() % NUM_MUTEXES)]
-                .runWithLock(runnable, acquireTimeout);
+        _oldMutex.runWithLock(() -> {
+            _mutexes[Math.abs(Hashing.murmur3_128().hashString(table, Charsets.UTF_8).asInt() % NUM_MUTEXES)]
+                            .runWithLock(runnable, acquireTimeout);
+        }, acquireTimeout);
 
-        _oldMutex.release(mutex);
     }
 }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
@@ -1,0 +1,23 @@
+package com.bazaarvoice.emodb.table.db.curator;
+
+import com.bazaarvoice.emodb.table.db.Mutex;
+import org.apache.curator.framework.CuratorFramework;
+import org.joda.time.Duration;
+
+public class TableMutexManager {
+
+    private static final int NUM_MUTEXES = 256;
+
+    private final Mutex[] _mutexes;
+
+    public TableMutexManager(CuratorFramework curator, String path) {
+        _mutexes = new Mutex[NUM_MUTEXES];
+        for (int i = 0; i < NUM_MUTEXES; i++) {
+            _mutexes[i] = new CuratorMutex(curator, path + "/" + i);
+        }
+    }
+
+    public void runWithLockForTable(Runnable runnable, Duration acquireTimeout, String table) {
+        _mutexes[table.hashCode() % NUM_MUTEXES].runWithLock(runnable, acquireTimeout);
+    }
+}

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
@@ -18,6 +18,6 @@ public class TableMutexManager {
     }
 
     public void runWithLockForTable(Runnable runnable, Duration acquireTimeout, String table) {
-        _mutexes[table.hashCode() % NUM_MUTEXES].runWithLock(runnable, acquireTimeout);
+        _mutexes[Math.abs(table.hashCode() % NUM_MUTEXES)].runWithLock(runnable, acquireTimeout);
     }
 }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
@@ -1,7 +1,11 @@
 package com.bazaarvoice.emodb.table.db.curator;
 
 import com.bazaarvoice.emodb.table.db.Mutex;
+import com.google.common.base.Charsets;
+import com.google.common.hash.Hashing;
 import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+import org.apache.curator.utils.ZKPaths;
 import org.joda.time.Duration;
 
 public class TableMutexManager {
@@ -9,15 +13,23 @@ public class TableMutexManager {
     private static final int NUM_MUTEXES = 256;
 
     private final Mutex[] _mutexes;
+    private final CuratorMutex _oldMutex;
 
-    public TableMutexManager(CuratorFramework curator, String path) {
+    public TableMutexManager(CuratorFramework curator, String oldPath, String newPath) {
         _mutexes = new Mutex[NUM_MUTEXES];
         for (int i = 0; i < NUM_MUTEXES; i++) {
-            _mutexes[i] = new CuratorMutex(curator, path + "/" + i);
+            _mutexes[i] = new CuratorMutex(curator, ZKPaths.makePath(newPath, Integer.toString(i)));
         }
+        _oldMutex = new CuratorMutex(curator, oldPath);
     }
 
     public void runWithLockForTable(Runnable runnable, Duration acquireTimeout, String table) {
-        _mutexes[Math.abs(table.hashCode() % NUM_MUTEXES)].runWithLock(runnable, acquireTimeout);
+
+        InterProcessMutex mutex = _oldMutex.acquire(acquireTimeout);
+
+        _mutexes[Math.abs(Hashing.murmur3_128().hashString(table, Charsets.UTF_8).asInt() % NUM_MUTEXES)]
+                .runWithLock(runnable, acquireTimeout);
+
+        _oldMutex.release(mutex);
     }
 }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/generic/MutexTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/generic/MutexTableDAO.java
@@ -189,7 +189,7 @@ public class MutexTableDAO implements TableDAO {
     }
 
     private void withLock(Runnable runnable, String table) {
-        if (_mutexManager.isPresent()) {
+        if (!_mutexManager.isPresent()) {
             throw new UnsupportedOperationException(
                     "The table metadata mutex is unavailable from this data center. " +
                     "Make sure that the `systemDataCenter` property points to the right system datacenter. " +


### PR DESCRIPTION
## Github Issue #
None

## What Are We Doing Here?

Any operation which updates a table's or facade's DDL (create table, drop table, set table attributes, etc) is protected by a global mutex lock. 

Our current implementation has two detrimental attributes:

1. The timeout for acquiring the mutex is 30 seconds, which is likely longer than many client's connection timeout
2. There is a single mutex for all table operations. This mutex prevents concurrent updates to the same table.

To fix this, I split the single mutex into multiple mutexes. I created a fixed number of mutexes and now emo will lock on a mutex based on a hash of the table name. Additionally, I lowered the timeout to 5 seconds.

## How to Test and Verify

Testing this PR is difficult, as it is difficult to prove any race condition. By result, most of the testing I have done so far has just been the usually battery of table creation and modification tests.

I welcome any suggestions on how to test this further.

## Risk

### Level 

`High`

### Required Testing

`Regression`

### Risk Summary

This is actually pretty risky, as the consequences could be pretty severe if there is a race condition that I am missing.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
