### PR TITLE
Partitioned the fanout queues

### DIFF
--- a/common/dropwizard/pom.xml
+++ b/common/dropwizard/pom.xml
@@ -23,6 +23,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.bazaarvoice.emodb</groupId>
+            <artifactId>emodb-common-zookeeper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.bazaarvoice.curator</groupId>
             <artifactId>recipes</artifactId>
         </dependency>

--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/leader/LeaderServiceTask.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/leader/LeaderServiceTask.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.common.dropwizard.leader;
 
 import com.bazaarvoice.curator.recipes.leader.LeaderService;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
+import com.bazaarvoice.emodb.common.zookeeper.leader.PartitionedLeaderService;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -46,6 +47,13 @@ public class LeaderServiceTask extends Task {
                 unregister(name, leaderService);
             }
         }, MoreExecutors.sameThreadExecutor());
+    }
+
+    public void register(final String name, final PartitionedLeaderService partitionedLeaderService) {
+        int partition = 0;
+        for (LeaderService leaderService : partitionedLeaderService.getPartitionLeaderServices()) {
+            register(String.format("%s-%d", name, partition++), leaderService);
+        }
     }
 
     public void unregister(String name, LeaderService leaderService) {

--- a/common/zookeeper/pom.xml
+++ b/common/zookeeper/pom.xml
@@ -36,6 +36,11 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>com.bazaarvoice.curator</groupId>
+            <artifactId>test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/LoggingPartitionedService.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/LoggingPartitionedService.java
@@ -1,0 +1,83 @@
+package com.bazaarvoice.emodb.common.zookeeper.leader;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.AbstractService;
+import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.dropwizard.lifecycle.Managed;
+import org.apache.curator.framework.CuratorFramework;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.time.Clock;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Sample implementation of a {@link PartitionedLeaderService}.  This service does nothing but log when leadership
+ * is gained or lost and maintain a metric of how many partitions it is currently leading.  Useful for testing.
+ */
+public class LoggingPartitionedService extends PartitionedLeaderService implements Managed {
+
+    private final Logger _log = LoggerFactory.getLogger(getClass());
+
+    private final String _serviceName;
+    private final AtomicInteger _ownedPartitions;
+
+    public LoggingPartitionedService(CuratorFramework curator, String leaderPath, String instanceId, String serviceName,
+                                     int numPartitions, long reacquireDelay, long repartitionDelay, TimeUnit delayUnit,
+                                     MetricRegistry metricRegistry, @Nullable Clock clock) {
+        super(curator, leaderPath, instanceId, serviceName, numPartitions, reacquireDelay, repartitionDelay, delayUnit, clock);
+        setServiceFactory(this::createServiceForPartition);
+        
+        _serviceName = serviceName;
+        _ownedPartitions = new AtomicInteger(0);
+        metricRegistry.register(
+                MetricRegistry.name("bv.emodb.LoggingPartitionedService", serviceName),
+                (Gauge) _ownedPartitions::intValue);
+    }
+
+    private Service createServiceForPartition(final int partition) {
+        return new AbstractService() {
+            private ExecutorService _service;
+            private CountDownLatch _latch = new CountDownLatch(1);
+
+            @Override
+            protected void doStart() {
+                _service = Executors.newSingleThreadExecutor(
+                        new ThreadFactoryBuilder().setNameFormat(String.format("%s-%d-%%d", _serviceName, partition)).build());
+                _service.submit(() -> {
+                    _log.info("{}-{}: Service started", _serviceName, partition);
+                    _ownedPartitions.incrementAndGet();
+                    try {
+                        while (!_service.isShutdown()) {
+                            try {
+                                _latch.await(5, TimeUnit.SECONDS);
+                            } catch (InterruptedException e) {
+                                if (!_service.isShutdown()) {
+                                    _log.info("{}-{}: Service thread interrupted prior to shutdown", _serviceName, partition);
+                                }
+                            }
+                        }
+                    } finally {
+                        _log.info("{}-{}: Service terminating", _serviceName, partition);
+                        _ownedPartitions.decrementAndGet();
+                    }
+                });
+                notifyStarted();
+            }
+
+            @Override
+            protected void doStop() {
+                _latch.countDown();
+                _service.shutdown();
+                notifyStopped();
+            }
+        };
+    }
+}

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderService.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderService.java
@@ -1,0 +1,310 @@
+package com.bazaarvoice.emodb.common.zookeeper.leader;
+
+import com.bazaarvoice.curator.recipes.leader.LeaderService;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.SettableFuture;
+import io.dropwizard.lifecycle.Managed;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.utils.ZKPaths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * There are circumstances where a service has multiple partitions and it is desirable to balance the workers for these
+ * partitions across the cluster.  {@link LeaderService} works for a single partition but doesn't allow for balancing
+ * leadership for multiple related leaders such as in our partitioned case.  This class uses multiple LeaderServices
+ * and makes a best effort to balance leadership across the cluster.
+ */
+public class PartitionedLeaderService implements Managed {
+
+    private static final Logger _log = LoggerFactory.getLogger(PartitionedLeaderService.class);
+
+    private static final String LEADER_PATH_PATTERN = "partition-%03d";
+
+    private final CuratorFramework _curator;
+    private final String _basePath;
+    private final String _instanceId;
+    private final String _serviceName;
+    private final int _numPartitions;
+    private final long _reacquireDelay;
+    private final long _repartitionDelay;
+    private final TimeUnit _delayUnit;
+    private final Clock _clock;
+    private final List<PartitionLeader> _partitionLeaders;
+
+    private PartitionedServiceSupplier _serviceFactory;
+    private PathChildrenCache _participantsCache;
+    private volatile int _maxPartitionsLeader;
+
+    public PartitionedLeaderService(CuratorFramework curator, String leaderPath, String instanceId, String serviceName,
+                                    int numPartitions, long reacquireDelay, long repartitionDelay, TimeUnit delayUnit,
+                                    PartitionedServiceSupplier serviceFactory, @Nullable Clock clock) {
+        this(curator, leaderPath, instanceId, serviceName, numPartitions, reacquireDelay, repartitionDelay, delayUnit, clock);
+        setServiceFactory(serviceFactory);
+    }
+
+    /**
+     * Constructor for subclasses.  The subclasses should call {@link #setServiceFactory(PartitionedServiceSupplier)}
+     * in their constructor.
+     */
+    protected PartitionedLeaderService(CuratorFramework curator, String leaderPath, String instanceId, String serviceName,
+                                                  int numPartitions, long reacquireDelay, long repartitionDelay, TimeUnit delayUnit,
+                                                  @Nullable Clock clock) {
+        _curator = curator;
+        _basePath = leaderPath;
+        _instanceId = instanceId;
+        _serviceName = serviceName;
+        _numPartitions = numPartitions;
+        _reacquireDelay = reacquireDelay;
+        _repartitionDelay = repartitionDelay;
+        _delayUnit = delayUnit;
+        _clock = Optional.ofNullable(clock).orElse(Clock.systemUTC());
+
+        _partitionLeaders = Lists.newArrayListWithCapacity(_numPartitions);
+        for (int partition = 0; partition < _numPartitions; partition++) {
+            _partitionLeaders.add(new PartitionLeader(partition));
+        }
+    }
+
+    final protected void setServiceFactory(PartitionedServiceSupplier serviceFactory) {
+        checkNotNull(serviceFactory, "serviceFactory");
+        if (_serviceFactory != null) {
+            throw new IllegalStateException("Service factory has already been set");
+        }
+        _serviceFactory = serviceFactory;
+    }
+
+    @Override
+    public void start() throws Exception {
+        if (_serviceFactory == null) {
+            throw new IllegalStateException("Cannot start service without first providing a service factory");
+        }
+        
+        String participantsPath = ZKPaths.makePath(_basePath, String.format(LEADER_PATH_PATTERN, 0));
+
+        // Watch the participants for partition 0 to determine how many potential leaders there are total
+        _participantsCache = new PathChildrenCache(_curator, participantsPath, true);
+        _participantsCache.getListenable().addListener((ignore1, ignore2) -> participantsUpdated(false));
+        _participantsCache.start(PathChildrenCache.StartMode.BUILD_INITIAL_CACHE);
+        participantsUpdated(true);
+        
+        List<Future<Void>> futures = Lists.newArrayListWithCapacity(_numPartitions);
+
+        for (PartitionLeader partitionLeader : _partitionLeaders) {
+            futures.add(partitionLeader.startAsync());
+        }
+
+        for (Future<Void> future : futures) {
+            future.get();
+        }
+    }
+
+    @Override
+    public void stop() throws Exception {
+        _participantsCache.close();
+
+        List<Future<Void>> futures = Lists.newArrayListWithCapacity(_numPartitions);
+        for (PartitionLeader partitionLeader : _partitionLeaders) {
+            futures.add(partitionLeader.stopAsync());
+        }
+
+        for (Future<Void> future : futures) {
+            future.get();
+        }
+    }
+
+    /**
+     * Returns the underlying leader services for each partition.  The services are guaranteed to be returned
+     * ordered by partition number.
+     */
+    public List<LeaderService> getPartitionLeaderServices() {
+        return _partitionLeaders.stream()
+                .map(PartitionLeader::getLeaderService)
+                .collect(Collectors.toList());
+    }
+
+    private synchronized void participantsUpdated(boolean initialUpdate) {
+        List<String> participantInstanceIds = _participantsCache.getCurrentData().stream()
+                .map(participant -> new String(participant.getData(), Charsets.UTF_8))
+                .sorted()
+                .collect(Collectors.toList());
+
+        if (participantInstanceIds.isEmpty()) {
+            // On the initial update there may be no participants if this is the only instance in the cluster.
+            // This is because the cache is started before the leader services.  For all but the initial update
+            // this should never happen since this instance at minimum is a participant.
+            if (!initialUpdate) {
+                _log.warn("Participant cache returned no participants");
+            }
+            participantInstanceIds = ImmutableList.of(_instanceId);
+        }
+
+        // If the partitions cannot be split evenly among the participants then the following uses the sorted
+        // participant instance IDs to deterministically allocate which instances get the extras.
+        int numParticipants = participantInstanceIds.size();
+        _maxPartitionsLeader = _numPartitions / numParticipants;
+        if (participantInstanceIds.indexOf(_instanceId) < _numPartitions % numParticipants) {
+            _maxPartitionsLeader += 1;
+        }
+
+        //
+        List<Integer> leadingPartitions = getLeadingPartitions();
+        int excessLeadership = leadingPartitions.size() - _maxPartitionsLeader;
+
+        while (excessLeadership > 0 && !leadingPartitions.isEmpty()) {
+            // This service owns more that it should given the new topology.  Voluntarily release the excess.
+            int leadingPartitionsIndex = (int) Math.floor(Math.random() * leadingPartitions.size());
+            int partitionToRelease = leadingPartitions.remove(leadingPartitionsIndex);
+            PartitionLeader partitionLeader = _partitionLeaders.get(partitionToRelease);
+
+            if (partitionLeader.relinquishLeadership()) {
+                excessLeadership -= 1;
+            }
+        }
+    }
+
+    public List<Integer> getLeadingPartitions() {
+        List<Integer> leadingPartitions = Lists.newArrayListWithCapacity(_numPartitions);
+        for (PartitionLeader partitionLeader : _partitionLeaders) {
+            if (partitionLeader.hasLeadership()) {
+                leadingPartitions.add(partitionLeader._partition);
+            }
+        }
+        return leadingPartitions;
+    }
+
+    /**
+     * Inner class to maintain leadership information about a single partition.
+     */
+    private class PartitionLeader {
+
+        private final int _partition;
+        private final LeaderService _leaderService;
+        private final SettableFuture<Void> _startedFuture = SettableFuture.create();
+        private final SettableFuture<Void> _terminatedFuture = SettableFuture.create();
+        private Instant _partitionReacquireTimeout = Instant.EPOCH;
+        private int _partitionReacquireRejections = 0;
+
+        PartitionLeader(int partition) {
+            _partition = partition;
+
+            String leaderPath = ZKPaths.makePath(_basePath, String.format(LEADER_PATH_PATTERN, partition));
+
+            _leaderService = new LeaderService(_curator, leaderPath, _instanceId, _serviceName,
+                    _reacquireDelay, _delayUnit, this::leadershipAcquired);
+
+            _leaderService.addListener(new Service.Listener() {
+                @Override
+                public void running() {
+                    _startedFuture.set(null);
+                }
+
+                @Override
+                public void terminated(Service.State from) {
+                    _terminatedFuture.set(null);
+                }
+            }, MoreExecutors.sameThreadExecutor());
+        }
+
+        Future<Void> startAsync() {
+            _leaderService.startAsync();
+            return _startedFuture;
+        }
+
+        Future<Void> stopAsync() {
+            _leaderService.stopAsync();
+            return _terminatedFuture;
+        }
+
+        Service leadershipAcquired() {
+            synchronized(PartitionedLeaderService.this) {
+                List<Integer> leadingPartitions = getLeadingPartitions();
+                //noinspection SuspiciousMethodCalls
+                leadingPartitions.remove((Object) _partition);
+
+                if (leadingPartitions.size() < _maxPartitionsLeader || _partitionReacquireRejections >= 3) {
+                    if (_partitionReacquireRejections >= 3) {
+                        _log.warn("Accepting leadership of partition {} for {} because no other server became leader after {} rejections",
+                                _partition, _serviceName, _partitionReacquireRejections);
+                    } else {
+                        _log.debug("Accepting leadership of partition {} for {}", _partition, _serviceName);
+                    }
+
+                    _partitionReacquireTimeout = Instant.EPOCH;
+                    _partitionReacquireRejections = 0;
+
+                    return _serviceFactory.createForPartition(_partition);
+                } else {
+                    if (_clock.instant().isAfter(_partitionReacquireTimeout)) {
+                        _log.info("Rejecting leadership of partition {} for {}, already own partitions {}",
+                                _partition, _serviceName, leadingPartitions);
+                        _partitionReacquireTimeout = _clock.instant().plusMillis(_delayUnit.toMillis(_repartitionDelay));
+                        _partitionReacquireRejections += 1;
+                    } else {
+                        _log.info("Rejecting leadership of partition {} for {} while in partition reacquire delay",
+                                _partition, _serviceName, leadingPartitions);
+                    }
+
+                    // Return a service which will immediately relinquish leadership
+                    return new RelinquishService();
+                }
+            }
+        }
+
+        boolean hasLeadership() {
+            if (!_leaderService.isRunning() || !_leaderService.hasLeadership()) {
+                return false;
+            }
+            // It's possible we technically have leadership but are in the process of giving it up because we already
+            // are leading the maximum number of partitions.  Verify that this isn't a rejected service.
+            Service delegateService = _leaderService.getCurrentDelegateService().orNull();
+            return delegateService == null || !(delegateService instanceof RelinquishService);
+        }
+        
+        boolean relinquishLeadership() {
+            if (hasLeadership()) {
+                // Release leadership by stopping the delegate service, but do not stop the leadership service itself
+                Service delegateService = _leaderService.getCurrentDelegateService().orNull();
+                if (delegateService != null) {
+                    _log.info("Relinquishing leadership of partition {} for {}", _partition, _serviceName);
+                    delegateService.stopAsync();
+                }
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        LeaderService getLeaderService() {
+            return _leaderService;
+        }
+    }
+
+    /**
+     * Service implementation which immediately returns having taken no action.  Used when the LeaderService gives
+     * a partition leadership when the total number of partitions already lead is at the maximum.
+     */
+    private static class RelinquishService extends AbstractExecutionThreadService {
+        @Override
+        protected void run() throws Exception {
+            // Do nothing
+        }
+    }
+}

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedServiceSupplier.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedServiceSupplier.java
@@ -1,0 +1,12 @@
+package com.bazaarvoice.emodb.common.zookeeper.leader;
+
+import com.google.common.util.concurrent.Service;
+
+/**
+ * Interface used by {@link PartitionedLeaderService} to get the service for handling a partition.
+ * Partition numbers are guaranteed to be in the range [0..numPartitions-1]
+ */
+public interface PartitionedServiceSupplier {
+
+    Service createForPartition(int partition);
+}

--- a/common/zookeeper/src/test/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderServiceTest.java
+++ b/common/zookeeper/src/test/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderServiceTest.java
@@ -44,7 +44,7 @@ public class PartitionedLeaderServiceTest {
             curator.start();
             
             PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/single", "instance0",
-                    "test-service", 3, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                    "test-service", 3, 1, 5000, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
 
             service.start();
 
@@ -77,7 +77,7 @@ public class PartitionedLeaderServiceTest {
                 curators.add(curator);
 
                 PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/multi", "instance" + i,
-                        "test-service", 10, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                        "test-service", 10, 1, 5000, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
                 service.start();
                 services.add(service);
             }
@@ -132,7 +132,7 @@ public class PartitionedLeaderServiceTest {
                 curators.add(curator);
 
                 PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/relinquish", "instance" + i,
-                        "test-service", 2, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                        "test-service", 2, 1, 5000, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
                 services.add(service);
             }
 

--- a/common/zookeeper/src/test/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderServiceTest.java
+++ b/common/zookeeper/src/test/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderServiceTest.java
@@ -1,0 +1,232 @@
+package com.bazaarvoice.emodb.common.zookeeper.leader;
+
+import com.bazaarvoice.curator.recipes.leader.LeaderService;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.Service;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.test.TestingServer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class PartitionedLeaderServiceTest {
+
+    private TestingServer _zookeeper;
+
+    @BeforeClass
+    private void setupZookeeper() throws Exception {
+        _zookeeper = new TestingServer();
+    }
+
+    @AfterClass
+    private void teardownZookeeper() throws Exception {
+        _zookeeper.close();
+    }
+
+    @Test
+    public void testSingleServer() throws Exception {
+        try (CuratorFramework curator = CuratorFrameworkFactory.newClient(_zookeeper.getConnectString(), new RetryNTimes(1, 10))) {
+            curator.start();
+            
+            PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/single", "instance0",
+                    "test-service", 3, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+
+            service.start();
+
+            List<LeaderService> leaderServices = service.getPartitionLeaderServices();
+            assertEquals(leaderServices.size(), 3, "Wrong number of services for the provided number of partitions");
+
+            // Give it 5 seconds to attain leadership on all 3 partitions
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            Set<Integer> leadPartitions = getLeadPartitions(service);
+
+            while (leadPartitions.size() != 3 && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+                leadPartitions = getLeadPartitions(service);
+            }
+
+            assertEquals(leadPartitions, ImmutableSet.of(0, 1, 2));
+            service.stop();
+        }
+    }
+
+    @Test
+    public void testMultiServer() throws Exception {
+        List<CuratorFramework> curators = Lists.newArrayListWithCapacity(3);
+
+        try {
+            List<PartitionedLeaderService> services = Lists.newArrayListWithCapacity(3);
+            for (int i=0; i < 3; i++) {
+                CuratorFramework curator = CuratorFrameworkFactory.newClient(_zookeeper.getConnectString(), new RetryNTimes(1, 10));
+                curator.start();
+                curators.add(curator);
+
+                PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/multi", "instance" + i,
+                        "test-service", 10, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                service.start();
+                services.add(service);
+            }
+
+
+            // Give it 5 seconds for leadership to be balanced.  With 10 partitions and 3 services this should
+            // be [4, 3, 3] since the first instance has the lowest instance ID.
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            List<Set<Integer>> leadPartitions = ImmutableList.of();
+
+            while (!leadPartitions.stream().map(Set::size).collect(Collectors.toList()).equals(ImmutableList.of(4, 3, 3)) && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+                leadPartitions = services.stream()
+                        .map(this::getLeadPartitions)
+                        .collect(Collectors.toList());
+            }
+
+            Set<Integer> unclaimedPartitions = Sets.newLinkedHashSet();
+            for (int i=0; i < 10; i++) {
+                unclaimedPartitions.add(i);
+            }
+
+            assertEquals(leadPartitions.size(), 3, "There should be three sets of partitions of leadership");
+            assertEquals(leadPartitions.get(0).size(), 4);
+            assertTrue(Sets.intersection(leadPartitions.get(0), unclaimedPartitions).equals(leadPartitions.get(0)));
+            unclaimedPartitions.removeAll(leadPartitions.get(0));
+            assertEquals(leadPartitions.get(1).size(), 3);
+            assertTrue(Sets.intersection(leadPartitions.get(1), unclaimedPartitions).equals(leadPartitions.get(1)));
+            unclaimedPartitions.removeAll(leadPartitions.get(1));
+            assertEquals(leadPartitions.get(2).size(), 3);
+            assertEquals(leadPartitions.get(2), unclaimedPartitions);
+
+            for (PartitionedLeaderService service : services) {
+                service.stop();
+            }
+        } finally {
+            for (CuratorFramework curator : curators) {
+                curator.close();
+            }
+        }
+    }
+
+    @Test
+    public void testRelinquish() throws Exception {
+        List<CuratorFramework> curators = Lists.newArrayListWithCapacity(2);
+
+        try {
+            List<PartitionedLeaderService> services = Lists.newArrayListWithCapacity(2);
+            for (int i=0; i < 2; i++) {
+                CuratorFramework curator = CuratorFrameworkFactory.newClient(_zookeeper.getConnectString(), new RetryNTimes(1, 10));
+                curator.start();
+                curators.add(curator);
+
+                PartitionedLeaderService service = new PartitionedLeaderService(curator, "/leader/relinquish", "instance" + i,
+                        "test-service", 2, 1, 1, TimeUnit.MILLISECONDS, TestLeaderService::new, null);
+                services.add(service);
+            }
+
+            // Start only the first service
+            services.get(0).start();
+
+            // Wait up to 5 seconds for the service to acquire leadership for both partitions
+            Stopwatch stopwatch = Stopwatch.createStarted();
+            while (getLeadPartitions(services.get(0)).size() != 2 && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+            }
+
+            assertEquals(getLeadPartitions(services.get(0)).size(), 2, "Service should have acquired leadership for both partitions");
+
+            // Now start the second service
+            services.get(1).start();
+
+            // Wait for the first service to relinquish one partition and for the second service to acquire it
+            stopwatch.reset().start();
+            Set<Integer> leadPartitions0 = ImmutableSet.of();
+            Set<Integer> leadPartitions1 = ImmutableSet.of();
+
+            while ((leadPartitions0.size() != 1 || leadPartitions1.size() != 1) && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+                leadPartitions0 = getLeadPartitions(services.get(0));
+                leadPartitions1 = getLeadPartitions(services.get(1));
+            }
+
+            Set<Integer> leadPartitions = Sets.newLinkedHashSet();
+            assertEquals(leadPartitions0.size(), 1);
+            leadPartitions.addAll(leadPartitions0);
+            assertEquals(leadPartitions1.size(), 1);
+            leadPartitions.addAll(leadPartitions1);
+            assertEquals(leadPartitions, ImmutableSet.of(0, 1));
+
+            // Finally, kill the first service completely
+            services.get(0).stop();
+
+            // Wait for the second service to lead both partitions
+            stopwatch.reset().start();
+            leadPartitions1 = ImmutableSet.of();
+
+            while (!leadPartitions1.equals(ImmutableSet.of(0, 1)) && stopwatch.elapsed(TimeUnit.SECONDS) < 5) {
+                Thread.sleep(10);
+                leadPartitions1 = getLeadPartitions(services.get(1));
+            }
+
+            assertEquals(leadPartitions1, ImmutableSet.of(0, 1));
+
+            for (PartitionedLeaderService service : services) {
+                service.stop();
+            }
+        } finally {
+            for (CuratorFramework curator : curators) {
+                curator.close();
+            }
+        }
+    }
+
+    private Set<Integer> getLeadPartitions(PartitionedLeaderService partitionedLeaderService) {
+        Set<Integer> leadPartitions = Sets.newLinkedHashSet();
+
+        for (Integer partition : partitionedLeaderService.getLeadingPartitions()) {
+            // Don't just take the service's word for it; double check that the service is actually in the execution body
+            Service uncastDelegate = partitionedLeaderService.getPartitionLeaderServices().get(partition).getCurrentDelegateService().orNull();
+            TestLeaderService delegate = uncastDelegate != null && uncastDelegate instanceof TestLeaderService ?
+                    (TestLeaderService) uncastDelegate : null;
+            if (delegate != null && delegate.inBody) {
+                leadPartitions.add(delegate.partition);
+            }
+        }
+
+        return leadPartitions;
+    }
+
+    private class TestLeaderService extends AbstractExecutionThreadService {
+
+        final int partition;
+        volatile boolean inBody;
+
+        public TestLeaderService(int partition) {
+            this.partition = partition;
+        }
+
+        @Override
+        protected void run() throws Exception {
+            inBody = true;
+            try {
+                while (isRunning()) {
+                    Thread.sleep(10);
+                }
+            } finally {
+                inBody = false;
+            }
+        }
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/ChannelNames.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/ChannelNames.java
@@ -18,15 +18,23 @@ public class ChannelNames {
     }
 
     public static boolean isSystemFanoutChannel(String channel) {
-        return channel.equals(MASTER_FANOUT) || channel.startsWith(REPLICATION_FANOUT_PREFIX);
+        return channel.startsWith(MASTER_FANOUT) || channel.startsWith(REPLICATION_FANOUT_PREFIX);
     }
 
-    public static String getMasterFanoutChannel() {
+    public static String getLegacyMasterFanoutChannel() {
         return MASTER_FANOUT;
     }
 
-    public static String getReplicationFanoutChannel(DataCenter dataCenter) {
+    public static String getMasterFanoutChannel(int partition) {
+        return String.format("%s[%d]", MASTER_FANOUT, partition);
+    }
+    
+    public static String getLegacyReplicationFanoutChannel(DataCenter dataCenter) {
         return REPLICATION_FANOUT_PREFIX + dataCenter.getName();
+    }
+
+    public static String getReplicationFanoutChannel(DataCenter dataCenter, int partition) {
+        return String.format("%s%s[%d]", REPLICATION_FANOUT_PREFIX, dataCenter.getName(), partition);
     }
 
     public static String getMasterReplayChannel() {

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/DataCenterFanoutPartitions.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/DataCenterFanoutPartitions.java
@@ -1,0 +1,16 @@
+package com.bazaarvoice.emodb.databus;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface DataCenterFanoutPartitions {
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusConfiguration.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusConfiguration.java
@@ -37,6 +37,16 @@ public class DatabusConfiguration {
     @JsonProperty("subscriptionCacheInvalidation")
     private CachingSubscriptionDAO.CachingMode _subscriptionCacheInvalidation = CachingSubscriptionDAO.CachingMode.normal;
 
+    @Valid
+    @NotNull
+    @JsonProperty("masterFanoutPartitions")
+    private int _masterFanoutPartitions = 4;
+
+    @Valid
+    @NotNull
+    @JsonProperty("dataCenterFanoutPartitions")
+    private int _dataCenterFanoutPartitions = 4;
+
     public CassandraConfiguration getCassandraConfiguration() {
         return _cassandraConfiguration;
     }
@@ -70,6 +80,24 @@ public class DatabusConfiguration {
 
     public DatabusConfiguration setSubscriptionCacheInvalidation(CachingSubscriptionDAO.CachingMode subscriptionCacheInvalidation) {
         _subscriptionCacheInvalidation = subscriptionCacheInvalidation;
+        return this;
+    }
+
+    public int getMasterFanoutPartitions() {
+        return _masterFanoutPartitions;
+    }
+
+    public DatabusConfiguration setMasterFanoutPartitions(int masterFanoutPartitions) {
+        _masterFanoutPartitions = masterFanoutPartitions;
+        return this;
+    }
+
+    public int getDataCenterFanoutPartitions() {
+        return _dataCenterFanoutPartitions;
+    }
+
+    public DatabusConfiguration setDataCenterFanoutPartitions(int dataCenterFanoutPartitions) {
+        _dataCenterFanoutPartitions = dataCenterFanoutPartitions;
         return this;
     }
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/MasterFanoutPartitions.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/MasterFanoutPartitions.java
@@ -1,0 +1,16 @@
+package com.bazaarvoice.emodb.databus;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface MasterFanoutPartitions {
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutManager.java
@@ -3,9 +3,13 @@ package com.bazaarvoice.emodb.databus.core;
 import com.bazaarvoice.curator.recipes.leader.LeaderService;
 import com.bazaarvoice.emodb.common.dropwizard.guice.SelfHostAndPort;
 import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ManagedGuavaService;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
+import com.bazaarvoice.emodb.common.zookeeper.leader.PartitionedLeaderService;
 import com.bazaarvoice.emodb.databus.ChannelNames;
+import com.bazaarvoice.emodb.databus.DataCenterFanoutPartitions;
 import com.bazaarvoice.emodb.databus.DatabusZooKeeper;
+import com.bazaarvoice.emodb.databus.MasterFanoutPartitions;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
 import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.databus.repl.ReplicationEventSource;
@@ -20,6 +24,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.Inject;
+import io.dropwizard.lifecycle.Managed;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
 import org.joda.time.Duration;
@@ -43,6 +48,9 @@ public class DefaultFanoutManager implements FanoutManager {
     private final LeaderServiceTask _dropwizardTask;
     private final RateLimitedLogFactory _logFactory;
     private final SubscriptionEvaluator _subscriptionEvaluator;
+    private final int _masterFanoutPartitions;
+    private final int _dataCenterFanoutPartitions;
+    private final PartitionSelector _dataCenterFanoutPartitionSelector;
     private final MetricRegistry _metricRegistry;
     private final Clock _clock;
 
@@ -50,6 +58,9 @@ public class DefaultFanoutManager implements FanoutManager {
     public DefaultFanoutManager(final EventStore eventStore, final SubscriptionDAO subscriptionDao,
                                 SubscriptionEvaluator subscriptionEvaluator, DataCenters dataCenters,
                                 @DatabusZooKeeper CuratorFramework curator, @SelfHostAndPort HostAndPort self,
+                                @MasterFanoutPartitions int masterFanoutPartitions,
+                                @DataCenterFanoutPartitions int dataCenterFanoutPartitions,
+                                @DataCenterFanoutPartitions PartitionSelector dataCenterFanoutPartitionSelector,
                                 LeaderServiceTask dropwizardTask, RateLimitedLogFactory logFactory,
                                 MetricRegistry metricRegistry, Clock clock) {
         _eventStore = checkNotNull(eventStore, "eventStore");
@@ -60,46 +71,79 @@ public class DefaultFanoutManager implements FanoutManager {
         _selfId = checkNotNull(self, "self").toString();
         _dropwizardTask = checkNotNull(dropwizardTask, "dropwizardTask");
         _logFactory = checkNotNull(logFactory, "logFactory");
+        _masterFanoutPartitions = masterFanoutPartitions;
+        _dataCenterFanoutPartitions = dataCenterFanoutPartitions;
+        _dataCenterFanoutPartitionSelector = checkNotNull(dataCenterFanoutPartitionSelector, "dataCenterFanoutPartitionSelector");
         _metricRegistry = metricRegistry;
         _clock = clock;
     }
 
     @Override
-    public Service newMasterFanout() {
-        String sourceChannel = ChannelNames.getMasterFanoutChannel();
-        EventStoreEventSource eventSource = new EventStoreEventSource(_eventStore, sourceChannel);
-        return create("master", eventSource, true, SAME_DC_SLEEP_WHEN_IDLE);
+    public Managed newMasterFanout() {
+        PartitionEventSourceSupplier eventSourceSupplier = partition ->
+                new EventStoreEventSource(_eventStore, ChannelNames.getMasterFanoutChannel(partition));
+        return create("master", eventSourceSupplier, _dataCenterFanoutPartitionSelector, SAME_DC_SLEEP_WHEN_IDLE, _masterFanoutPartitions);
     }
 
     @Override
-    public Service newInboundReplicationFanout(DataCenter dataCenter, ReplicationSource replicationSource) {
-        String sourceChannel = ChannelNames.getReplicationFanoutChannel(_dataCenters.getSelf());
-        EventSource eventSource = new ReplicationEventSource(replicationSource, sourceChannel);
-        return create("in-" + dataCenter.getName(), eventSource, false, REMOTE_DC_SLEEP_WHEN_IDLE);
+    public Managed newLegacyMasterFanout() {
+        PartitionEventSourceSupplier eventSourceSupplier = ignore ->
+                new EventStoreEventSource(_eventStore, ChannelNames.getLegacyMasterFanoutChannel());
+        return create("master", eventSourceSupplier, _dataCenterFanoutPartitionSelector, SAME_DC_SLEEP_WHEN_IDLE, 0);
     }
 
-    private Service create(final String name, final EventSource eventSource, final boolean replicateOutbound, final Duration sleepWhenIdle) {
-        final Function<Multimap<String, ByteBuffer>, Void> eventSink = new Function<Multimap<String, ByteBuffer>, Void>() {
-            @Override
-            public Void apply(@Nullable Multimap<String, ByteBuffer> eventsByChannel) {
-                _eventStore.addAll(eventsByChannel);
-                return null;
-            }
-        };
-        final Supplier<Iterable<OwnedSubscription>> subscriptionsSupplier = () -> _subscriptionDao.getAllSubscriptions();
+    @Override
+    public Managed newInboundReplicationFanout(DataCenter dataCenter, ReplicationSource replicationSource) {
+        PartitionEventSourceSupplier eventSourceSupplier = partition ->
+                new ReplicationEventSource(replicationSource, ChannelNames.getReplicationFanoutChannel(_dataCenters.getSelf(), partition));
+        return create("in-" + dataCenter.getName(), eventSourceSupplier, null, REMOTE_DC_SLEEP_WHEN_IDLE, _dataCenterFanoutPartitions);
+    }
 
-        LeaderService leaderService = new LeaderService(
-                _curator, ZKPaths.makePath("/leader/fanout", name), _selfId, "LeaderSelector-" + name, 1, TimeUnit.MINUTES,
-                new Supplier<Service>() {
-                    @Override
-                    public Service get() {
-                        return new DefaultFanout(name, eventSource, eventSink, replicateOutbound, sleepWhenIdle,
-                                subscriptionsSupplier, _dataCenters.getSelf(), _logFactory, _subscriptionEvaluator,
-                                _metricRegistry, _clock);
-                    }
-                });
-        ServiceFailureListener.listenTo(leaderService, _metricRegistry);
-        _dropwizardTask.register("databus-fanout-" + name, leaderService);
-        return leaderService;
+    @Override
+    public Managed newLegacyInboundReplicationFanout(DataCenter dataCenter, ReplicationSource replicationSource) {
+        PartitionEventSourceSupplier eventSourceSupplier = ignore ->
+                new ReplicationEventSource(replicationSource, ChannelNames.getLegacyReplicationFanoutChannel(_dataCenters.getSelf()));
+        return create("in-" + dataCenter.getName(), eventSourceSupplier, null, REMOTE_DC_SLEEP_WHEN_IDLE, 0);
+    }
+
+    private Managed create(final String name, final PartitionEventSourceSupplier eventSourceSupplier,
+                           @Nullable final PartitionSelector outboundPartitionSelector, final Duration sleepWhenIdle,
+                           final int partitions) {
+        final Function<Multimap<String, ByteBuffer>, Void> eventSink = eventsByChannel -> {
+            _eventStore.addAll(eventsByChannel);
+            return null;
+        };
+
+        final Supplier<Iterable<OwnedSubscription>> subscriptionsSupplier = _subscriptionDao::getAllSubscriptions;
+
+        if (partitions == 0) {
+            EventSource eventSource = eventSourceSupplier.createEventSourceForPartition(0);
+            LeaderService leaderService = new LeaderService(
+                    _curator, ZKPaths.makePath("/leader/fanout", name), _selfId, "LeaderSelector-" + name, 1, TimeUnit.MINUTES,
+                    () -> new DefaultFanout(name, eventSource, eventSink, outboundPartitionSelector, sleepWhenIdle,
+                            subscriptionsSupplier, _dataCenters.getSelf(), _logFactory, _subscriptionEvaluator,
+                            "legacy", _metricRegistry, _clock));
+            ServiceFailureListener.listenTo(leaderService, _metricRegistry);
+            _dropwizardTask.register("databus-fanout-" + name, leaderService);
+            return new ManagedGuavaService(leaderService);
+        } else {
+            PartitionedLeaderService partitionedLeaderService = new PartitionedLeaderService(
+                    _curator, ZKPaths.makePath("/leader/fanout", "partitioned-" + name),
+                    _selfId, "PartitionedLeaderSelector-" + name, partitions, 1,  1, TimeUnit.MINUTES,
+                    partition -> new DefaultFanout(name, eventSourceSupplier.createEventSourceForPartition(partition),
+                            eventSink, outboundPartitionSelector, sleepWhenIdle, subscriptionsSupplier, _dataCenters.getSelf(),
+                            _logFactory, _subscriptionEvaluator, "partition-" + partition, _metricRegistry, _clock),
+                    _clock);
+
+            for (LeaderService leaderService : partitionedLeaderService.getPartitionLeaderServices()) {
+                ServiceFailureListener.listenTo(leaderService, _metricRegistry);
+            }
+            _dropwizardTask.register("databus-fanout-" + name, partitionedLeaderService);
+            return partitionedLeaderService;
+        }
+    }
+
+    private interface PartitionEventSourceSupplier {
+        EventSource createEventSourceForPartition(int partition);
     }
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DrainFanoutPartitionTask.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DrainFanoutPartitionTask.java
@@ -1,0 +1,143 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
+import com.bazaarvoice.emodb.databus.ChannelNames;
+import com.bazaarvoice.emodb.databus.DataCenterFanoutPartitions;
+import com.bazaarvoice.emodb.databus.MasterFanoutPartitions;
+import com.bazaarvoice.emodb.datacenter.api.DataCenter;
+import com.bazaarvoice.emodb.datacenter.api.DataCenters;
+import com.bazaarvoice.emodb.event.api.EventStore;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.inject.Inject;
+import io.dropwizard.servlets.tasks.Task;
+
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Task which can be used to drain a fanout partition if the number of partitions is ever decreased from a higher to
+ * a lower value.  For example, if the number of master fanout partitions is decreased from 6 to 4 then this task
+ * must be used to fully drain the partitions 4 and 5 to one of the remaining partitions, [0..3].  This task should
+ * only be run after all hosts with the old number of partitions have been shut down, otherwise new events may be
+ * added to the partitions after they have been drained.
+ *
+ * Examples:
+ *
+ * Drain the master queue from partition 4 to partition 3:
+ * <pre>
+ *  curl -s -XPOST "http://localhost:8081/tasks/drain-fanout-partition?fanout=master&from=4&to=3"
+ * </pre>
+ *
+ * Drain the outbound replication queue for eu-west-1 from partition 2 to partition 1:
+ * <pre>
+ *  curl -s -XPOST "http://localhost:8081/tasks/drain-fanout-partition?fanout=eu-west-1&from=2&to=1"
+ * </pre>
+ */
+public class DrainFanoutPartitionTask extends Task {
+
+    private final EventStore _eventStore;
+    private final int _masterFanoutPartitions;
+    private final int _dataCenterFanoutPartitions;
+    private final DataCenters _dataCenters;
+
+    @Inject
+    public DrainFanoutPartitionTask(TaskRegistry tasks,
+                                    EventStore eventStore,
+                                    @MasterFanoutPartitions int masterFanoutPartitions,
+                                    @DataCenterFanoutPartitions int dataCenterFanoutPartitions,
+                                    DataCenters dataCenters) {
+        super("drain-fanout-partition");
+        _eventStore = eventStore;
+        _masterFanoutPartitions = masterFanoutPartitions;
+        _dataCenterFanoutPartitions = dataCenterFanoutPartitions;
+        _dataCenters = dataCenters;
+
+        tasks.addTask(this);
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter printWriter) throws Exception {
+        String fanout = getOnlyParameter("fanout", parameters);
+        if (fanout == null) {
+            printWriter.write("Exactly one \"fanout\" parameter is required");
+            return;
+        }
+
+        String fromString = getOnlyParameter("from", parameters);
+        if (fromString == null) {
+            printWriter.write("Exactly one \"from\" parameter is required");
+            return;
+        }
+        int from = Integer.parseInt(fromString);
+        if (from < 0) {
+            printWriter.write("Invalid \"from\" parameter");
+            return;
+        }
+
+        String toString = getOnlyParameter("to", parameters);
+        if (toString == null) {
+            printWriter.write("Exactly one \"to\" parameter is required");
+            return;
+        }
+        int to = Integer.parseInt(toString);
+        if (to < 0) {
+            printWriter.write("Invalid \"to\" parameter");
+            return;
+        }
+
+        if ("master".equals(fanout)) {
+            drainMasterPartition(from, to, printWriter);
+        } else {
+            drainDataCenterPartition(fanout, from, to, printWriter);
+        }
+    }
+
+    private void drainMasterPartition(int from, int to, PrintWriter printWriter) {
+        if (from < _masterFanoutPartitions) {
+            printWriter.write("Cannot drain partition currently in use");
+            return;
+        }
+        if (to >= _masterFanoutPartitions) {
+            printWriter.write("Cannot drain to partition not in use");
+            return;
+        }
+        printWriter.write(String.format("Draining master partition %d to partition %d...\n", from, to));
+        _eventStore.move(ChannelNames.getMasterFanoutChannel(from), ChannelNames.getMasterFanoutChannel(to));
+        printWriter.write("Done!\n");
+    }
+
+    private void drainDataCenterPartition(String dataCenter, int from, int to, PrintWriter printWriter) {
+        Map<String, DataCenter> availableDataCenters = _dataCenters.getAll().stream()
+                .filter(dc -> !_dataCenters.getSelf().equals(dc))
+                .collect(Collectors.toMap(DataCenter::getName, dc -> dc));
+
+        DataCenter outboundDataCenter = availableDataCenters.get(dataCenter);
+        if (outboundDataCenter == null) {
+            printWriter.write("Invalid data center, must be one of " + Joiner.on(",").join(availableDataCenters.keySet()));
+            return;
+        }
+        
+        if (from < _dataCenterFanoutPartitions) {
+            printWriter.write("Cannot drain partition currently in use");
+            return;
+        }
+        if (to >= _dataCenterFanoutPartitions) {
+            printWriter.write("Cannot drain to partition not in use");
+            return;
+        }
+        printWriter.write(String.format("Draining %s partition %d to partition %d...\n", dataCenter, from, to));
+        _eventStore.move(ChannelNames.getReplicationFanoutChannel(outboundDataCenter, from), ChannelNames.getReplicationFanoutChannel(outboundDataCenter, to));
+        printWriter.write("Done!\n");
+    }
+
+    private String getOnlyParameter(String name, ImmutableMultimap<String, String> parameters) {
+        Collection<String> values = parameters.get(name);
+        if (values.size() != 1) {
+            return null;
+        }
+        return values.iterator().next();
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/FanoutManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/FanoutManager.java
@@ -3,12 +3,19 @@ package com.bazaarvoice.emodb.databus.core;
 import com.bazaarvoice.emodb.databus.repl.ReplicationSource;
 import com.bazaarvoice.emodb.datacenter.api.DataCenter;
 import com.google.common.util.concurrent.Service;
+import io.dropwizard.lifecycle.Managed;
 
 public interface FanoutManager {
 
     /** Starts the main fanout thread that copies from __system_bus:master to individual subscriptions. */
-    Service newMasterFanout();
+    Managed newMasterFanout();
+
+    /** Starts the legacy fanout thread that copies from __system_bus:master to individual subscriptions. */
+    Managed newLegacyMasterFanout();
 
     /** Starts polling remote data centers and copying events to local individual subscriptions. */
-    Service newInboundReplicationFanout(DataCenter dataCenter, ReplicationSource replicationSource);
+    Managed newInboundReplicationFanout(DataCenter dataCenter, ReplicationSource replicationSource);
+
+    /** Starts polling remote data centers from the legacy queue and copying events to local individual subscriptions. */
+    Managed newLegacyInboundReplicationFanout(DataCenter dataCenter, ReplicationSource replicationSource);
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/HashingPartitionSelector.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/HashingPartitionSelector.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import com.google.common.hash.Hashing;
+
+/**
+ * {@link PartitionSelector} which determines the partition based on a hash of the input value.
+ */
+public class HashingPartitionSelector implements PartitionSelector {
+
+    private final int _numPartitions;
+
+    public HashingPartitionSelector(int numPartitions) {
+        _numPartitions = numPartitions;
+    }
+
+    @Override
+    public int getPartition(byte[] key) {
+        return Math.abs(Hashing.murmur3_32().hashBytes(key).asInt()) % _numPartitions;
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/MasterFanout.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/MasterFanout.java
@@ -1,7 +1,6 @@
 package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
-import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ManagedGuavaService;
 import com.google.inject.Inject;
 
 /** Starts the Database master fanout thread. */
@@ -9,6 +8,11 @@ public class MasterFanout {
 
     @Inject
     public MasterFanout(LifeCycleRegistry lifeCycle, final FanoutManager fanoutManager) {
-        lifeCycle.manage(new ManagedGuavaService(fanoutManager.newMasterFanout()));
+        lifeCycle.manage(fanoutManager.newMasterFanout());
+
+        // Until both of the following are true we need to continue running the legacy master fanout:
+        // 1. All servers writing to the legacy un-partitioned master queue have been taken out of service
+        // 2. All events previously written to the master fanout have been processed and acknowledged
+        lifeCycle.manage(fanoutManager.newLegacyMasterFanout());
     }
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/PartitionSelector.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/PartitionSelector.java
@@ -3,7 +3,7 @@ package com.bazaarvoice.emodb.databus.core;
 import com.google.common.base.Charsets;
 
 /**
- * Interface for getting the partition for an event.  All partitions numbers are in the range of [0..n], where n
+ * Interface for getting the partition for an event.  All partitions numbers are in the range of [0..n-1], where n
  * is the maximum number of available partitions.
  */
 public interface PartitionSelector {

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/PartitionSelector.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/PartitionSelector.java
@@ -1,0 +1,24 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import com.google.common.base.Charsets;
+
+/**
+ * Interface for getting the partition for an event.  All partitions numbers are in the range of [0..n], where n
+ * is the maximum number of available partitions.
+ */
+public interface PartitionSelector {
+
+    int getPartition(byte[] key);
+
+    /**
+     * Convenience implementation for getting the partition for a String.
+     */
+    default int getPartition(String key) {
+        return key != null ? getPartition(key.getBytes(Charsets.UTF_8)) : 0;
+    }
+
+    /**
+     * Efficient default implementation where there is only one partition.
+     */
+    PartitionSelector SINGLE_PARTITION_SELECTOR = key -> 0;
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
@@ -76,7 +76,7 @@ public class SubscriptionEvaluator {
 
     public MatchEventData getMatchEventData(ByteBuffer eventData) throws UnknownTableException {
         UpdateRef ref = UpdateRefSerializer.fromByteBuffer(eventData.duplicate());
-        return new MatchEventData(_dataProvider.getTable(ref.getTable()), ref.getTags(), ref.getChangeId());
+        return new MatchEventData(_dataProvider.getTable(ref.getTable()), ref.getKey(), ref.getTags(), ref.getChangeId());
     }
 
     private boolean subscriberHasPermission(OwnedSubscription subscription, Table table) {
@@ -85,17 +85,23 @@ public class SubscriptionEvaluator {
 
     protected class MatchEventData {
         private final Table _table;
+        private final String _key;
         private final Set<String> _tags;
         private final UUID _changeId;
 
-        public MatchEventData(Table table, Set<String> tags, UUID changeId) {
+        public MatchEventData(Table table, String key, Set<String> tags, UUID changeId) {
             _table = checkNotNull(table, "table");
+            _key = key;
             _tags = tags;
             _changeId = changeId;
         }
 
         public Table getTable() {
             return _table;
+        }
+
+        public String getKey() {
+            return _key;
         }
 
         public Set<String> getTags() {

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitor.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitor.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.databus.core;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
 import com.bazaarvoice.emodb.common.dropwizard.metrics.MetricsGroup;
 import com.bazaarvoice.emodb.databus.ChannelNames;
+import com.bazaarvoice.emodb.databus.MasterFanoutPartitions;
 import com.bazaarvoice.emodb.datacenter.api.DataCenter;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.table.db.ClusterInfo;
@@ -29,13 +30,18 @@ public class SystemQueueMonitor extends AbstractScheduledService {
     private final DatabusEventStore _eventStore;
     private final DataCenters _dataCenters;
     private final Collection<ClusterInfo> _clusterInfo;
+    private final int _masterFanoutPartitions;
+    private final int _dataCenterFanoutPartitions;
     private final MetricsGroup _gauges;
 
     public SystemQueueMonitor(DatabusEventStore eventStore, DataCenters dataCenters,
-                              Collection<ClusterInfo> clusterInfo, MetricRegistry metricRegistry) {
+                              Collection<ClusterInfo> clusterInfo, int masterFanoutPartitions,
+                              int dataCenterFanoutPartitions, MetricRegistry metricRegistry) {
         _eventStore = checkNotNull(eventStore, "eventStore");
         _dataCenters = checkNotNull(dataCenters, "dataCenters");
         _clusterInfo = checkNotNull(clusterInfo, "clusterInfo");
+        _masterFanoutPartitions = masterFanoutPartitions;
+        _dataCenterFanoutPartitions = dataCenterFanoutPartitions;
         _gauges = new MetricsGroup(metricRegistry);
         ServiceFailureListener.listenTo(this, metricRegistry);
     }
@@ -62,7 +68,12 @@ public class SystemQueueMonitor extends AbstractScheduledService {
     private void pollQueueSizes() {
         _gauges.beginUpdates();
 
-        pollQueueSize("master", ChannelNames.getMasterFanoutChannel());
+        pollQueueSize("legacy-master", ChannelNames.getLegacyMasterFanoutChannel());
+        long totalMasterQueueSize = 0;
+        for (int partition = 0; partition < _masterFanoutPartitions; partition++) {
+            totalMasterQueueSize += pollQueueSize("master-" + partition, ChannelNames.getMasterFanoutChannel(partition));
+        }
+        _gauges.gauge(newMetric("master")).set(totalMasterQueueSize);
 
         for (ClusterInfo cluster : _clusterInfo) {
             pollQueueSize("canary-" + cluster.getClusterMetric(), ChannelNames.getMasterCanarySubscription(cluster.getCluster()));
@@ -71,21 +82,30 @@ public class SystemQueueMonitor extends AbstractScheduledService {
         DataCenter self = _dataCenters.getSelf();
         for (DataCenter dataCenter : _dataCenters.getAll()) {
             if (!dataCenter.equals(self)) {
-                pollQueueSize("out-" + dataCenter.getName(), ChannelNames.getReplicationFanoutChannel(dataCenter));
+                long totalDataCenterQueueSize = 0;
+                for (int partition = 0; partition < _dataCenterFanoutPartitions; partition++) {
+                    totalDataCenterQueueSize += pollQueueSize("out-" + dataCenter.getName() + partition,
+                            ChannelNames.getReplicationFanoutChannel(dataCenter, partition));
+                }
+                _gauges.gauge(newMetric("out-" + dataCenter.getName())).set(totalDataCenterQueueSize);
+
+                pollQueueSize("legacy-out-" + dataCenter.getName(), ChannelNames.getLegacyReplicationFanoutChannel(dataCenter));
             }
         }
 
         _gauges.endUpdates();
     }
 
-    private void pollQueueSize(String name, String channel) {
+    private long pollQueueSize(String name, String channel) {
         try {
             // Exact count up to 500, estimate above that.
             long count = _eventStore.getSizeEstimate(channel, 500);
             _log.debug("System queue size {}: {} (channel={})", name, count, channel);
             _gauges.gauge(newMetric(name)).set(count);
+            return count;
         } catch (Exception e) {
             _log.error("Unexpected exception polling channel size: {}", channel, e);
+            return 0;
         }
     }
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitorManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitorManager.java
@@ -6,7 +6,9 @@ import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ManagedGuavaService;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
+import com.bazaarvoice.emodb.databus.DataCenterFanoutPartitions;
 import com.bazaarvoice.emodb.databus.DatabusZooKeeper;
+import com.bazaarvoice.emodb.databus.MasterFanoutPartitions;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.table.db.ClusterInfo;
 import com.bazaarvoice.emodb.table.db.consistency.DatabusClusterInfo;
@@ -29,6 +31,8 @@ public class SystemQueueMonitorManager {
                               @DatabusClusterInfo final Collection<ClusterInfo> clusterInfo,
                               @DatabusZooKeeper CuratorFramework curator,
                               @SelfHostAndPort HostAndPort self,
+                              @MasterFanoutPartitions int masterFanoutPartitions,
+                              @DataCenterFanoutPartitions int dataCenterFanoutPartitions,
                               LeaderServiceTask dropwizardTask,
                               final MetricRegistry metricRegistry) {
         LeaderService leaderService = new LeaderService(
@@ -36,7 +40,7 @@ public class SystemQueueMonitorManager {
                 new Supplier<Service>() {
                     @Override
                     public Service get() {
-                        return new SystemQueueMonitor(eventStore, dataCenters, clusterInfo, metricRegistry);
+                        return new SystemQueueMonitor(eventStore, dataCenters, clusterInfo, masterFanoutPartitions, dataCenterFanoutPartitions, metricRegistry);
                     }
                 });
         ServiceFailureListener.listenTo(leaderService, metricRegistry);

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/DefaultReplicationManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/DefaultReplicationManager.java
@@ -20,9 +20,11 @@ import com.bazaarvoice.ostrich.pool.ServicePoolProxies;
 import com.bazaarvoice.ostrich.retry.ExponentialBackoffRetry;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
@@ -136,10 +138,43 @@ public class DefaultReplicationManager extends AbstractScheduledService {
         final ReplicationSource replicationSource = newRemoteReplicationSource(dataCenter);
 
         // Start asynchronously downloading events from the remote data center.
-        final Managed fanout = new GuavaServiceController(_replicationEnabled, new Supplier<Service>() {
+        final Managed fanout = new GuavaServiceController(_replicationEnabled, () -> new AbstractService() {
+            Managed _fanout = null;
+            Managed _legacyFanout = null;
+
             @Override
-            public Service get() {
-                return _fanoutManager.newInboundReplicationFanout(dataCenter, replicationSource);
+            protected void doStart() {
+                _fanout = _fanoutManager.newInboundReplicationFanout(dataCenter, replicationSource);
+
+                // Until both of the following are true we need to continue running the legacy master fanout:
+                // 1. All servers writing to the legacy un-partitioned replication queue have been taken out of service
+                // 2. All events previously written to the replication fanout have been processed and acknowledged
+                _legacyFanout = _fanoutManager.newLegacyInboundReplicationFanout(dataCenter, replicationSource);
+                
+                try {
+                    _fanout.start();
+                    _legacyFanout.start();
+                } catch (Exception e) {
+                    throw Throwables.propagate(e);
+                }
+                notifyStarted();
+            }
+
+            @Override
+            protected void doStop() {
+                try {
+                    if (_fanout != null) {
+                        _fanout.stop();
+                        _fanout = null;
+                    }
+                    if (_legacyFanout != null) {
+                        _legacyFanout.stop();
+                        _legacyFanout = null;
+                    }
+                } catch (Exception e) {
+                    throw Throwables.propagate(e);
+                }
+                notifyStopped();
             }
         });
 

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/ConsolidationTest.java
@@ -341,7 +341,8 @@ public class ConsolidationTest {
         DatabusAuthorizer databusAuthorizer = ConstantDatabusAuthorizer.ALLOW_ALL;
         return new DefaultDatabus(lifeCycle, eventBus, dataProvider, subscriptionDao, eventStore, subscriptionEvaluator,
                 jobService, jobHandlerRegistry, databusAuthorizer, "replication",
-                Suppliers.ofInstance(Conditions.alwaysFalse()), mock(ExecutorService.class), new MetricRegistry(), clock);
+                Suppliers.ofInstance(Conditions.alwaysFalse()), mock(ExecutorService.class), 1, key -> 0,
+                new MetricRegistry(), clock);
     }
 
     private static EventData newEvent(final String id, String table, String key, UUID changeId) {

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusSizeCachingTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusSizeCachingTest.java
@@ -47,7 +47,7 @@ public class DatabusSizeCachingTest {
                 mock(LifeCycleRegistry.class), mock(EventBus.class), mock(DataProvider.class), mock(SubscriptionDAO.class),
                 mockEventStore, mock(SubscriptionEvaluator.class), mock(JobService.class), mock(JobHandlerRegistry.class),
                 mock(DatabusAuthorizer.class), "replication", Suppliers.ofInstance(Conditions.alwaysFalse()), mock(ExecutorService.class),
-                mock(MetricRegistry.class), clock);
+                1, key -> 0, mock(MetricRegistry.class), clock);
 
         // At limit=500, size estimate should be at 4800
         // At limit=50, size estimate should be at 5000


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

At scale we have found that Emo holds up well to high write traffic but the fanout queues lag quickly under periods of high writes.  Fanout optimizations aside, because this process is run on a single server via leadership election improving fanout speed can only be accomplished by scaling vertically, and even this has bottlenecks which cannot be addressed by vertical scaling alone, such as IO time to Cassandra.

This PR changes the fanout architecture so use mutiple partitions.  As updates are made to Emo or fanned out to remote data centers the events are spread across multiple partitions.  Each partition has a corresponding fanout worker, and which worker executes it is determined through cooperative distributed leadership election.

This PR builds upon https://github.com/bazaarvoice/emodb/pull/154, which itself makes up the first 2 commits of this PR.  To view only the changes relevant to distributed fanout see the final commit.

To maintain a smooth migration this PR includes a "legacy" fanout which will continue to fan out the old master and data center channels.  Once they are fully drained the legacy code can be removed from Emo in a future PR.  In the meantime this will result in nominal overhead as once-per-second the fanout will poll the perpetually empty legacy event queue then go back to sleep.

## How to Test and Verify

There is really no way to "see" that the fanout partitioner is working.  The best way to test is to run Emo through a battery of regression and integration tests and verify that no databus events are lost and that fanout behaves exactly as before.

## Risk

The biggest risk is that an error in fanout could result in lost databus events.  However, since the fanout code itself is unchanged, any likely errors would result from problems with leadership election or an undetected race condition caused by multiple concurrent fanout processes on different hosts.

### Level 

`High`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
