### PR TITLE
Consolidate system table placement

### DIFF
--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreConfiguration.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreConfiguration.java
@@ -11,12 +11,6 @@ import java.util.Map;
 import java.util.Set;
 
 public class BlobStoreConfiguration {
-    /**
-     * Where does the SoR store system information such as table definitions?
-     */
-    @Valid
-    @NotNull
-    private String _systemTablePlacement;
 
     @Valid
     @NotNull
@@ -42,15 +36,6 @@ public class BlobStoreConfiguration {
     @NotNull
     @JsonProperty("approvedContentTypes")
     private Set<String> _approvedContentTypes = ImmutableSet.of();
-
-    public String getSystemTablePlacement() {
-        return _systemTablePlacement;
-    }
-
-    public BlobStoreConfiguration setSystemTablePlacement(String systemTablePlacement) {
-        _systemTablePlacement = systemTablePlacement;
-        return this;
-    }
 
     public Set<String> getValidTablePlacements() {
         return _validTablePlacements;

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -150,6 +150,8 @@ public class BlobStoreModule extends PrivateModule {
         bind(HintsConsistencyTimeProvider.class).asEagerSingleton();
         bind(MinLagConsistencyTimeProvider.class).asEagerSingleton();
 
+        requireBinding(Key.get(String.class, SystemTablePlacement.class));
+
         // No bootstrap tables are required.  System tables are stored as regular SoR tables.
         bind(new TypeLiteral<Map<String, Long>>() {}).annotatedWith(BootstrapTables.class)
                 .toInstance(ImmutableMap.<String, Long>of());
@@ -220,12 +222,6 @@ public class BlobStoreModule extends PrivateModule {
             return Optional.<Mutex>of(new CuratorMutex(curator, "/lock/tables"));
         }
         return Optional.absent();
-    }
-
-
-    @Provides @Singleton @SystemTablePlacement
-    String provideSystemTablePlacement(BlobStoreConfiguration configuration) {
-        return configuration.getSystemTablePlacement();
     }
 
     @Provides @Singleton @CurrentDataCenter

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -55,7 +55,7 @@ import com.bazaarvoice.emodb.table.db.astyanax.PlacementFactory;
 import com.bazaarvoice.emodb.table.db.astyanax.PlacementsUnderMove;
 import com.bazaarvoice.emodb.table.db.astyanax.RateLimiterCache;
 import com.bazaarvoice.emodb.table.db.astyanax.SystemTableNamespace;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.astyanax.TableChangesEnabledTask;
 import com.bazaarvoice.emodb.table.db.astyanax.ValidTablePlacements;
 import com.bazaarvoice.emodb.table.db.consistency.CassandraClusters;

--- a/blob/src/test/java/com/bazaarvoice/emodb/blob/BlobStoreModuleTest.java
+++ b/blob/src/test/java/com/bazaarvoice/emodb/blob/BlobStoreModuleTest.java
@@ -18,6 +18,7 @@ import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.table.db.TableBackingStore;
 import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxTableDAO;
+import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.table.db.generic.CachingTableDAO;
 import com.bazaarvoice.emodb.table.db.generic.MutexTableDAO;
@@ -100,7 +101,6 @@ public class BlobStoreModuleTest {
 
                 // construct the minimum necessary elements to allow a BlobStore module to be created.
                 bind(BlobStoreConfiguration.class).toInstance(new BlobStoreConfiguration()
-                        .setSystemTablePlacement("ugc_global:sys")
                         .setValidTablePlacements(ImmutableSet.of("media_global:ugc"))
                         .setCassandraClusters(ImmutableMap.of("media_global", new CassandraConfiguration()
                                 .setCluster("Test Cluster")
@@ -108,6 +108,8 @@ public class BlobStoreModuleTest {
                                 .setPartitioner("bop")
                                 .setKeyspaces(ImmutableMap.of(
                                         "media_global", new KeyspaceConfiguration())))));
+
+                bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance("ugc_global:sys");
 
                 bind(DataCenterConfiguration.class).toInstance(new DataCenterConfiguration()
                         .setSystemDataCenter("datacenter1")

--- a/blob/src/test/java/com/bazaarvoice/emodb/blob/BlobStoreModuleTest.java
+++ b/blob/src/test/java/com/bazaarvoice/emodb/blob/BlobStoreModuleTest.java
@@ -18,7 +18,7 @@ import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.table.db.TableBackingStore;
 import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxTableDAO;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.table.db.generic.CachingTableDAO;
 import com.bazaarvoice.emodb.table.db.generic.MutexTableDAO;

--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/guice/SystemTablePlacement.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/guice/SystemTablePlacement.java
@@ -1,4 +1,4 @@
-package com.bazaarvoice.emodb.table.db.astyanax;
+package com.bazaarvoice.emodb.common.dropwizard.guice;
 
 import com.google.inject.BindingAnnotation;
 

--- a/job/src/main/java/com/bazaarvoice/emodb/job/JobConfiguration.java
+++ b/job/src/main/java/com/bazaarvoice/emodb/job/JobConfiguration.java
@@ -13,9 +13,6 @@ public class JobConfiguration {
     private final static int DEFAULT_QUEUE_PEEK_LIMIT = 100;
     private final static Duration DEFAULT_NOT_OWNER_RETRY_DELAY = Duration.standardMinutes(5);
 
-    // The placement holds the table with job statuses and results
-    @NotNull
-    private String _tablePlacement;
     // Number of jobs that can be run concurrently (job thread pool size)
     private int _concurrencyLevel = DEFAULT_CONCURRENCY_LEVEL;
     // How long the head of the queue should be cached locally before refreshing
@@ -24,15 +21,6 @@ public class JobConfiguration {
     private int _queuePeekLimit = DEFAULT_QUEUE_PEEK_LIMIT;
     // Minimum amount of time to wait before retrying a job locally which had returned "notOwner" on the last run
     private Duration _notOwnerRetryDelay = DEFAULT_NOT_OWNER_RETRY_DELAY;
-
-    public String getTablePlacement() {
-        return _tablePlacement;
-    }
-
-    public JobConfiguration setTablePlacement(String tablePlacement) {
-        _tablePlacement = tablePlacement;
-        return this;
-    }
 
     public int getConcurrencyLevel() {
         return _concurrencyLevel;

--- a/job/src/main/java/com/bazaarvoice/emodb/job/JobModule.java
+++ b/job/src/main/java/com/bazaarvoice/emodb/job/JobModule.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.job;
 
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode;
 import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
@@ -10,7 +11,6 @@ import com.bazaarvoice.emodb.job.api.JobService;
 import com.bazaarvoice.emodb.job.dao.DataStoreJobStatusDAO;
 import com.bazaarvoice.emodb.job.dao.JobStatusDAO;
 import com.bazaarvoice.emodb.job.dao.JobsTableName;
-import com.bazaarvoice.emodb.job.dao.JobsTablePlacement;
 import com.bazaarvoice.emodb.job.handler.DefaultJobHandlerRegistry;
 import com.bazaarvoice.emodb.job.handler.JobHandlerRegistryInternal;
 import com.bazaarvoice.emodb.job.service.DefaultJobService;
@@ -62,7 +62,7 @@ public class JobModule extends PrivateModule {
     @Override
     protected void configure() {
 
-        requireBinding(Key.get(String.class, JobsTablePlacement.class));
+        requireBinding(Key.get(String.class, SystemTablePlacement.class));
 
         bind(String.class).annotatedWith(JobQueueName.class).toInstance(QUEUE_NAME);
 

--- a/job/src/main/java/com/bazaarvoice/emodb/job/JobModule.java
+++ b/job/src/main/java/com/bazaarvoice/emodb/job/JobModule.java
@@ -21,6 +21,7 @@ import com.bazaarvoice.emodb.job.service.QueuePeekLimit;
 import com.bazaarvoice.emodb.job.service.QueueRefreshTime;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.google.common.base.Supplier;
+import com.google.inject.Key;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -60,6 +61,9 @@ public class JobModule extends PrivateModule {
 
     @Override
     protected void configure() {
+
+        requireBinding(Key.get(String.class, JobsTablePlacement.class));
+
         bind(String.class).annotatedWith(JobQueueName.class).toInstance(QUEUE_NAME);
 
         bind(JobStatusDAO.class).to(DataStoreJobStatusDAO.class).asEagerSingleton();
@@ -69,11 +73,6 @@ public class JobModule extends PrivateModule {
 
         expose(JobService.class);
         expose(JobHandlerRegistry.class);
-    }
-
-    @Provides @Singleton @JobsTablePlacement
-    protected String provideJobsTablePlacement(JobConfiguration configuration) {
-        return configuration.getTablePlacement();
     }
 
     @Provides @Singleton @JobsTableName

--- a/job/src/main/java/com/bazaarvoice/emodb/job/dao/DataStoreJobStatusDAO.java
+++ b/job/src/main/java/com/bazaarvoice/emodb/job/dao/DataStoreJobStatusDAO.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.job.dao;
 
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.common.json.JsonHelper;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.job.api.JobIdentifier;
@@ -30,7 +31,7 @@ public class DataStoreJobStatusDAO implements JobStatusDAO {
 
     @Inject
     public DataStoreJobStatusDAO(@JobsTableName final Supplier<String> tableNameSupplier,
-                                 @JobsTablePlacement final String placement,
+                                 @SystemTablePlacement final String placement,
                                  DataStore dataStore) {
         _dataStore = dataStore;
 

--- a/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
@@ -38,7 +38,7 @@ import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.util.ZKNamespaces;
 import com.bazaarvoice.ostrich.ServiceRegistry;

--- a/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
@@ -38,6 +38,7 @@ import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
+import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.util.ZKNamespaces;
 import com.bazaarvoice.ostrich.ServiceRegistry;
@@ -119,18 +120,19 @@ public class CasBlobStoreTest {
                 bind(TaskRegistry.class).toInstance(mock(TaskRegistry.class));
 
                 bind(BlobStoreConfiguration.class).toInstance(new BlobStoreConfiguration()
-                        .setSystemTablePlacement("app_global:sys")
                         .setValidTablePlacements(ImmutableSet.of("media_global:ugc"))
                         .setCassandraClusters(ImmutableMap.<String, CassandraConfiguration>of(
                                 "media_global", new TestCassandraConfiguration("media_global", "ugc_blob"))));
 
                 bind(DataStoreConfiguration.class).toInstance(new DataStoreConfiguration()
-                        .setSystemTablePlacement("app_global:sys")
                         .setValidTablePlacements(ImmutableSet.of("app_global:sys", "ugc_global:ugc"))
                         .setCassandraClusters(ImmutableMap.<String, CassandraConfiguration>of(
                                 "ugc_global", new TestCassandraConfiguration("ugc_global", "ugc_delta"),
                                 "app_global", new TestCassandraConfiguration("app_global", "sys_delta")))
                         .setHistoryTtl(Period.days(2)));
+
+                bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance("app_global:sys");
+
                 bind(DataStore.class).annotatedWith(SystemDataStore.class).toInstance(mock(DataStore.class));
                 bind(BlobStore.class).annotatedWith(SystemBlobStore.class).toInstance(mock(BlobStore.class));
                 bind(JobService.class).toInstance(mock(JobService.class));

--- a/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
@@ -38,6 +38,7 @@ import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
+import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.util.ZKNamespaces;
 import com.bazaarvoice.ostrich.HostDiscovery;
@@ -110,12 +111,14 @@ public class CasDatabusTest {
                         .setCassandraConfiguration(cassandraConfiguration));
 
                 bind(DataStoreConfiguration.class).toInstance(new DataStoreConfiguration()
-                        .setSystemTablePlacement("app_global:sys")
                         .setValidTablePlacements(ImmutableSet.of("app_global:sys", "ugc_global:ugc", "app_remote:default"))
                         .setCassandraClusters(ImmutableMap.<String, CassandraConfiguration>of(
                                 "ugc_global", new TestCassandraConfiguration("ugc_global", "ugc_delta"),
                                 "app_global", new TestCassandraConfiguration("app_global", "sys_delta")))
                         .setHistoryTtl(Period.days(2)));
+
+                bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance("app_global:sys");
+
                 bind(DataStore.class).annotatedWith(SystemDataStore.class).toInstance(mock(DataStore.class));
 
                 bind(DataCenterConfiguration.class).toInstance(new DataCenterConfiguration()

--- a/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/CasDatabusTest.java
@@ -38,7 +38,7 @@ import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.util.ZKNamespaces;
 import com.bazaarvoice.ostrich.HostDiscovery;

--- a/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
@@ -41,6 +41,7 @@ import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.util.ZKNamespaces;
 import com.bazaarvoice.ostrich.ServiceRegistry;
@@ -123,12 +124,14 @@ public class CasDataStoreTest {
                 bind(TaskRegistry.class).toInstance(mock(TaskRegistry.class));
 
                 bind(DataStoreConfiguration.class).toInstance(new DataStoreConfiguration()
-                        .setSystemTablePlacement("app_global:sys")
                         .setValidTablePlacements(ImmutableSet.of("app_global:sys", "ugc_global:ugc"))
                         .setCassandraClusters(ImmutableMap.<String, CassandraConfiguration>of(
                                 "ugc_global", new TestCassandraConfiguration("ugc_global", "ugc_delta"),
                                 "app_global", new TestCassandraConfiguration("app_global", "sys_delta")))
                         .setHistoryTtl(Period.days(2)));
+
+                bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance("app_global:sys");
+
                 bind(DataStore.class).annotatedWith(SystemDataStore.class).toInstance(mock(DataStore.class));
                 bind(JobService.class).toInstance(mock(JobService.class));
                 bind(JobHandlerRegistry.class).toInstance(mock(JobHandlerRegistry.class));

--- a/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/CasDataStoreTest.java
@@ -41,7 +41,7 @@ import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.util.ZKNamespaces;
 import com.bazaarvoice.ostrich.ServiceRegistry;

--- a/quality/integration/src/test/resources/config-blob-role.yaml
+++ b/quality/integration/src/test/resources/config-blob-role.yaml
@@ -4,6 +4,9 @@ serviceMode: STANDARD_BLOB
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #datadog:
 #  apiKey: <api-key>
@@ -34,8 +37,6 @@ dataCenter:
 
 
 systemOfRecord:
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -97,8 +98,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -164,9 +163,7 @@ queueService:
       queue: {}
 
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:
@@ -182,7 +179,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/quality/integration/src/test/resources/config-main-role.yaml
+++ b/quality/integration/src/test/resources/config-main-role.yaml
@@ -4,6 +4,9 @@ serviceMode: STANDARD_MAIN
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #datadog:
 #  apiKey: <api-key>
@@ -34,8 +37,6 @@ dataCenter:
 
 
 systemOfRecord:
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -97,8 +98,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -145,9 +144,7 @@ queueService:
       queue: {}
 
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 auth:
   # The admin and replication API keys must be encrypted using the encrypt-configuration-api-key command
@@ -155,7 +152,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/quality/integration/src/test/resources/config-stash-role.yaml
+++ b/quality/integration/src/test/resources/config-stash-role.yaml
@@ -4,6 +4,9 @@ serviceMode: SCANNER
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #datadog:
 #  apiKey: <api-key>
@@ -34,9 +37,6 @@ dataCenter:
 
 
 systemOfRecord:
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
-
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT0S
  
@@ -97,8 +97,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -145,9 +143,7 @@ queueService:
       queue: {}
 
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:
@@ -163,7 +159,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/sdk/src/main/resources/emodb-default-config.yaml
+++ b/sdk/src/main/resources/emodb-default-config.yaml
@@ -80,7 +80,7 @@ systemOfRecord:
       healthCheck:
         name: sor-cassandra
       keyspaces:
-        zglobal: {}
+        app_global: {}
         ugc_global: {}
         catalog_global: {}
 

--- a/sdk/src/main/resources/emodb-default-config.yaml
+++ b/sdk/src/main/resources/emodb-default-config.yaml
@@ -4,6 +4,8 @@ serviceMode: STANDARD_ALL
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #metrics:
 #  reporters:
@@ -50,8 +52,6 @@ dataCenter:
 
 
 systemOfRecord:
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -80,7 +80,7 @@ systemOfRecord:
       healthCheck:
         name: sor-cassandra
       keyspaces:
-        app_global: {}
+        zglobal: {}
         ugc_global: {}
         catalog_global: {}
 
@@ -109,8 +109,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -181,9 +179,7 @@ queueService:
   # It should include all members of the ZooKeeper ensemble.
   #connectString: localhost:2181
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 auth:
   # The admin and replication API keys must be encrypted using the encrypt-configuration-api-key command
@@ -191,7 +187,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
@@ -15,12 +15,6 @@ import java.util.Map;
 import java.util.Set;
 
 public class DataStoreConfiguration {
-    /**
-     * Where does the SoR store system information such as table definitions?
-     */
-    @Valid
-    @NotNull
-    private String _systemTablePlacement;
 
     @Valid
     @NotNull
@@ -89,15 +83,6 @@ public class DataStoreConfiguration {
         _stashBlackListTableCondition = stashBlackListTableCondition;
     }
 
-    public String getSystemTablePlacement() {
-        return _systemTablePlacement;
-    }
-
-    public DataStoreConfiguration setSystemTablePlacement(String systemTablePlacement) {
-        _systemTablePlacement = systemTablePlacement;
-        return this;
-    }
-
     public Set<String> getValidTablePlacements() {
         return _validTablePlacements;
     }
@@ -131,17 +116,6 @@ public class DataStoreConfiguration {
     public DataStoreConfiguration setPlacementsUnderMove(Map<String, String> placementsUnderMove) {
         _placementsUnderMove = placementsUnderMove;
         return this;
-    }
-
-    @ValidationMethod(message = ".systemTablePlacement references a keyspace not defined in 'cassandraKeyspaces'")
-    public boolean isValidSystemTablePlacement() {
-        String systemKeyspace = _systemTablePlacement.substring(0, _systemTablePlacement.indexOf(':'));
-        for (CassandraConfiguration cassandraConfig : _cassandraClusters.values()) {
-            if (cassandraConfig.getKeyspaces().containsKey(systemKeyspace)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     public SlowQueryLogConfiguration getSlowQueryLogConfiguration() {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -6,6 +6,7 @@ import com.bazaarvoice.emodb.common.cassandra.CassandraFactory;
 import com.bazaarvoice.emodb.common.cassandra.CassandraKeyspace;
 import com.bazaarvoice.emodb.common.cassandra.CqlDriverConfiguration;
 import com.bazaarvoice.emodb.common.cassandra.cqldriver.HintsPollerCQLSession;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.common.dropwizard.healthcheck.HealthCheckRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
@@ -238,17 +239,6 @@ public class DataStoreModule extends PrivateModule {
         bind(MigratorTools.class).to(DefaultMigratorTools.class);
         expose(MigratorTools.class);
     }
-
-//    @ValidationMethod(message = ".systemTablePlacement references a keyspace not defined in 'cassandraKeyspaces'")
-//    public boolean isValidSystemTablePlacement() {
-//        String systemKeyspace = _systemTablePlacement.substring(0, _systemTablePlacement.indexOf(':'));
-//        for (CassandraConfiguration cassandraConfig : _cassandraClusters.values()) {
-//            if (cassandraConfig.getKeyspaces().containsKey(systemKeyspace)) {
-//                return true;
-//            }
-//        }
-//        return false;
-//    }
 
     @Provides @Singleton
     Optional<Mutex> provideMutex(DataCenterConfiguration dataCenterConfiguration, @DataStoreZooKeeper CuratorFramework curator) {

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/DataStoreModuleTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/DataStoreModuleTest.java
@@ -26,7 +26,7 @@ import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
 import com.bazaarvoice.emodb.table.db.ClusterInfo;
 import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxTableDAO;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.table.db.generic.CachingTableDAO;
 import com.bazaarvoice.emodb.table.db.generic.MutexTableDAO;

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/DataStoreModuleTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/DataStoreModuleTest.java
@@ -26,6 +26,7 @@ import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
 import com.bazaarvoice.emodb.table.db.ClusterInfo;
 import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxTableDAO;
+import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.table.db.generic.CachingTableDAO;
 import com.bazaarvoice.emodb.table.db.generic.MutexTableDAO;
@@ -106,7 +107,6 @@ public class DataStoreModuleTest {
 
                 // construct the minimum necessary elements to allow a DataStore module to be created.
                 bind(DataStoreConfiguration.class).toInstance(new DataStoreConfiguration()
-                        .setSystemTablePlacement("app_global:sys")
                         .setHistoryTtl(Period.days(2))
                         .setValidTablePlacements(ImmutableSet.of("app_global:sys"))
                         .setCassandraClusters(ImmutableMap.of("app_global", new CassandraConfiguration()
@@ -115,6 +115,7 @@ public class DataStoreModuleTest {
                                 .setPartitioner("bop")
                                 .setKeyspaces(ImmutableMap.of(
                                         "app_global", new KeyspaceConfiguration())))));
+                bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance("app_global:sys");
 
                 bind(DataStore.class).annotatedWith(SystemDataStore.class).toInstance(mock(DataStore.class));
                 bind(DataCenterConfiguration.class).toInstance(new DataCenterConfiguration()

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
@@ -5,6 +5,7 @@ import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
 import com.bazaarvoice.emodb.cachemgr.api.InvalidationScope;
 import com.bazaarvoice.emodb.common.api.impl.LimitCounter;
 import com.bazaarvoice.emodb.common.cassandra.CassandraKeyspace;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.json.JsonHelper;
 import com.bazaarvoice.emodb.common.zookeeper.store.ValueStore;

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/CQLStashTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/CQLStashTableDAO.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.table.db.astyanax;
 
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.common.json.JsonHelper;
 import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.datastax.driver.core.BatchStatement;

--- a/web-local/config-ci-local.yaml
+++ b/web-local/config-ci-local.yaml
@@ -4,6 +4,9 @@ serviceMode: STANDARD_ALL
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #metrics:
 #  reporters:
@@ -34,7 +37,6 @@ dataCenter:
   systemDataCenterServiceUri: http://emodb.ci.us-east-1.nexus.bazaarvoice.com:8080 # Load-balanced highly available base URL for the EmoDB system data center
 
 systemOfRecord:
-  systemTablePlacement: app_global:sys        # Where does the SoR store system information such as table definitions?
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -119,7 +121,6 @@ queueService:
 
 
 blobStore:
-  systemTablePlacement: app_global:sys                  # Where does the SoR store system information such as blob store table definitions?
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -149,9 +150,7 @@ blobStore:
       latencyAware: true
       partitioner: bop
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 zooKeeper:

--- a/web-local/config-dc2.yaml
+++ b/web-local/config-dc2.yaml
@@ -4,6 +4,9 @@ serviceMode: STANDARD_ALL
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #metrics:
 #  reporters:
@@ -51,8 +54,6 @@ dataCenter:
 
 
 systemOfRecord:
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -111,8 +112,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -147,9 +146,7 @@ queueService:
     latencyAware: true
     partitioner: bop
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:
@@ -165,7 +162,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/web-local/config-jenkins.yaml
+++ b/web-local/config-jenkins.yaml
@@ -1,6 +1,8 @@
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+  systemTablePlacement: app_global:sys
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #metrics:
 #  reporters:
@@ -46,8 +48,6 @@ dataCenter:
 
 
 systemOfRecord:
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -125,8 +125,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -197,9 +195,7 @@ queueService:
     partitioner: bop
 
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:
@@ -215,7 +211,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/web-local/config-local-2.yaml
+++ b/web-local/config-local-2.yaml
@@ -7,6 +7,9 @@ serviceMode: STANDARD_ALL
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #metrics:
 #  reporters:
@@ -55,8 +58,6 @@ dataCenter:
 
 systemOfRecord:
   stashRoot: s3://emodb-us-east-1/stash/ci
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -120,8 +121,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -201,9 +200,7 @@ cqlDriver:
   multiRowFetchSize: 100
   multiRowPrefetchLimit: 50
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:
@@ -219,7 +216,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/web-local/config-local-blob-role.yaml
+++ b/web-local/config-local-blob-role.yaml
@@ -7,6 +7,9 @@ serviceMode: STANDARD_BLOB
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #metrics:
 #  reporters:
@@ -55,8 +58,6 @@ dataCenter:
 
 systemOfRecord:
   stashRoot: s3://emodb-us-east-1/stash/ci
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -118,8 +119,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -196,9 +195,7 @@ queueService:
       queue: {}
 
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:
@@ -214,7 +211,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/web-local/config-local-main-role.yaml
+++ b/web-local/config-local-main-role.yaml
@@ -7,6 +7,9 @@ serviceMode: STANDARD_MAIN
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #metrics:
 #  reporters:
@@ -55,8 +58,6 @@ dataCenter:
 
 systemOfRecord:
   stashRoot: s3://emodb-us-east-1/stash/ci
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -121,8 +122,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -197,9 +196,7 @@ queueService:
         healthCheckColumnFamily: manifest
 
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:
@@ -215,7 +212,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -7,6 +7,10 @@ serviceMode: STANDARD_ALL
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #metrics:
 #  reporters:
@@ -60,9 +64,6 @@ systemOfRecord:
 
   # Optional property - to exclude the tables satisfying the condition from the daily Stash run.
   stashBlackListTableCondition: "intrinsic(\"~table\":like(\"nostash:*\"))"
-
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -130,8 +131,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -211,17 +210,15 @@ cqlDriver:
   multiRowFetchSize: 100
   multiRowPrefetchLimit: 50
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
-
-# Configure the ZooKeeper connection used for SOA service discovery
-#zooKeeper:
-  #namespace: datacenter1
-
-  # ZooKeeper connection string that looks like "host:port,host:port,...".
-  # It should include all members of the ZooKeeper ensemble.
-  #connectString: localhost:2181
+#jobs:
+#
+#Configure the ZooKeeper connection used for SOA service discovery
+# zooKeeper:
+#  #namespace: datacenter1
+#
+#  # ZooKeeper connection string that looks like "host:port,host:port,...".
+#  # It should include all members of the ZooKeeper ensemble.
+#  #connectString: localhost:2181
 
 auth:
   # The admin and replication API keys must be encrypted using the encrypt-configuration-api-key command
@@ -229,7 +226,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/web-local/config-migrator.yaml
+++ b/web-local/config-migrator.yaml
@@ -5,6 +5,9 @@ serviceMode: DELTA_MIGRATOR
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as blob store table definitions?
+systemTablePlacement: app_global:sys
+
 deltaMigrator:
   migrateStatusTablePlacement: "app_global:migration"
   migrateApiKey:    "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"
@@ -39,8 +42,6 @@ systemOfRecord:
   migrationPhase: DOUBLE_WRITE_LEGACY_READ
   deltaBlockSizeInKb: 8
   stashRoot: s3://emodb-us-east-1/stash/ci
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -109,8 +110,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -190,9 +189,7 @@ cqlDriver:
   multiRowFetchSize: 100
   multiRowPrefetchLimit: 50
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:
@@ -208,7 +205,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/web-local/config-scantest.yaml
+++ b/web-local/config-scantest.yaml
@@ -8,6 +8,9 @@ serviceMode: SCANNER
 # A unique name for the cluster that this service node/instance belongs to; use alphanumeric and underscores only.
 cluster: local_default
 
+# Where does the system store information such as table definitions?
+systemTablePlacement: app_global:sys
+
 # Define how yammer metrics should be pushed to third-party metrics aggregators/reporters
 #metrics:
 #  reporters:
@@ -56,8 +59,6 @@ dataCenter:
 
 systemOfRecord:
   stashRoot: s3://emodb-us-east-1/stash/ci
-  # Where does the SoR store system information such as table definitions?
-  systemTablePlacement: app_global:sys
 
   # How long should we retain historical deltas? To disable, use PT0S
   historyTtl: PT48H
@@ -125,8 +126,6 @@ databus:
 
 
 blobStore:
-  # Where does the SoR store system information such as blob store table definitions?
-  systemTablePlacement: app_global:sys
 
   # All valid placement strings for create table operations.
   validTablePlacements:
@@ -206,9 +205,7 @@ cqlDriver:
   multiRowFetchSize: 100
   multiRowPrefetchLimit: 50
 
-jobs:
-  # Placement for table which holds jobs metadata and results
-  tablePlacement: "app_global:sys"
+#jobs:
 
 # Configure the ZooKeeper connection used for SOA service discovery
 #zooKeeper:
@@ -224,7 +221,6 @@ auth:
   # IN A PRODUCTION ENVIRONMENT DO NOT INCLUDE THE UNENCRYPTED KEYS IN THIS FILE!
   adminApiKey:       "zl+p3AU4/EgT8OtR0ZmLrkL70j0SklugAzd+xxYR1Dz/rioe5aXo4yay7sKi7PSKD59h7/HumH7442nGhlR2rw"  # local_admin
   replicationApiKey: "iuOPUIfI0lyxRrNZ9j9Aa68m1yrALBbVMw8kdqb6FVhSwMgOXVsuUblLr9nL73D4xpMVEZZHZr50pCBy1gbjDg"  # local_replication
-  tablePlacement: "app_global:sys"
   anonymousRoles:
   - anonymous
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoConfiguration.java
@@ -35,6 +35,11 @@ public class EmoConfiguration extends Configuration {
 
     @Valid
     @NotNull
+    @JsonProperty("_systemTablePlacement")
+    private String _systemTablePlacement;
+
+    @Valid
+    @NotNull
     @JsonProperty("systemOfRecord")
     private DataStoreConfiguration _dataStoreConfiguration;
 
@@ -114,6 +119,15 @@ public class EmoConfiguration extends Configuration {
 
     public EmoConfiguration setCluster(String cluster) {
         _cluster = cluster;
+        return this;
+    }
+
+    public String getSystemTablePlacement() {
+        return _systemTablePlacement;
+    }
+
+    public EmoConfiguration setSystemTablePlacement(String systemTablePlacement) {
+        _systemTablePlacement = systemTablePlacement;
         return this;
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -193,6 +193,21 @@ public class EmoModule extends AbstractModule {
 
     private class CommonModuleSetup extends AbstractModule {
 
+        private CommonModuleSetup() {
+            checkValidSystemTablePlacement();
+        }
+
+        private void checkValidSystemTablePlacement() {
+            String systemTablePlacement = _configuration.getSystemTablePlacement();
+            String systemKeyspace = systemTablePlacement.substring(0, systemTablePlacement.indexOf(':'));
+            for (CassandraConfiguration cassandraConfig : _configuration.getDataStoreConfiguration().getCassandraClusters().values()) {
+                if (cassandraConfig.getKeyspaces().containsKey(systemKeyspace)) {
+                    return;
+                }
+            }
+            throw new ProvisionException("System Table Placement references a keyspace not defined in 'cassandraKeyspaces");
+        }
+
         @Override
         protected void configure() {
             bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance(_configuration.getSystemTablePlacement());
@@ -273,21 +288,6 @@ public class EmoModule extends AbstractModule {
     }
 
     private class DataStoreSetup extends AbstractModule  {
-
-        private DataStoreSetup() {
-            checkValidSystemTablePlacement();
-        }
-
-        private void checkValidSystemTablePlacement() {
-            String systemTablePlacement = _configuration.getSystemTablePlacement();
-            String systemKeyspace = systemTablePlacement.substring(0, systemTablePlacement.indexOf(':'));
-            for (CassandraConfiguration cassandraConfig : _configuration.getDataStoreConfiguration().getCassandraClusters().values()) {
-                if (cassandraConfig.getKeyspaces().containsKey(systemKeyspace)) {
-                    return;
-                }
-            }
-            throw new ProvisionException("System Table Placement references a keyspace not defined in 'cassandraKeyspaces");
-        }
 
         @Override
         protected void configure() {

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -52,7 +52,6 @@ import com.bazaarvoice.emodb.datacenter.DataCenterModule;
 import com.bazaarvoice.emodb.job.JobConfiguration;
 import com.bazaarvoice.emodb.job.JobModule;
 import com.bazaarvoice.emodb.job.JobZooKeeper;
-import com.bazaarvoice.emodb.job.dao.JobsTablePlacement;
 import com.bazaarvoice.emodb.plugin.PluginConfiguration;
 import com.bazaarvoice.emodb.plugin.PluginServerMetadata;
 import com.bazaarvoice.emodb.plugin.lifecycle.ServerStartedListener;
@@ -83,7 +82,7 @@ import com.bazaarvoice.emodb.sor.core.DataStoreAsyncModule;
 import com.bazaarvoice.emodb.sor.core.SystemDataStore;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForMultiGets;
 import com.bazaarvoice.emodb.sor.db.cql.CqlForScans;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.bazaarvoice.emodb.web.auth.AuthorizationConfiguration;
 import com.bazaarvoice.emodb.web.auth.OwnerDatabusAuthorizer;
@@ -140,7 +139,6 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.server.ServerFactory;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.validation.ValidationMethod;
 import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -293,7 +291,6 @@ public class EmoModule extends AbstractModule {
 
         @Override
         protected void configure() {
-            bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance(_configuration.getSystemTablePlacement());
             bind(DataStoreConfiguration.class).toInstance(_configuration.getDataStoreConfiguration());
             bind(new TypeLiteral<Supplier<Boolean>>(){}).annotatedWith(CqlForMultiGets.class)
                     .to(Key.get(new TypeLiteral<Setting<Boolean>>(){}, CqlForMultiGets.class));
@@ -349,7 +346,6 @@ public class EmoModule extends AbstractModule {
     private class BlobStoreSetup extends AbstractModule  {
         @Override
         protected void configure() {
-            bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance(_configuration.getSystemTablePlacement());
             bind(BlobStoreConfiguration.class).toInstance(_configuration.getBlobStoreConfiguration());
             install(new BlobStoreModule(_serviceMode, "bv.emodb.blob", _environment.metrics()));
         }
@@ -566,7 +562,6 @@ public class EmoModule extends AbstractModule {
     private class ReportSetup extends AbstractModule  {
         @Override
         protected void configure() {
-            bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance(_configuration.getSystemTablePlacement());
             install(new ReportsModule());
         }
     }
@@ -575,7 +570,6 @@ public class EmoModule extends AbstractModule {
         @Override
         protected void configure() {
             bind(JobConfiguration.class).toInstance(_configuration.getJobConfiguration());
-            bind(String.class).annotatedWith(JobsTablePlacement.class).toInstance(_configuration.getSystemTablePlacement());
             install(new JobModule(_serviceMode));
         }
 
@@ -589,7 +583,6 @@ public class EmoModule extends AbstractModule {
     private class SecuritySetup extends AbstractModule  {
         @Override
         protected void configure() {
-            bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance(_configuration.getSystemTablePlacement());
             bind(AuthorizationConfiguration.class).toInstance(_configuration.getAuthorizationConfiguration());
             install(new SecurityModule());
         }
@@ -634,7 +627,6 @@ public class EmoModule extends AbstractModule {
     private class ScannerSetup extends AbstractModule  {
         @Override
         protected void configure() {
-            bind(String.class).annotatedWith(SystemTablePlacement.class).toInstance(_configuration.getSystemTablePlacement());
             install(new ScanUploadModule(_configuration.getScanner().get()));
         }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/AuthorizationConfiguration.java
@@ -31,9 +31,6 @@ public class AuthorizationConfiguration {
     // Table for storing mappings of role groups to roles
     @NotNull
     private String _roleGroupTable = DEFAULT_ROLE_GROUP_TABLE;
-    // Placement for preceding tables
-    @NotNull
-    private String _tablePlacement;
     // EmoDB administrator
     @NotNull
     private String _adminApiKey;
@@ -85,15 +82,6 @@ public class AuthorizationConfiguration {
 
     public AuthorizationConfiguration setRoleGroupTable(String roleGroupTable) {
         _roleGroupTable = roleGroupTable;
-        return this;
-    }
-
-    public String getTablePlacement() {
-        return _tablePlacement;
-    }
-
-    public AuthorizationConfiguration setTablePlacement(String tablePlacement) {
-        _tablePlacement = tablePlacement;
         return this;
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
@@ -35,6 +35,7 @@ import com.bazaarvoice.emodb.databus.SystemIdentity;
 import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.client.DataStoreClient;
+import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
 import com.bazaarvoice.emodb.uac.api.AuthUserAccessControl;
 import com.bazaarvoice.emodb.uac.client.UserAccessControlClientFactory;
 import com.bazaarvoice.emodb.web.uac.LocalSubjectUserAccessControl;
@@ -240,9 +241,9 @@ public class SecurityModule extends PrivateModule {
     @Named("dao")
     AuthIdentityManager<ApiKey> provideAuthIdentityManagerDAO(
             AuthorizationConfiguration config, DataStore dataStore, @ApiKeyHashFunction HashFunction hash,
-            @IdentityIdSupplier Supplier<String> identityIdSupplier) {
+            @IdentityIdSupplier Supplier<String> identityIdSupplier, @SystemTablePlacement String tablePlacement) {
         return new TableAuthIdentityManagerDAO<>(ApiKey.class, dataStore, config.getIdentityTable(),
-                config.getIdIndexTable(), config.getTablePlacement(), identityIdSupplier, hash);
+                config.getIdIndexTable(), tablePlacement, identityIdSupplier, hash);
     }
 
     @Provides
@@ -298,9 +299,10 @@ public class SecurityModule extends PrivateModule {
     @Singleton
     @Named("dao")
     PermissionManager providePermissionManagerDAO(
-            AuthorizationConfiguration config, PermissionResolver permissionResolver, DataStore dataStore) {
+            AuthorizationConfiguration config, PermissionResolver permissionResolver, DataStore dataStore,
+            @SystemTablePlacement String tablePlacement) {
         return new TablePermissionManagerDAO(
-                permissionResolver, dataStore, config.getPermissionsTable(), config.getTablePlacement());
+                permissionResolver, dataStore, config.getPermissionsTable(), tablePlacement);
     }
 
     @Provides
@@ -336,9 +338,9 @@ public class SecurityModule extends PrivateModule {
     @Singleton
     @Named("dao")
     RoleManager provideRoleManagerDAO(AuthorizationConfiguration config, DataStore dataStore,
-                                      PermissionManager permissionManager) {
+                                      PermissionManager permissionManager, @SystemTablePlacement String tablePlacement) {
         return new TableRoleManagerDAO(dataStore, config.getRoleTable(), config.getRoleGroupTable(),
-                config.getTablePlacement(), permissionManager);
+                tablePlacement, permissionManager);
     }
 
     @Provides

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
@@ -35,7 +35,7 @@ import com.bazaarvoice.emodb.databus.SystemIdentity;
 import com.bazaarvoice.emodb.datacenter.DataCenterConfiguration;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.client.DataStoreClient;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.uac.api.AuthUserAccessControl;
 import com.bazaarvoice.emodb.uac.client.UserAccessControlClientFactory;
 import com.bazaarvoice.emodb.web.uac.LocalSubjectUserAccessControl;

--- a/web/src/main/java/com/bazaarvoice/emodb/web/report/ReportsModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/report/ReportsModule.java
@@ -5,6 +5,7 @@ import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
 import com.bazaarvoice.emodb.web.report.db.AllTablesReportDAO;
 import com.bazaarvoice.emodb.web.report.db.DAOReportLoader;
 import com.bazaarvoice.emodb.web.report.db.EmoTableAllTablesReportDAO;
+import com.google.inject.Key;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
@@ -17,12 +18,9 @@ public class ReportsModule extends PrivateModule {
         bind(ReportLoader.class).to(DAOReportLoader.class).asEagerSingleton();
         bind(AllTablesReportGenerator.class).asEagerSingleton();
 
+        requireBinding(Key.get(String.class, SystemTablePlacement.class));
+
         expose(AllTablesReportGenerator.class);
         expose(ReportLoader.class);
-    }
-
-    @Provides @Singleton @SystemTablePlacement
-    String provideSystemTablePlacement(DataStoreConfiguration configuration) {
-        return configuration.getSystemTablePlacement();
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/report/ReportsModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/report/ReportsModule.java
@@ -1,14 +1,11 @@
 package com.bazaarvoice.emodb.web.report;
 
-import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.web.report.db.AllTablesReportDAO;
 import com.bazaarvoice.emodb.web.report.db.DAOReportLoader;
 import com.bazaarvoice.emodb.web.report.db.EmoTableAllTablesReportDAO;
 import com.google.inject.Key;
 import com.google.inject.PrivateModule;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
 
 public class ReportsModule extends PrivateModule {
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/report/db/EmoTableAllTablesReportDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/report/db/EmoTableAllTablesReportDAO.java
@@ -17,7 +17,7 @@ import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
 import com.bazaarvoice.emodb.sor.delta.MapDeltaBuilder;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.web.report.AllTablesReportQuery;
 import com.bazaarvoice.emodb.web.report.ReportNotFoundException;
 import com.bazaarvoice.emodb.web.report.TableStatistics;

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
@@ -25,7 +25,7 @@ import com.bazaarvoice.emodb.queue.api.QueueService;
 import com.bazaarvoice.emodb.queue.client.QueueClientFactory;
 import com.bazaarvoice.emodb.queue.client.QueueServiceAuthenticator;
 import com.bazaarvoice.emodb.sor.api.DataStore;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.bazaarvoice.emodb.web.auth.ApiKeyEncryption;
 import com.bazaarvoice.emodb.web.scanner.config.ScannerConfiguration;
 import com.bazaarvoice.emodb.web.scanner.config.ScheduledScanConfiguration;

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
@@ -24,9 +24,8 @@ import com.bazaarvoice.emodb.queue.api.AuthQueueService;
 import com.bazaarvoice.emodb.queue.api.QueueService;
 import com.bazaarvoice.emodb.queue.client.QueueClientFactory;
 import com.bazaarvoice.emodb.queue.client.QueueServiceAuthenticator;
-import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
 import com.bazaarvoice.emodb.sor.api.DataStore;
-import com.bazaarvoice.emodb.web.EmoConfiguration;
+import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
 import com.bazaarvoice.emodb.web.auth.ApiKeyEncryption;
 import com.bazaarvoice.emodb.web.scanner.config.ScannerConfiguration;
 import com.bazaarvoice.emodb.web.scanner.config.ScheduledScanConfiguration;
@@ -76,12 +75,7 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
-import com.google.inject.Inject;
-import com.google.inject.PrivateModule;
-import com.google.inject.Provider;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
-import com.google.inject.TypeLiteral;
+import com.google.inject.*;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
@@ -110,16 +104,18 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class ScanUploadModule extends PrivateModule {
     private final ScannerConfiguration _config;
 
-    public ScanUploadModule(EmoConfiguration config) {
-        _config = config.getScanner().get();
+    public ScanUploadModule(ScannerConfiguration config) {
+        checkArgument(config.getScanThreadCount() > 0, "Scan thread count must be at least 1");
+        checkArgument(config.getUploadThreadCount() > 0, "Upload thread count must be at least 1");
 
-        checkArgument(_config.getScanThreadCount() > 0, "Scan thread count must be at least 1");
-        checkArgument(_config.getUploadThreadCount() > 0, "Upload thread count must be at least 1");
+        _config = config;
     }
 
     @Override
     protected void configure() {
         binder().requireExplicitBindings();
+
+        requireBinding(Key.get(String.class, SystemTablePlacement.class));
 
         bind(ScanUploader.class).asEagerSingleton();
         bind(StashRequestManager.class).asEagerSingleton();
@@ -173,15 +169,15 @@ public class ScanUploadModule extends PrivateModule {
     @Provides
     @Singleton
     @ScanStatusTablePlacement
-    protected String provideScanStatusTablePlacement(DataStoreConfiguration config) {
-        return config.getSystemTablePlacement();
+    protected String provideScanStatusTablePlacement(@SystemTablePlacement String tablePlacement) {
+        return tablePlacement;
     }
 
     @Provides
     @Singleton
     @StashRequestTablePlacement
-    protected String provideScanRequestTablePlacement(DataStoreConfiguration config) {
-        return config.getSystemTablePlacement();
+    protected String provideScanRequestTablePlacement(@SystemTablePlacement String tablePlacement) {
+        return tablePlacement;
     }
     
     @Provides

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
@@ -3,10 +3,8 @@ package com.bazaarvoice.emodb.web.settings;
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
 import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
 import com.bazaarvoice.emodb.sor.api.DataStore;
-import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
 import com.google.inject.*;
-
-import java.time.Clock;
 
 /**
  * Guice module which configures globally accessible server settings.

--- a/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/settings/SettingsModule.java
@@ -1,14 +1,10 @@
 package com.bazaarvoice.emodb.web.settings;
 
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
-import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.sor.DataStoreConfiguration;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.table.db.astyanax.SystemTablePlacement;
-import com.google.inject.PrivateModule;
-import com.google.inject.Provider;
-import com.google.inject.Provides;
-import com.google.inject.Singleton;
+import com.google.inject.*;
 
 import java.time.Clock;
 
@@ -36,19 +32,10 @@ public class SettingsModule extends PrivateModule {
         bind(SettingsRegistry.class).to(SettingsManager.class);
         bind(Settings.class).to(SettingsManager.class);
 
+        requireBinding(Key.get(String.class, SystemTablePlacement.class));
+
         expose(SettingsRegistry.class);
         expose(Settings.class);
-    }
-
-    /**
-     * Returns the binding for the system table placement.  This implementation piggy-backs on the system table
-     * placement from the DataStore configuration.  This isn't optimal since it's violating separation of concerns,
-     * but until there is a globally accessible system table placement available for injection this will
-     * have to suffice.
-     */
-    @Provides @Singleton @SystemTablePlacement
-    String provideSystemTablePlacement(DataStoreConfiguration config) {
-        return config.getSystemTablePlacement();
     }
 
     @Provides @Singleton @SettingsCacheRegistry


### PR DESCRIPTION
## Github Issue #

[53](https://github.com/bazaarvoice/emodb/issues/53)

## What Are We Doing Here?

This PR consolidates the system table placement into the upper level emo configuration and removes it from subset configurations. The emo guice module now injects the placement into the dependent modules.

## How to Test and Verify

1. Check out this PR
2. Build Emo
3. Run locally
4. Run `cqlsh` and observe that app_global:sys is still being used as the system table

## Risk

### Level 

`Low`

### Required Testing

`Smoke`

### Risk Summary

This is extremely low risk, as any potential issue would be quickly discovered on boot.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
