### PR TITLE
Added a single metric per system queue for maximum local lag

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
@@ -23,6 +23,7 @@ import com.bazaarvoice.emodb.databus.core.DefaultDatabus;
 import com.bazaarvoice.emodb.databus.core.DefaultFanoutManager;
 import com.bazaarvoice.emodb.databus.core.DefaultRateLimitedLogFactory;
 import com.bazaarvoice.emodb.databus.core.DrainFanoutPartitionTask;
+import com.bazaarvoice.emodb.databus.core.FanoutLagMonitor;
 import com.bazaarvoice.emodb.databus.core.FanoutManager;
 import com.bazaarvoice.emodb.databus.core.HashingPartitionSelector;
 import com.bazaarvoice.emodb.databus.core.MasterFanout;
@@ -149,6 +150,7 @@ public class DatabusModule extends PrivateModule {
             bind(DefaultReplicationManager.class).asEagerSingleton();
             bind(ReplicationEnabledTask.class).asEagerSingleton();
             bind(SystemQueueMonitorManager.class).asEagerSingleton();
+            bind(FanoutLagMonitor.class).asEagerSingleton();
         }
 
         // Databus

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/FanoutLagMonitor.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/FanoutLagMonitor.java
@@ -1,0 +1,87 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import com.bazaarvoice.emodb.common.dropwizard.metrics.MetricsGroup;
+import com.bazaarvoice.emodb.datacenter.api.DataCenter;
+import com.bazaarvoice.emodb.datacenter.api.DataCenters;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import org.joda.time.Duration;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Service which monitors the lags for all fanouts currently being performed by this server and publishes the maximum
+ * as a single metric.
+ */
+public class FanoutLagMonitor extends AbstractScheduledService {
+
+    private static final Duration LAG_UPDATE_INTERVAL = Duration.standardSeconds(10);
+
+    private final int _masterFanoutPartitions;
+    private final int _dataCenterFanoutPartitions;
+    private final DataCenters _dataCenters;
+    private final MetricRegistry _metricRegistry;
+    private final MetricsGroup _gauges;
+
+    public FanoutLagMonitor(int masterFanoutPartitions, int dataCenterFanoutPartitions, DataCenters dataCenters,
+                            MetricRegistry metricRegistry) {
+        _masterFanoutPartitions = masterFanoutPartitions;
+        _dataCenterFanoutPartitions = dataCenterFanoutPartitions;
+        _dataCenters = checkNotNull(dataCenters, "dataCenters");
+        _metricRegistry = checkNotNull(metricRegistry, "metricRegistry");
+        _gauges = new MetricsGroup(metricRegistry);
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+        return Scheduler.newFixedDelaySchedule(0, LAG_UPDATE_INTERVAL.getMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        _gauges.close();
+    }
+
+    @Override
+    protected void runOneIteration() throws Exception {
+        _gauges.beginUpdates();
+
+        _gauges.gauge(lagMetric("master")).set(getMaximumLag("master", _masterFanoutPartitions));
+
+        DataCenter self = _dataCenters.getSelf();
+        for (DataCenter dataCenter : _dataCenters.getAll()) {
+            if (!dataCenter.equals(self)) {
+                String metricName = "in-" + dataCenter.getName();
+                _gauges.gauge(lagMetric(metricName)).set(getMaximumLag(metricName, _dataCenterFanoutPartitions));
+            }
+        }
+
+        _gauges.endUpdates();
+    }
+
+    private String lagMetric(String name) {
+        return MetricRegistry.name("bv.emodb.databus", "DefaultFanout", "lagSeconds", name);
+    }
+
+    private String partitionLagMetric(String name, int partition) {
+        return MetricRegistry.name("bv.emodb.databus", "DefaultFanout", "lagSeconds", name, "partition-" + partition);
+    }
+
+    private long getMaximumLag(String name, int partitions) {
+        final Set<String> metricNames = Sets.newHashSet();
+        for (int partition=0; partition < partitions; partition++) {
+            metricNames.add(partitionLagMetric(name, partition));
+        }
+        MetricFilter metricFilter = (metricName, metric) -> metricNames.contains(metricName);
+
+        return _metricRegistry.getGauges(metricFilter).values().stream()
+                .map(gauge -> ((Number) gauge.getValue()).longValue())
+                .max(Long::compareTo)
+                .orElse(0L);
+    }
+}

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitor.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitor.java
@@ -84,7 +84,7 @@ public class SystemQueueMonitor extends AbstractScheduledService {
             if (!dataCenter.equals(self)) {
                 long totalDataCenterQueueSize = 0;
                 for (int partition = 0; partition < _dataCenterFanoutPartitions; partition++) {
-                    totalDataCenterQueueSize += pollQueueSize("out-" + dataCenter.getName() + partition,
+                    totalDataCenterQueueSize += pollQueueSize("out-" + dataCenter.getName() + "-" + partition,
                             ChannelNames.getReplicationFanoutChannel(dataCenter, partition));
                 }
                 _gauges.gauge(newMetric("out-" + dataCenter.getName())).set(totalDataCenterQueueSize);

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitorManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitorManager.java
@@ -22,12 +22,7 @@ import org.apache.curator.framework.CuratorFramework;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Starts the System queue length monitor, subject to ZooKeeper leader election.
- * Additionally starts the System queue lag monitor.  The lag is the maximum lag of all system queues currently being
- * fanned out by this server, as determined by leadership election.  Therefore it is not subject to leadership election
- * and runs on every server, but the maximum it reports will only be the maximum for those queues with local leadership.
- */
+/** Starts the System queue length monitor, subject to ZooKeeper leader election. */
 public class SystemQueueMonitorManager {
     @Inject
     SystemQueueMonitorManager(LifeCycleRegistry lifeCycle,
@@ -51,8 +46,5 @@ public class SystemQueueMonitorManager {
         ServiceFailureListener.listenTo(leaderService, metricRegistry);
         dropwizardTask.register("queue-monitor", leaderService);
         lifeCycle.manage(new ManagedGuavaService(leaderService));
-
-        FanoutLagMonitor fanoutLagMonitor = new FanoutLagMonitor(masterFanoutPartitions, dataCenterFanoutPartitions, dataCenters, metricRegistry);
-        lifeCycle.manage(new ManagedGuavaService(fanoutLagMonitor));
     }
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitorManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitorManager.java
@@ -22,7 +22,12 @@ import org.apache.curator.framework.CuratorFramework;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-/** Starts the System queue length monitor, subject to ZooKeeper leader election. */
+/**
+ * Starts the System queue length monitor, subject to ZooKeeper leader election.
+ * Additionally starts the System queue lag monitor.  The lag is the maximum lag of all system queues currently being
+ * fanned out by this server, as determined by leadership election.  Therefore it is not subject to leadership election
+ * and runs on every server, but the maximum it reports will only be the maximum for those queues with local leadership.
+ */
 public class SystemQueueMonitorManager {
     @Inject
     SystemQueueMonitorManager(LifeCycleRegistry lifeCycle,
@@ -46,5 +51,8 @@ public class SystemQueueMonitorManager {
         ServiceFailureListener.listenTo(leaderService, metricRegistry);
         dropwizardTask.register("queue-monitor", leaderService);
         lifeCycle.manage(new ManagedGuavaService(leaderService));
+
+        FanoutLagMonitor fanoutLagMonitor = new FanoutLagMonitor(masterFanoutPartitions, dataCenterFanoutPartitions, dataCenters, metricRegistry);
+        lifeCycle.manage(new ManagedGuavaService(fanoutLagMonitor));
     }
 }

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DefaultFanoutTest.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.databus.core;
 
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.databus.ChannelNames;
 import com.bazaarvoice.emodb.databus.auth.DatabusAuthorizer;
@@ -87,9 +88,11 @@ public class DefaultFanoutTest {
         _outboundPartitionSelector = mock(PartitionSelector.class);
         when(_outboundPartitionSelector.getPartition(anyString())).thenReturn(0);
 
-        _defaultFanout = new DefaultFanout("test", mock(EventSource.class), eventSink, _outboundPartitionSelector,
+        MetricRegistry metricRegistry = new MetricRegistry();
+
+        _defaultFanout = new DefaultFanout("test", "test", mock(EventSource.class), eventSink, _outboundPartitionSelector,
                 Duration.standardSeconds(1), _subscriptionsSupplier, _currentDataCenter, rateLimitedLogFactory, subscriptionEvaluator,
-                "test", new MetricRegistry(), Clock.systemUTC());
+                new FanoutLagMonitor(mock(LifeCycleRegistry.class), metricRegistry), metricRegistry, Clock.systemUTC());
     }
 
     @Test


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

In the last release, 5.6.13, a the fanout queues were partitioned.  There are metrics for each partition as well as a single metrics for each fanout queue's size which sums the sizes of each partition's queue and publishes the sum as a single metric.  However, there is no equivalent single metric which publishes the maximum lag for all fanout queues.  This isn't strictly necessary since it can be derived by getting the maximum of each individual partition queue's lag, but this requires the metrics observer to know a priori how may partitions there are.  This PR simplifies this by adding an additional metric which is the maximum lag for all fanout partitions being fanned out on the local server by leadership election.  Getting the maximum of all maximums reported by each server then gives the maximum system-wide lag.

## How to Test and Verify

This is difficult to test locally since it's difficult to control the actual lag.  However, it can be verified that the new metric is being published by doing the following:

```
> curl localhost:8081/metrics | jq -r '.gauges | keys[] | select(startswith("bv.emodb.databus.DefaultFanout.lagSeconds.master"))'
bv.emodb.databus.DefaultFanout.lagSeconds.master
bv.emodb.databus.DefaultFanout.lagSeconds.master.legacy
bv.emodb.databus.DefaultFanout.lagSeconds.master.partition-0
bv.emodb.databus.DefaultFanout.lagSeconds.master.partition-1
bv.emodb.databus.DefaultFanout.lagSeconds.master.partition-2
bv.emodb.databus.DefaultFanout.lagSeconds.master.partition-3
```

Notice that all of the existing metrics are present (legacy + per-partition) plus the first total lag metric.

### Risk

This is a pretty low risk change.  As long as there are no regression errors the affect of a bug would be limited to the metrics.

### Level 

`Low`.  This PR only introduces new metrics, it doesn't change any existing metrics or significantly change any existing code paths.

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
