### PR TITLE
Removed polling of legacy fanout channels

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/ChannelNames.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/ChannelNames.java
@@ -21,16 +21,8 @@ public class ChannelNames {
         return channel.startsWith(MASTER_FANOUT) || channel.startsWith(REPLICATION_FANOUT_PREFIX);
     }
 
-    public static String getLegacyMasterFanoutChannel() {
-        return MASTER_FANOUT;
-    }
-
     public static String getMasterFanoutChannel(int partition) {
         return String.format("%s[%d]", MASTER_FANOUT, partition);
-    }
-    
-    public static String getLegacyReplicationFanoutChannel(DataCenter dataCenter) {
-        return REPLICATION_FANOUT_PREFIX + dataCenter.getName();
     }
 
     public static String getReplicationFanoutChannel(DataCenter dataCenter, int partition) {

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/FanoutManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/FanoutManager.java
@@ -2,20 +2,13 @@ package com.bazaarvoice.emodb.databus.core;
 
 import com.bazaarvoice.emodb.databus.repl.ReplicationSource;
 import com.bazaarvoice.emodb.datacenter.api.DataCenter;
-import com.google.common.util.concurrent.Service;
 import io.dropwizard.lifecycle.Managed;
 
 public interface FanoutManager {
 
     /** Starts the main fanout thread that copies from __system_bus:master to individual subscriptions. */
     Managed newMasterFanout();
-
-    /** Starts the legacy fanout thread that copies from __system_bus:master to individual subscriptions. */
-    Managed newLegacyMasterFanout();
-
+    
     /** Starts polling remote data centers and copying events to local individual subscriptions. */
     Managed newInboundReplicationFanout(DataCenter dataCenter, ReplicationSource replicationSource);
-
-    /** Starts polling remote data centers from the legacy queue and copying events to local individual subscriptions. */
-    Managed newLegacyInboundReplicationFanout(DataCenter dataCenter, ReplicationSource replicationSource);
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/MasterFanout.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/MasterFanout.java
@@ -9,10 +9,5 @@ public class MasterFanout {
     @Inject
     public MasterFanout(LifeCycleRegistry lifeCycle, final FanoutManager fanoutManager) {
         lifeCycle.manage(fanoutManager.newMasterFanout());
-
-        // Until both of the following are true we need to continue running the legacy master fanout:
-        // 1. All servers writing to the legacy un-partitioned master queue have been taken out of service
-        // 2. All events previously written to the master fanout have been processed and acknowledged
-        lifeCycle.manage(fanoutManager.newLegacyMasterFanout());
     }
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitor.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SystemQueueMonitor.java
@@ -68,7 +68,6 @@ public class SystemQueueMonitor extends AbstractScheduledService {
     private void pollQueueSizes() {
         _gauges.beginUpdates();
 
-        pollQueueSize("legacy-master", ChannelNames.getLegacyMasterFanoutChannel());
         long totalMasterQueueSize = 0;
         for (int partition = 0; partition < _masterFanoutPartitions; partition++) {
             totalMasterQueueSize += pollQueueSize("master-" + partition, ChannelNames.getMasterFanoutChannel(partition));
@@ -88,8 +87,6 @@ public class SystemQueueMonitor extends AbstractScheduledService {
                             ChannelNames.getReplicationFanoutChannel(dataCenter, partition));
                 }
                 _gauges.gauge(newMetric("out-" + dataCenter.getName())).set(totalDataCenterQueueSize);
-
-                pollQueueSize("legacy-out-" + dataCenter.getName(), ChannelNames.getLegacyReplicationFanoutChannel(dataCenter));
             }
         }
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/DefaultReplicationManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/DefaultReplicationManager.java
@@ -146,11 +146,6 @@ public class DefaultReplicationManager extends AbstractScheduledService {
             protected void doStart() {
                 _fanout = _fanoutManager.newInboundReplicationFanout(dataCenter, replicationSource);
 
-                // Until both of the following are true we need to continue running the legacy master fanout:
-                // 1. All servers writing to the legacy un-partitioned replication queue have been taken out of service
-                // 2. All events previously written to the replication fanout have been processed and acknowledged
-                _legacyFanout = _fanoutManager.newLegacyInboundReplicationFanout(dataCenter, replicationSource);
-                
                 try {
                     _fanout.start();
                     _legacyFanout.start();

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/DefaultReplicationManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/DefaultReplicationManager.java
@@ -19,13 +19,11 @@ import com.bazaarvoice.ostrich.pool.ServicePoolBuilder;
 import com.bazaarvoice.ostrich.pool.ServicePoolProxies;
 import com.bazaarvoice.ostrich.retry.ExponentialBackoffRetry;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.common.util.concurrent.AbstractService;
-import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.sun.jersey.api.client.Client;
@@ -140,7 +138,6 @@ public class DefaultReplicationManager extends AbstractScheduledService {
         // Start asynchronously downloading events from the remote data center.
         final Managed fanout = new GuavaServiceController(_replicationEnabled, () -> new AbstractService() {
             Managed _fanout = null;
-            Managed _legacyFanout = null;
 
             @Override
             protected void doStart() {
@@ -148,7 +145,6 @@ public class DefaultReplicationManager extends AbstractScheduledService {
 
                 try {
                     _fanout.start();
-                    _legacyFanout.start();
                 } catch (Exception e) {
                     throw Throwables.propagate(e);
                 }
@@ -161,10 +157,6 @@ public class DefaultReplicationManager extends AbstractScheduledService {
                     if (_fanout != null) {
                         _fanout.stop();
                         _fanout = null;
-                    }
-                    if (_legacyFanout != null) {
-                        _legacyFanout.stop();
-                        _legacyFanout = null;
                     }
                 } catch (Exception e) {
                     throw Throwables.propagate(e);


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

In https://github.com/bazaarvoice/emodb/pull/157 the fanout queues were partitioned and moved to new channels.  To maintain a smooth loss-less migration EmoDB currently polls the partitioned and legacy fanout queues.  Once all servers have been upgraded and the legacy queues fully drained this polling is no longer necessary.  This PR removes polling the legacy fanout queues.

## How to Test and Verify

There are no new features with this PR.  Regression check to ensure the partitioned queues are still being polled as expected.

## Risk

Low.  Once these legacy fanout queues are empty they are not in any write-paths, so removing this polling should have no effect.

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
