### PR TITLE
Remove legacy table mutex

### DIFF
--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -216,7 +216,7 @@ public class BlobStoreModule extends PrivateModule {
     Optional<TableMutexManager> provideTableMutexManager(DataCenterConfiguration dataCenterConfiguration, @BlobStoreZooKeeper CuratorFramework curator) {
         // We only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            return Optional.of(new TableMutexManager(curator, "/lock/tables", "/lock/table-partitions"));
+            return Optional.of(new TableMutexManager(curator, "/lock/table-partitions"));
         }
         return Optional.absent();
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -260,7 +260,7 @@ public class DataStoreModule extends PrivateModule {
     Optional<TableMutexManager> provideTableMutexManager(DataCenterConfiguration dataCenterConfiguration, @DataStoreZooKeeper CuratorFramework curator) {
         // We only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         if (dataCenterConfiguration.isSystemDataCenter()) {
-            return Optional.of(new TableMutexManager(curator, "/lock/tables", "/lock/table-partitions"));
+            return Optional.of(new TableMutexManager(curator, "/lock/table-partitions"));
         }
         return Optional.absent();
     }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
@@ -13,23 +13,18 @@ public class TableMutexManager {
     private static final int NUM_MUTEXES = 256;
 
     private final Mutex[] _mutexes;
-    private final CuratorMutex _oldMutex;
 
-    public TableMutexManager(CuratorFramework curator, String oldPath, String newPath) {
+    public TableMutexManager(CuratorFramework curator, String path) {
         _mutexes = new Mutex[NUM_MUTEXES];
         for (int i = 0; i < NUM_MUTEXES; i++) {
-            _mutexes[i] = new CuratorMutex(curator, ZKPaths.makePath(newPath, Integer.toString(i)));
+            _mutexes[i] = new CuratorMutex(curator, ZKPaths.makePath(path, Integer.toString(i)));
         }
-        _oldMutex = new CuratorMutex(curator, oldPath);
     }
 
     public void runWithLockForTable(Runnable runnable, Duration acquireTimeout, String table) {
 
-
-        _oldMutex.runWithLock(() -> {
-            _mutexes[Math.abs(Hashing.murmur3_128().hashString(table, Charsets.UTF_8).asInt() % NUM_MUTEXES)]
-                            .runWithLock(runnable, acquireTimeout);
-        }, acquireTimeout);
+        _mutexes[Math.abs(Hashing.murmur3_128().hashString(table, Charsets.UTF_8).asInt() % NUM_MUTEXES)]
+                .runWithLock(runnable, acquireTimeout);
 
     }
 }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/curator/TableMutexManager.java
@@ -4,9 +4,10 @@ import com.bazaarvoice.emodb.table.db.Mutex;
 import com.google.common.base.Charsets;
 import com.google.common.hash.Hashing;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.locks.InterProcessMutex;
 import org.apache.curator.utils.ZKPaths;
 import org.joda.time.Duration;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class TableMutexManager {
 
@@ -22,7 +23,8 @@ public class TableMutexManager {
     }
 
     public void runWithLockForTable(Runnable runnable, Duration acquireTimeout, String table) {
-
+        checkNotNull(table, "table cannot be null");
+        
         _mutexes[Math.abs(Hashing.murmur3_128().hashString(table, Charsets.UTF_8).asInt() % NUM_MUTEXES)]
                 .runWithLock(runnable, acquireTimeout);
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

This is the follow up PR to #156. This PR removes the legacy mutex that can now be removed because all Emo instances are also locking on table specific mutexes.

## How to Test and Verify

Like the previous PR, Testing this is difficult, as it is difficult to prove any race condition. By result, most of the testing I have done so far has just been the usually battery of table creation and modification tests.

## Risk

### Level 

`Hight`

### Required Testing

`Regression`

### Risk Summary

This is actually pretty risky, as the consequences could be pretty severe if there is a race condition that we aren't noticing.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
