### PR TITLE
Added union functionality for scan ranges

### DIFF
--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/db/ScanRangeTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/db/ScanRangeTest.java
@@ -62,4 +62,53 @@ public class ScanRangeTest {
         // Shared endpoints but no overlap
         assertEquals(create(b, c).intersection(create(c, b)), empty);
     }
+
+    @Test
+    public void testUnion() {
+        ByteBuffer a = ByteBuffer.wrap(BaseEncoding.base16().decode("010000000000000064666F6F"));
+        ByteBuffer b = ByteBuffer.wrap(BaseEncoding.base16().decode("030000000000000064666F6F"));
+        ByteBuffer c = ByteBuffer.wrap(BaseEncoding.base16().decode("050000000000000064666F6F"));
+        ByteBuffer d = ByteBuffer.wrap(BaseEncoding.base16().decode("070000000000000064666F6F"));
+        ByteBuffer e = ByteBuffer.wrap(BaseEncoding.base16().decode("090000000000000064666F6F"));
+
+        // Non-wrapping tests
+
+        // Equality
+        assertEquals(create(a, b).union(create(a, b)), ImmutableList.of(create(a, b)));
+        // Shared start
+        assertEquals(create(a, c).union(create(a, b)), ImmutableList.of(create(a, c)));
+        // Shared end
+        assertEquals(create(a, c).union(create(b, c)), ImmutableList.of(create(a, c)));
+        // Partial overlap
+        assertEquals(create(a, c).union(create(b, d)), ImmutableList.of(create(a, d)));
+        // No overlap
+        assertEquals(create(a, b).union(create(c, d)), ImmutableList.of(create(a, b), create(c, d)));
+        // Shared endpoint but no overlap
+        assertEquals(create(a, b).union(create(b, c)), ImmutableList.of(create(a, c)));
+
+        // Wrapping tests
+
+        // Complete range, same endpoint
+        assertEquals(create(a, a).union(create(a, a)), ImmutableList.of(ScanRange.all()));
+        // Complete range, different endpoint
+        assertEquals(create(a, a).union(create(b, b)), ImmutableList.of(ScanRange.all()));
+        // Partial overlap with low-end
+        assertEquals(create(a, d).union(create(e, c)), ImmutableList.of(create(e, d)));
+        // Complete overlap with low-end
+        assertEquals(create(a, b).union(create(d, c)), ImmutableList.of(create(d, c)));
+        // Partial overlap with high-end
+        assertEquals(create(b, e).union(create(c, a)), ImmutableList.of(create(b, a)));
+        // Complete overlap with high-end
+        assertEquals(create(d, e).union(create(c, b)), ImmutableList.of(create(c, b)));
+        // Double overlapping with partial overlap
+        assertEquals(create(d, a).union(create(e, b)), ImmutableList.of(create(d, b)));
+        // Double overlapping with complete overlap
+        assertEquals(create(d, b).union(create(e, a)), ImmutableList.of(create(d, b)));
+        // Partial overlap on both ends
+        assertEquals(create(a, e).union(create(d, b)), ImmutableList.of(ScanRange.all()));
+        // No overlap
+        assertEquals(create(b, c).union(create(e, a)), ImmutableList.of(create(b, c), create(e, a)));
+        // Shared endpoints but no overlap
+        assertEquals(create(b, c).union(create(c, b)), ImmutableList.of(ScanRange.all()));
+    }
 }


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

This PR adds the `union` method to `ScanRange` to get the union of two scan ranges.

This was done in the context of another PR.  As it turned out it wasn't needed, but since the work was done seemed useful to submit it independently in a separate PR in case it is ever needed.

## How to Test and Verify

The union method is not used in any live code, so the only way to test it is to verify the unit test works and is accurate.

## Risk

Low, since this adds no methods in the live code path.

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
