### PR TITLE
Added ability to start a Stash using the plan from a previous Stash

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/resource/StashResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/resource/StashResource1.java
@@ -6,8 +6,8 @@ import com.bazaarvoice.emodb.web.resources.SuccessResponse;
 import com.bazaarvoice.emodb.web.scanner.ScanDestination;
 import com.bazaarvoice.emodb.web.scanner.ScanOptions;
 import com.bazaarvoice.emodb.web.scanner.ScanUploader;
-import com.bazaarvoice.emodb.web.scanner.scanstatus.StashRequest;
 import com.bazaarvoice.emodb.web.scanner.scanstatus.ScanStatus;
+import com.bazaarvoice.emodb.web.scanner.scanstatus.StashRequest;
 import com.bazaarvoice.emodb.web.scanner.scheduling.StashRequestManager;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
@@ -16,7 +16,6 @@ import io.dropwizard.jersey.params.DateTimeParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.joda.time.DateTime;
-import org.joda.time.Duration;
 import org.joda.time.format.ISOPeriodFormat;
 
 import javax.ws.rs.Consumes;
@@ -63,6 +62,7 @@ public class StashResource1 {
                                 @QueryParam ("compactionEnabled") @DefaultValue ("false") Boolean compactionEnabled,
                                 @QueryParam ("rangeScanSplitSize") @DefaultValue("1000000") Integer rangeScanSplitSize,
                                 @QueryParam ("maxRangeScanTime") @DefaultValue("PT10M") String maxRangeScanTime,
+                                @QueryParam ("usePlanFrom") String usePlanFromStashId,
                                 @QueryParam ("dryRun") @DefaultValue ("false") Boolean dryRun) {
 
         checkArgument(!placements.isEmpty(), "Placement is required");
@@ -94,7 +94,10 @@ public class StashResource1 {
                 .setRangeScanSplitSize(rangeScanSplitSize)
                 .setMaxRangeScanTime(ISOPeriodFormat.standard().parsePeriod(maxRangeScanTime).toStandardDuration());
 
-        return _scanUploader.scanAndUpload(id, options, dryRun);
+        return _scanUploader.scanAndUpload(id, options)
+                .dryRun(dryRun)
+                .usePlanFromStashId(usePlanFromStashId)
+                .start();
     }
 
     @GET

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScanUploadSchedulingService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScanUploadSchedulingService.java
@@ -275,7 +275,7 @@ public class ScanUploadSchedulingService extends LeaderService {
 
             _log.info("Starting scheduled scan and upload to {} for time {}", destination, scheduledTime);
 
-            return _scanUploader.scanAndUpload(scanId, scanOptions);
+            return _scanUploader.scanAndUpload(scanId, scanOptions).start();
         }
 
         /**

--- a/web/src/test/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScanUploadSchedulingServiceTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScanUploadSchedulingServiceTest.java
@@ -148,6 +148,8 @@ public class ScanUploadSchedulingServiceTest {
     @Test(dataProvider = "every10minutes")
     public void testMissedScansStarted(DateTime now) {
         ScanUploader scanUploader = mock(ScanUploader.class);
+        ScanUploader.ScanAndUploadBuilder scanAndUploadBuilder = mock(ScanUploader.ScanAndUploadBuilder.class);
+        when(scanUploader.scanAndUpload(anyString(), any(ScanOptions.class))).thenReturn(scanAndUploadBuilder);
         StashRequestManager stashRequestManager = mock(StashRequestManager.class);
         ScheduledExecutorService executorService = mock(ScheduledExecutorService.class);
         ScanCountListener scanCountListener = mock(ScanCountListener.class);
@@ -193,6 +195,7 @@ public class ScanUploadSchedulingServiceTest {
         // Each were actually scanned.  Don't concern over the exact options, that's covered in #testStartScheduledScan().
         verify(scanUploader).scanAndUpload(eq(expectedScanId1), any(ScanOptions.class));
         verify(scanUploader).scanAndUpload(eq(expectedScanId9), any(ScanOptions.class));
+        verify(scanAndUploadBuilder, times(2)).start();
 
         verifyNoMoreInteractions(executorService, scanUploader);
     }
@@ -210,7 +213,9 @@ public class ScanUploadSchedulingServiceTest {
                         destination, DateTimeFormat.forPattern("yyyyMMddHHmmss").withZoneUTC(),
                         ImmutableList.of("placement1"), 1, true, false, 1000000, Duration.standardMinutes(10));
 
+        ScanUploader.ScanAndUploadBuilder builder = mock(ScanUploader.ScanAndUploadBuilder.class);
         ScanUploader scanUploader = mock(ScanUploader.class);
+        when(scanUploader.scanAndUpload(anyString(), any(ScanOptions.class))).thenReturn(builder);
         StashRequestManager stashRequestManager = mock(StashRequestManager.class);
         ScanCountListener scanCountListener = mock(ScanCountListener.class);
 
@@ -234,6 +239,8 @@ public class ScanUploadSchedulingServiceTest {
                         .setMaxConcurrentSubRangeScans(1)
                         .setScanByAZ(true));
 
+        verify(builder).start();
+        
         verifyNoMoreInteractions(scanUploader);
     }
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

We've seen when Cassandra is under stress at the time Stash starts it may timeout trying to get splits for the plan.  Unlike most of Stash this represents a single point of failure; if this first step of generating the plan fails then the entire Stash fails.  PR #163 was introduced to help with this issue.  As an additional backup this PR gives an administrator the ability to create a new Stash using the same plan from a previous successful Stash.  This way there is no attempt to get splits from Cassandra at all in order to begin Stash.

This is not ideal in all circumstances because if there have been significant writes to Emo since the last Stash the splits may be disproportionately large.  This is ok, Stash is resilient to this, but it means that Stash could be slowed down because of this.  Therefore it is generally a good idea to always use the last successful Stash's plan, though the API allow selection of any prior Stash.

## How to Test and Verify

1. Check out this PR
2. Run Emo, create tables, write some documents
3. Generate a stash using the StashResource API.
4. Once it completes generate another Stash with the `usePlanFrom` parameter as the ID of the first Stash.
5. Use the StashResource API to verify both plans are identical.

## Risk

This is a low risk change.  None of the core functionality of Stash is changed, only an alternate method for building the initial plan.  This new functionality is also only introduced by using the StashResource API, so normal Stash operations are unaffected by this update.

### Level 

`Medium`

### Required Testing

`Manual`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
