### PR TITLE
Updated refetch query to be adaptive if cached results are no longer in memory

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
@@ -743,10 +743,9 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
 
         Statement statement = where
                 .orderBy(ascending ? asc(tableDDL.getChangeIdColumnName()) : desc(tableDDL.getChangeIdColumnName()))
-                .setFetchSize(_driverConfig.getSingleRowFetchSize())
                 .setConsistencyLevel(consistency);
 
-        return placement.getKeyspace().getCqlSession().execute(statement);
+        return AdaptiveResultSet.executeAdaptiveQuery(placement.getKeyspace().getCqlSession(), statement, _driverConfig.getSingleRowFetchSize());
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
@@ -737,10 +737,9 @@ public class CqlDataReaderDAO implements DataReaderDAO, MigratorReaderDAO {
         Statement statement = where
                 .orderBy(ascending ? asc(tableDDL.getChangeIdColumnName()) : desc(tableDDL.getChangeIdColumnName()))
                 .limit(limit)
-                .setFetchSize(_driverConfig.getSingleRowFetchSize())
                 .setConsistencyLevel(consistency);
 
-        return placement.getKeyspace().getCqlSession().execute(statement);
+        return AdaptiveResultSet.executeAdaptiveQuery(placement.getKeyspace().getCqlSession(), statement, _driverConfig.getSingleRowFetchSize());
     }
 
     @Override


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

When Emo performs a multi-row query (such as with splits or Stash reads) it does the following:

1. A `ResultSet` is generated which returns all CQL rows.
2. This raw `ResultSet` is wrapped in a `DeltaRowGroupResultSetIterator`.  This iterator provides a view which groups all rows for the same key into a single iterator.
3. This is then further wrapped by a `CachingRowGroupIterator`.  This iterator takes the grouped rows from the previous iterator and softly references all but the first 20 results.
4. If any of the softly-cached rows are garbage collected the iterator reloads the remaining rows for the key and iterates them directly from Cassandra.

Most queries from Cassandra are wrapped in an `AdaptiveResultSet`.  This is a helper for `ResultSet`s which checks for whether fetching results fails because the result size is too large.  When this happens it reduces the fetch size and tries again.

The re-query performed when the cached results are lost is not wrapped in an `AdaptiveResultSet`.  We've seen evidence that this can lead to queries failing when a) memory pressure is high and b) a single row contains many many deltas, such that the results exceed the 256 MB frame buffer size.

This PR wraps those re-querys with an `AdaptiveResultSet`


## How to Test and Verify

This is a difficult circumstance to force.  The best way to test would be to disable compaction, perform many large delta writes to a single row, then verify that the table with that row can be scanned.

## Risk

This is a fairly low risk change.  The `AdaptiveResultSet` is already widely in use in queries, so the effect should only be to add the existing adaptive behavior to this previously existing query.

### Level 

`Medium`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
