### PR TITLE
Fixed stash client to work with buckets in all regions

### DIFF
--- a/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashUtil.java
+++ b/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashUtil.java
@@ -1,17 +1,16 @@
 package com.bazaarvoice.emodb.common.stash;
 
-import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
-import com.google.common.collect.ImmutableMap;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import java.text.ParseException;
 import java.util.Date;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Utility methods for Stash operations.
@@ -21,11 +20,7 @@ public class StashUtil {
     public static final DateTimeFormatter STASH_DIRECTORY_DATE_FORMAT = DateTimeFormat.forPattern("yyyy-MM-dd-HH-mm-ss").withZoneUTC();
     public static final String LATEST_FILE = "_LATEST";
     public static final String SUCCESS_FILE = "_SUCCESS";
-
-    private static final Map<String, Region> REGION_BY_BUCKET = ImmutableMap.of(
-            "emodb-us-east-1", Region.getRegion(Regions.US_EAST_1),
-            "emodb-eu-west-1", Region.getRegion(Regions.EU_WEST_1));
-
+    
     /**
      * Converts characters which are valid in table names but not valid or problematic in URLs and S3 keys.
      * Since all EmoDB tables cannot have upper-case characters they make a dense substitution without
@@ -59,13 +54,17 @@ public class StashUtil {
         return table;
     }
 
-    public static Region getRegionForBucket(String bucket) {
-        Region region = REGION_BY_BUCKET.get(bucket);
-        if (region == null) {
-            // Default to us-east-1 if unknown
-            region = Region.getRegion(Regions.US_EAST_1);
+    public static Optional<String> getRegionForBucket(String bucket) {
+        if (bucket == null) {
+            return Optional.empty();
         }
-        return region;
+        if (bucket.startsWith("emodb-us-east-1")) {
+            return Optional.of(Regions.US_EAST_1.getName());
+        }
+        if (bucket.startsWith("emodb-eu-west-1")) {
+            return Optional.of(Regions.EU_WEST_1.getName());
+        }
+        return Optional.empty();
     }
 
     public static Date getStashCreationTime(String stashDirectory) {


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

The Stash client has hard-coded a map of bucket names to AWS regions.  Any bucket not explicitly listed is presumed to be in us-east-1.  As new stashes have been created in non-us-east-1 buckets not hard-coded the client has failed since the AWS client constructed is configured with the incorrect region.

This PR updates the hard-coding convention with a wider list of well-known Stash buckets used by the EmoDB team.  Additionally any buckets not hard-coded now perform a lookup for the correct region rather than presuming us-east-1.

## How to Test and Verify

This is difficult to test locally since it only affects client code and requires an S3 bucket to fully test.  The best way is to create a client and use it to access Stash in a non-us-east-1 bucket.

## Risk

Low.  This only affects client code.

### Level 

`Low`

### Required Testing

`Manual`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
