### PR TITLE
Work-around to allow Emo commands which take additional parameters to execute

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -134,7 +134,8 @@ public class EmoService extends Application<EmoConfiguration> {
         parser.addArgument("config-ddl").required(true).help("config-ddl.yaml");
 
         // Get the path to config-ddl
-        Namespace result = parser.parseArgs(args);
+        String[] first3Args = (String[]) ArrayUtils.subarray(args, 0, Math.min(args.length, 3));
+        Namespace result = parser.parseArgs(first3Args);
 
         // Remove config-ddl arg
         new EmoService(result.getString("config-ddl"), new File(result.getString("emo-config")))


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

The standard EmoDB "server" command takes 3 arguments: command ("server), path to config.yaml, and path to config-ddl.yaml.  Other commands require additional parameters, such as "encrypt-configuration-api-key" which has "--api-key" and "--cluster" parameters.  However, because of the way the command line arguments are parsed in `EmoService` running the application with any more than the first 3 positional arguments will cause an argument parser failure.

While it would be nice to rework the arguments to be more robust this PR takes a very expedient approach.  Since the first three arguments are positional it changes the first parse to only look at the first three arguments.  It still passes the full list of arguments (sans config-ddl.yaml) to `Application.run()`, so effectively this doesn't change anything, but it prevents the application from failing on that initial parse.

## How to Test and Verify

1. Check out this PR
2. Build
3. From the root directory run:
```
java -jar web/target/emodb-web-5.6.20-SNAPSHOT.jar encrypt-configuration-api-key web-local/config-local.yaml web-local/config-ddl-local.yaml --api-key foo
```
4. It should return the string "OMBxgZNnoPQkyIFRns2m00l6tl1MIDUC7T3iIlIpLywpY9hkbETXZLycx9Wbg2+W7QGoAmFbm3Z+Qu93AZ3Vgg".  Without the fix it will return an argument parsing error.

## Risk

Low.  This doesn't affect any part of Emo beyond the initial argument parsing.

### Level 

`Low`

### Required Testing

`Regression`

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
