### PR TITLE
Changed blob read consistency to be configurable and changed to default local quorum

### DIFF
--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobReadConsistency.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobReadConsistency.java
@@ -1,0 +1,19 @@
+package com.bazaarvoice.emodb.blob;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annontation for consistency level to use when reading blobs.
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface BlobReadConsistency {
+}

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreConfiguration.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreConfiguration.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.blob;
 import com.bazaarvoice.emodb.common.cassandra.CassandraConfiguration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableSet;
+import com.netflix.astyanax.model.ConsistencyLevel;
 
 import javax.annotation.Nullable;
 import javax.validation.Valid;
@@ -36,6 +37,11 @@ public class BlobStoreConfiguration {
     @NotNull
     @JsonProperty("approvedContentTypes")
     private Set<String> _approvedContentTypes = ImmutableSet.of();
+
+    @Valid
+    @NotNull
+    @JsonProperty("readConsistency")
+    private ConsistencyLevel _readConsistency = ConsistencyLevel.CL_LOCAL_QUORUM;
 
     public Set<String> getValidTablePlacements() {
         return _validTablePlacements;
@@ -78,6 +84,15 @@ public class BlobStoreConfiguration {
 
     public BlobStoreConfiguration setApprovedContentTypes(Set<String> approvedContentTypes) {
         _approvedContentTypes = approvedContentTypes;
+        return this;
+    }
+
+    public ConsistencyLevel getReadConsistency() {
+        return _readConsistency;
+    }
+
+    public BlobStoreConfiguration setReadConsistency(ConsistencyLevel readConsistency) {
+        _readConsistency = readConsistency;
         return this;
     }
 }

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -89,6 +89,7 @@ import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.matcher.Matchers;
 import com.google.inject.name.Names;
+import com.netflix.astyanax.model.ConsistencyLevel;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
 import org.joda.time.Duration;
@@ -356,5 +357,11 @@ public class BlobStoreModule extends PrivateModule {
             checkArgument(!moveMap.containsKey(entry.getValue()), "Chained moves are not allowed");
         }
         return moveMap;
+    }
+
+    @Provides @Singleton @BlobReadConsistency
+    ConsistencyLevel provideBlobReadConsistency(BlobStoreConfiguration configuration) {
+        // By default use local quorum
+        return Optional.fromNullable(configuration.getReadConsistency()).or(ConsistencyLevel.CL_LOCAL_QUORUM);
     }
 }


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

A recent increase in our sor-blob ring created an unexpectedly high number of records not written to quorum.  We will repair the ring to resolve this.  In the meantime, however, blob store reads by default use CL_ONE, and this is causing an unacceptable rate of false 404 and 500 errors as the underlying records aren't fully replicated.  This PR allows us to switch to quorum reads at least while the repair is taking place, if not long-term.

## How to Test and Verify

1. Check out this PR
2. Do blob stuff, verify it isn't broken.

## Risk

Low.  In fact, quorum reads are arguably better than CL_ONE.  I can only presume it was written this way to return blobs faster.

### Level 

`Low`

### Required Testing

`Regression`

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
