### PR TITLE
Adjusted rules around draining redundant 

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -626,10 +626,10 @@ public class DefaultDatabus implements OwnerAwareDatabus, Managed {
             approximateSize = uniqueItems.size() + deferredRawEvents.size();
         }
 
-        // Try draining the queue asynchronously there are still more events available and more than twice the number
-        // of redundant events were discarded while resolving the items found so far.
+        // Try draining the queue asynchronously if there are still more events available and more redundant events were
+        // discarded than resolved items found so far.
         // Doing this only in the poll case for now.
-        if (repeatable && eventsAvailableForNextPoll && itemsDiscarded * 2 > uniqueItems.size()) {
+        if (repeatable && eventsAvailableForNextPoll && itemsDiscarded > uniqueItems.size()) {
             drainQueueAsync(subscription);
         }
 
@@ -1092,7 +1092,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, Managed {
 
         long totalSubscriptionDrainTime = _drainedSubscriptionsMap.getOrDefault(subscription, 0L) + stopwatch.elapsed(TimeUnit.MILLISECONDS);
 
-        // submit a new task for next batch if all the found items in this batch are redundant and there are more items available on the queue.
+        // submit a new task for next batch if any the found items in this batch are redundant and there are more items available on the queue.
         // Also right now, we are only giving MAX_QUEUE_DRAIN_TIME_FOR_A_SUBSCRIPTION time for draining for a subscription for each poll. This is because there is no guarantee that the local server
         // remains as the owner of the subscription through out. The right solution here is to check if the local service still owns the subscription for each task submission.
         // But, MAX_QUEUE_DRAIN_TIME_FOR_A_SUBSCRIPTION may be OK as we can easily expect subsequent polls from the clients which will trigger these tasks again.


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

In diagnosing an issue in production we found that the databus async drainer for redundant updates frequently stops draining while the queue is still backed up with redundant updates.  This PR contains recommendations found from that investigation:

1. The draining process continues so long as there are any redundant events found at the head instead of until at least one non-redundant event is found.
2. Draining starts when over half the events IDs read during a poll instead of when all of them are.

## How to Test and Verify

1. Check out this PR
2. Create a databus subscription to all tables.
3. Create multiple records with thousands of redundant updates.
4. Poll the databus with a limit of 500.
5. Poll again.

Without the fix the second poll will always return empty or, once the TTL expires, the original event again until the event is eventually ack'd.  With the fix the async drainer will eventually clear the redundant events and the poll will return the remaining events.

## Risk

This is a fairly low risk fix.  In the worst case the draining will happen more frequently, placing whatever additional load that causes on the application servers and Cassandra hosts.

### Level 

`Medium`
### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
