### PR TITLE
Fix databus events lost immediately after table creation

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OrphanedEventException.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/OrphanedEventException.java
@@ -1,0 +1,31 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import java.time.Instant;
+
+/**
+ * Event thrown when a databus event exists for an unknown table.  Typically this happens when the table has been dropped
+ * after a document in the table was updated but before the event associated with that update is fanned out.  There
+ * also exists a race condition where document updates written immediately after a table is created may reach fanout
+ * before the table cache local to fanout has been properly updated.  To assist with this case the event's timestamp
+ * is included in the event so fanout can delay deleting the event until enough time has passed to be confident the
+ * event is orphaned because of the expected case where the table has been dropped.
+ */
+public class OrphanedEventException extends Exception {
+
+    private String _table;
+    private Instant _eventTime;
+
+    public OrphanedEventException(String table, Instant eventTime) {
+        super("Event for unknown table: " + table);
+        _table = table;
+        _eventTime = eventTime;
+    }
+
+    public String getTable() {
+        return _table;
+    }
+
+    public Instant getEventTime() {
+        return _eventTime;
+    }
+}

--- a/table/src/test/java/com/bazaarvoice/emodb/table/db/generic/CachingTableDAOTest.java
+++ b/table/src/test/java/com/bazaarvoice/emodb/table/db/generic/CachingTableDAOTest.java
@@ -1,0 +1,129 @@
+package com.bazaarvoice.emodb.table.db.generic;
+
+import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
+import com.bazaarvoice.emodb.sor.api.UnknownTableException;
+import com.bazaarvoice.emodb.table.db.Table;
+import com.bazaarvoice.emodb.table.db.TableDAO;
+import com.google.common.cache.LoadingCache;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.fail;
+
+public class CachingTableDAOTest {
+
+    private TableDAO _delegate;
+    private Instant _now;
+    private CachingTableDAO _cachingTableDAO;
+    private LoadingCache _cache;
+
+    @BeforeMethod
+    public void setUp() {
+        _delegate = mock(TableDAO.class);
+
+        _now = Instant.ofEpochMilli(1526068800000L);
+        Clock clock = mock(Clock.class);
+        when(clock.instant()).then(ignore -> _now);
+        when(clock.millis()).then(ignore -> _now.toEpochMilli());
+
+        CacheRegistry cacheRegistry = mock(CacheRegistry.class);
+        _cachingTableDAO = new CachingTableDAO(_delegate, cacheRegistry, clock);
+
+        ArgumentCaptor<LoadingCache> argumentCaptor = ArgumentCaptor.forClass(LoadingCache.class);
+        verify(cacheRegistry).register(eq("tables"), argumentCaptor.capture(), eq(true));
+        _cache = argumentCaptor.getValue();
+    }
+
+    @AfterMethod
+    public void verifyMocks() {
+        verifyNoMoreInteractions(_delegate);
+    }
+
+    @Test
+    public void testTableCached() throws Exception {
+        Table firstResponse = mock(Table.class);
+        Table secondResponse = mock(Table.class);
+
+        when(_delegate.get("table")).thenReturn(firstResponse, secondResponse);
+        Table table = _cachingTableDAO.get("table");
+        assertSame(table, firstResponse);
+
+        // Move time forward one minute, should still get back cached instance
+        _now = _now.plus(Duration.ofMinutes(1));
+        table = _cachingTableDAO.get("table");
+        assertSame(table, firstResponse);
+
+        // 1 millisecond prior to cache invalidation
+        _now = _now.plus(Duration.ofMinutes(9).minusMillis(1));
+        table = _cachingTableDAO.get("table");
+        assertSame(table, firstResponse);
+
+        // 1 millisecond after cache invalidation
+        _now = _now.plus(Duration.ofMillis(2));
+        table = _cachingTableDAO.get("table");
+        assertSame(table, secondResponse);
+
+        verify(_delegate, times(2)).get("table");
+    }
+
+    @Test
+    public void testTableInvalidation() throws Exception {
+        Table firstResponse = mock(Table.class);
+        Table secondResponse = mock(Table.class);
+
+        when(_delegate.get("table")).thenReturn(firstResponse, secondResponse);
+        Table table = _cachingTableDAO.get("table");
+        assertSame(table, firstResponse);
+
+        _cache.invalidateAll();
+        table = _cachingTableDAO.get("table");
+        assertSame(table, secondResponse);
+
+        verify(_delegate, times(2)).get("table");
+    }
+
+    @Test
+    public void testShortCachingOfUnknownTable() throws Exception {
+        Table actualTable = mock(Table.class);
+
+        when(_delegate.get("table"))
+                .thenThrow(new UnknownTableException())
+                .thenReturn(actualTable);
+
+        try {
+            _cachingTableDAO.get("table");
+            fail("Unknown table");
+        } catch (UnknownTableException e) {
+            // expected
+        }
+
+        // Move just under 2 seconds, should still get back cached exception
+        _now = _now.plus(Duration.ofSeconds(2).minusMillis(1));
+        try {
+            _cachingTableDAO.get("table");
+            fail("Unknown table");
+        } catch (UnknownTableException e) {
+            // expected
+        }
+
+        // Move to just over 2 seconds, should re-read the table from delegate
+        _now = _now.plus(Duration.ofMillis(2));
+        Table table = _cachingTableDAO.get("table");
+        assertSame(table, actualTable);
+
+        verify(_delegate, times(2)).get("table");
+    }
+}


### PR DESCRIPTION
## Github Issue #

[174](https://github.com/bazaarvoice/emodb/issues/174)

## What Are We Doing Here?

This PR makes the following changes:

1. `CachingTableDAO` will only cache that a table is unknown for at up to 2 seconds, not the default 10 minutes.
2. `DefaultFanout` will only discard events from unknown tables after 30 seconds have elapsed from the time the event was created.

The combination of the two changes above should ensure that if `DefaultFanout` discards an event from an unknown table it is because the table has been dropped and not because the table cache has a dirty entry indicating the table is unknown.

## How to Test and Verify

The circumstances which generate this defect are extremely difficult to recreate intentionally.  The best way to verify is to create a cluster of at least two EmoDB servers, create a subscription for all events, then quickly create new tables and immediately start writing events to the tables on all servers.  In the end verify that no events are missing from the subscription.

## Risk

As noted in the issue this is a fairly low risk change.  The risk is that the delay in deleting events may slow fanout briefly.  These changes should not change fanout significantly nor introduce a new path where fanout events could be lost.

### Level 

`Medium`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
