### PR TITLE
Increasing the scan wait time to 5 minutess instead of 1 minute.

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploader.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploader.java
@@ -51,6 +51,7 @@ public class ScanUploader {
     private static final Logger _log = LoggerFactory.getLogger(ScanUploader.class);
 
     private long _compactionControlBufferTimeInMillis = Duration.ofMinutes(1).toMillis();
+    private long _scanWaitTimeInMillis = Duration.ofMinutes(5).toMillis();
 
     private final DataTools _dataTools;
     private final ScanWorkflow _scanWorkflow;
@@ -73,6 +74,11 @@ public class ScanUploader {
     @VisibleForTesting
     public void setCompactionControlBufferTimeInMillis(long compactionControlBufferTimeInMillis) {
         _compactionControlBufferTimeInMillis = compactionControlBufferTimeInMillis;
+    }
+
+    @VisibleForTesting
+    public void setScanWaitTimeInMillis(long scanWaitTimeInMillis) {
+        _scanWaitTimeInMillis = scanWaitTimeInMillis;
     }
 
     public ScanAndUploadBuilder scanAndUpload(String scanId, ScanOptions options) {
@@ -204,8 +210,8 @@ public class ScanUploader {
             boolean scanCreated = false;
 
             try {
-                // We would like to wait 1 minute here to continue to scan to make sure scan don't miss any deltas that are written before the compaction control time.
-                Thread.sleep(_compactionControlBufferTimeInMillis);
+                // We would like to wait for 5 minutes here to continue to scan to make sure scan don't miss any deltas that are written before the compaction control time.
+                Thread.sleep(_scanWaitTimeInMillis);
 
                 // Create the scan
                 _scanStatusDAO.updateScanStatus(status);

--- a/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/ScanOperationsTimeUpdateTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/ScanOperationsTimeUpdateTest.java
@@ -70,6 +70,7 @@ public class ScanOperationsTimeUpdateTest {
         ScanUploader scanUploader = new ScanUploader(getDataTools(), scanWorkflow, scanStatusDAO, stashStateListener, compactionControlSource, dataCenters);
         // the default in code is 1 minute for compaction control buffer time, but we don't want to wait that long in the test, so set to a smaller value.
         scanUploader.setCompactionControlBufferTimeInMillis(Duration.millis(1).getMillis());
+        scanUploader.setScanWaitTimeInMillis(Duration.millis(5).getMillis());
         scanUploader.scanAndUpload("test1", scanOptions).start();
         // sleeping for 1 sec just to be certain that the thread was executed in scanAndUpload process.
         Thread.sleep(Duration.standardSeconds(1).getMillis());
@@ -102,6 +103,7 @@ public class ScanOperationsTimeUpdateTest {
         ScanUploader scanUploader = new ScanUploader(getDataTools(), scanWorkflow, scanStatusDAO, stashStateListener, compactionControlSource, dataCenters);
         // the default in code is 1 minute for compaction control buffer time, but we don't want to wait that long in the test, so set to a smaller value.
         scanUploader.setCompactionControlBufferTimeInMillis(Duration.millis(1).getMillis());
+        scanUploader.setScanWaitTimeInMillis(Duration.millis(5).getMillis());
         try {
             scanUploader.scanAndUpload("test1", scanOptions).start();
         } catch (Exception e) {

--- a/web/src/test/java/com/bazaarvoice/emodb/web/scanner/ScanUploaderTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/scanner/ScanUploaderTest.java
@@ -329,6 +329,7 @@ public class ScanUploaderTest {
         ScanUploader scanUploader = new ScanUploader(dataTools, scanWorkflow, scanStatusDAO, stashStateListener, compactionControlSource, dataCenters);
         // the default in code is 1 minute for compaction control buffer time, but we don't want to wait that long in the test, so set to a smaller value.
         scanUploader.setCompactionControlBufferTimeInMillis(Duration.millis(1).getMillis());
+        scanUploader.setScanWaitTimeInMillis(Duration.millis(5).getMillis());
         scanUploader.scanAndUpload("test1",
                 new ScanOptions("placement1").addDestination(ScanDestination.to(new URI("s3://testbucket/test/path")))).start();
         // sleeping for 1 sec just to be certain that the thread was executed in scanAndUpload process.
@@ -451,6 +452,7 @@ public class ScanUploaderTest {
         ScanUploader scanUploader = new ScanUploader(dataStore, scanWorkflow, scanStatusDAO, mock(StashStateListener.class), new InMemoryCompactionControlSource(), dataCenters);
         // the default in code is 1 minute for compaction control buffer time, but we don't want to wait that long in the test, so set to a smaller value.
         scanUploader.setCompactionControlBufferTimeInMillis(Duration.millis(1).getMillis());
+        scanUploader.setScanWaitTimeInMillis(Duration.millis(5).getMillis());
 
         ScanOptions scanOptions = new ScanOptions("app_global:default")
                 .setRangeScanSplitSize(1000000)


### PR DESCRIPTION
Few records were missing from Bazaar Temporal Stash. 
June 14th - 6 records in total.
June 15th - 3 records in total.
June 18th - 5 records in total.
June 19th - 3 records in total.

This change is to increase the scan wait time from 1 minute to 5 minutes to eliminate any timing issues.

