### PR TITLE
Added short-term caching of the first column in the channel manifest

### DIFF
--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -14,6 +14,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -52,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -72,6 +74,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
     private final ExecutorService _cleanupExecutor;
     private final LoadingCache<ChannelSlab, SlabCursor> _openSlabCursors;
     private final LoadingCache<ChannelSlab, SlabCursor> _closedSlabCursors;
+    private final Cache<String, ByteBuffer> _oldestSlab;
     private final Meter _staleSlabMeter;
 
     @Inject
@@ -110,6 +113,10 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
                 maximumSize(100000).  // 100k - bigger than the open slab cache since it's more important for performance.
                 recordStats().
                 build(slabCursorFactory);
+        _oldestSlab = CacheBuilder.newBuilder().
+                expireAfterWrite(10, TimeUnit.SECONDS).
+                maximumSize(10000).   // 10k - as with open slabs, misses are inconvenient but tolerable
+                build();
         InstrumentedCache.instrument(_openSlabCursors, metricRegistry, metricsGroup, "openSlabCursors", false);
         InstrumentedCache.instrument(_closedSlabCursors, metricRegistry, metricsGroup, "closedSlabCursors", false);
 
@@ -283,16 +290,38 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
         //    benefit from using a cursor to start the read part-way through the slab.  So the open slab cursor cache
         //    has a very short TTL (250ms) to reduce memory requirements and minimize the latency between the time
         //    data is written and first read.
+        //
+        // Additionally a third cache is used to track the oldest known slab in channel's manifest.  If the events
+        // are written and acknowledged quickly and frequently then the head of the manifest row for the channel may
+        // accrue tombstones as older slabs are fully read and deleted.  By caching the oldest slab in the manifest
+        // reading the older tombstones can be minimized.  Since slabs can be written out-of-order across the cluster
+        // we still occasionally (10 seconds) re-reads all slabs to pick up any of these newer-older slabs we may
+        // have missed.
+
+        final ByteBuffer oldestSlab = _oldestSlab.getIfPresent(channel);
+        RangeBuilder range = new RangeBuilder().setLimit(50);
+        if (oldestSlab != null) {
+            range.setStart(oldestSlab);
+        }
+        boolean firstSlab = true;
 
         Iterable<Column<ByteBuffer>> manifestColumns = executePaginated(
                 _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_LOCAL_ONE)
                         .getKey(channel)
-                        .withColumnRange(new RangeBuilder().setLimit(50).build())
+                        .withColumnRange(range.build())
                         .autoPaginate(true));
 
         for (Column<ByteBuffer> manifestColumn : manifestColumns) {
             ByteBuffer slabId = manifestColumn.getName();
             boolean open = manifestColumn.getBooleanValue();
+
+            if (firstSlab) {
+                if (oldestSlab == null) {
+                    cacheOldestSlabForChannel(channel, slabId);
+                }
+                firstSlab = false;
+            }
+
             ChannelSlab channelSlab = new ChannelSlab(channel, slabId);
             SlabCursor cursor = (open ? _openSlabCursors : _closedSlabCursors).getUnchecked(channelSlab);
 
@@ -312,6 +341,22 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
                     break;
                 }
             }
+        }
+
+        if (firstSlab && oldestSlab == null) {
+            // Channel was completely empty.  Cache a TimeUUID which will only read at most 1 minute of tombstones
+            // until the cache expires 10 seconds later.
+            cacheOldestSlabForChannel(channel, TimeUUIDSerializer.get().toByteBuffer(
+                    TimeUUIDs.uuidForTimeMillis(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(1))));
+        }
+    }
+
+    private void cacheOldestSlabForChannel(String channel, ByteBuffer slabId) {
+        // Functionally the same as ConcurrentMap.computeIfAbsent(...)
+        try {
+            _oldestSlab.get(channel, () -> slabId);
+        } catch (ExecutionException e) {
+            // Won't happen, the "execution" just returns a constant.
         }
     }
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

An inefficiency was uncovered when the head of the "manifest" table for queues and databus subscriptions have accrued many tombstones which have not yet been compacted away.  Since every poll re-reads the manifest from the beginning the entire poll is slowed down as Cassandra scans over the tombstoned records.  This PR briefly caches the oldest know slab ID in the manifest plus a 1 minute buffer.  Future queries can be run starting at this manifest to bypass any tombstones from older, fully read and deleted slabs.

## How to Test and Verify

There is no test specifically for this condition.  The most important test is regression.

## Risk

This is a fairly low-risk update.  Even though it is at the heart of databus and queue channels the caching should serve as an optimization without risking that any manifest data goes completely unread.

### Level 

`Medium`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
