### PR TITLE
Change local start scripts to work outside of web-local directory

### DIFF
--- a/web-local/pom.xml
+++ b/web-local/pom.xml
@@ -18,8 +18,8 @@
         <mavenVersion>3.1.1</mavenVersion>
         <mavenPluginAnnotationsVersion>3.2</mavenPluginAnnotationsVersion>
         <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
-        <config.file>config-local.yaml</config.file>
-        <ddl.file>config-ddl-local.yaml</ddl.file>
+        <config.file>${project.basedir}/config-local.yaml</config.file>
+        <ddl.file>${project.basedir}/config-ddl-local.yaml</ddl.file>
     </properties>
 
     <dependencies>
@@ -147,8 +147,8 @@
                                     <mainClass>com.bazaarvoice.emodb.local.EmoServiceWithZK</mainClass>
                                     <arguments>
                                         <argument>server</argument>
-                                        <argument>${project.basedir}/${config.file}</argument>
-                                        <argument>${project.basedir}/${ddl.file}</argument>
+                                        <argument>${config.file}</argument>
+                                        <argument>${ddl.file}</argument>
                                         <argument>-z</argument>
                                     </arguments>
                                 </configuration>

--- a/web-local/start-clean.sh
+++ b/web-local/start-clean.sh
@@ -1,19 +1,68 @@
 #!/bin/bash
 
-#
-# Starts the following servers locally:
-# - EmoDB (ports 8080, 8081)
-# - Cassandra (port 9160)
-# - ZooKeeper (port 2181)
-#
-# Cassandra will be initialized with a default schema and an empty data set.
-# Data will stored in "target/cassandra".
-#
-# Once the server is running you can access the Cassandra command line
-# interface using the following commands:
-#
-#   cd target/cassandra/bin
-#   java -jar cassandra-cli.jar
-#
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CONFIG_FILE="${DIR}/config-local.yaml"
+DDL_FILE="${DIR}/config-ddl-local.yaml"
 
-mvn clean verify -P init-cassandra,start-emodb
+function print_usage_and_exit {
+    cat <<EOF
+    $(basename $0) - Start EmoDB locally.
+
+
+     Starts the following servers locally (using ${DDL_FILE} and ${CONFIG_FILE}):
+     - EmoDB (ports 8080, 8081)
+     - Cassandra (port 9160)
+     - ZooKeeper (port 2181)
+
+     The first time this is run, Cassandra will be initialized with a default
+     schema and an empty # data set.  Data will be stored in "target/cassandra".
+     On subsequent runs where "target/cassandra" already exists, the Cassandra
+     schema and data will not be modified.
+
+     Once the server is running you can access the Cassandra command line
+     interface using the following commands:
+
+       cd target/cassandra/bin
+       java -jar cassandra-cli.jar
+
+     Options:
+
+        --ddl-file       Which ddl file to use [Default: emodb/web-local/${DDL_FILE}]
+        --config-file    Which config file to use [Default: emodb/web-local/${CONFIG_FILE}]
+
+     Examples:
+
+        Using default files
+            $(basename $0)
+
+        Passing in files
+            $(basename $0) --ddl-file config-ddl-local-2.yaml --config-file config-local-2.yaml
+
+EOF
+
+    exit 2
+}
+
+
+if [[ $# -gt 0 ]]; then
+    while [[ $# -gt 0 ]]; do
+        case "${1}" in
+            -h|--help)
+                print_usage_and_exit
+                ;;
+            --ddl-file)
+                DDL_FILE="${PWD}/${2}"
+                shift 2
+                ;;
+            --config-file)
+                CONFIG_FILE="${PWD}/${2}"
+                shift 2
+                ;;
+            *)
+                error "Unknown option ${1}"
+                ;;
+        esac
+    done
+fi
+
+mvn clean verify -f ${DIR{/pom.xml -P init-cassandra,start-emodb -Dconfig.file="${CONFIG_FILE}" -Dddl.file="${DDL_FILE}"

--- a/web-local/start.sh
+++ b/web-local/start.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-CONFIG_FILE="config-local.yaml"
-DDL_FILE="config-ddl-local.yaml"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CONFIG_FILE="${DIR}/config-local.yaml"
+DDL_FILE="${DIR}/config-ddl-local.yaml"
 
 function print_usage_and_exit {
     cat <<EOF
@@ -50,11 +51,11 @@ if [[ $# -gt 0 ]]; then
                 print_usage_and_exit
                 ;;
             --ddl-file)
-                DDL_FILE="${2}"
+                DDL_FILE="${PWD}/${2}"
                 shift 2
                 ;;
             --config-file)
-                CONFIG_FILE="${2}"
+                CONFIG_FILE="${PWD}/${2}"
                 shift 2
                 ;;
             *)
@@ -64,5 +65,4 @@ if [[ $# -gt 0 ]]; then
     done
 fi
 
-
-mvn verify -P init-cassandra,start-emodb -Dconfig.file="${CONFIG_FILE}" -Dddl.file="${DDL_FILE}"
+mvn verify -f ${DIR}/pom.xml -P init-cassandra,start-emodb -Dconfig.file="${CONFIG_FILE}" -Dddl.file="${DDL_FILE}"


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Emo's local start scripts currently only work properly if they are executed from within the web-local directory. This PR modifies both `start.sh` and `start-clean.sh` so that they can be executed from anywhere and will still work properly. 

Additionally, I added the ability for `start-clean.sh` to accept specified config files, similar to `start.sh`

## How to Test and Verify

1. Check out this PR
2. Test each script from both inside and outside the web-local directory and make sure they are still working as expected

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

This has almost no risk involved. The absolute worst consequence of this would be that the emo stops working locally, and if that happens, we can simply revert.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
