### PR TITLE
Remove from *-api client modules

### DIFF
--- a/auth/auth-client/pom.xml
+++ b/auth/auth-client/pom.xml
@@ -15,11 +15,4 @@
 
     <name>EmoDB Authentication Client</name>
 
-    <!-- 3rd-party dependencies -->
-    <dependencies>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-    </dependencies>
 </project>

--- a/blob-api/pom.xml
+++ b/blob-api/pom.xml
@@ -32,13 +32,7 @@
             <artifactId>emodb-common-json</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <!-- 3rd-party dependencies -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
+        
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/AuthBlobStore.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/AuthBlobStore.java
@@ -5,7 +5,6 @@ import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.TableExistsException;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
-import com.google.common.io.InputSupplier;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -14,6 +13,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Authenticating interface to {@link BlobStore}.  This method should exactly mirror BlobStore except with added
@@ -102,7 +102,7 @@ public interface AuthBlobStore {
     Blob get(@Credential String apiKey, String table, String blobId, @Nullable RangeSpecification rangeSpec)
             throws BlobNotFoundException, RangeNotSatisfiableException;
 
-    void put(@Credential String apiKey, String table, String blobId, InputSupplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
+    void put(@Credential String apiKey, String table, String blobId, Supplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException;
 
     void delete(@Credential String apiKey, String table, String blobId);

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/BlobStore.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/BlobStore.java
@@ -4,7 +4,6 @@ import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.TableExistsException;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
-import com.google.common.io.InputSupplier;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -13,6 +12,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Supplier;
 
 public interface BlobStore {
 
@@ -96,7 +96,7 @@ public interface BlobStore {
     Blob get(String table, String blobId, @Nullable RangeSpecification rangeSpec)
             throws BlobNotFoundException, RangeNotSatisfiableException;
 
-    void put(String table, String blobId, InputSupplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
+    void put(String table, String blobId, Supplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException;
 
     void delete(String table, String blobId);

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/DefaultBlob.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/DefaultBlob.java
@@ -3,7 +3,7 @@ package com.bazaarvoice.emodb.blob.api;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public final class DefaultBlob extends DefaultBlobMetadata implements Blob, StreamSupplier {
     private final Range _range;
@@ -11,8 +11,8 @@ public final class DefaultBlob extends DefaultBlobMetadata implements Blob, Stre
 
     public DefaultBlob(BlobMetadata metadata, Range byteRange, StreamSupplier streamSupplier) {
         super(metadata);
-        _range = checkNotNull(byteRange, "byteRange");
-        _streamSupplier = checkNotNull(streamSupplier, "streamSupplier");
+        _range = requireNonNull(byteRange, "byteRange");
+        _streamSupplier = requireNonNull(streamSupplier, "streamSupplier");
     }
 
     @Override

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/DefaultBlobMetadata.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/DefaultBlobMetadata.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class DefaultBlobMetadata implements BlobMetadata {
     private final String _id;
@@ -26,12 +26,12 @@ public class DefaultBlobMetadata implements BlobMetadata {
                                @JsonProperty("length") long length,
                                @JsonProperty("md5") String md5, @JsonProperty("sha1") String sha1,
                                @JsonProperty("attributes") Map<String, String> attributes) {
-        _id = checkNotNull(id, "id");
-        _timestamp = checkNotNull(timestamp, "timestamp");
+        _id = requireNonNull(id, "id");
+        _timestamp = requireNonNull(timestamp, "timestamp");
         _length = length;
         _md5 = md5;
         _sha1 = sha1;
-        _attributes = checkNotNull(attributes, "attributes");
+        _attributes = requireNonNull(attributes, "attributes");
     }
 
     @Override

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/DefaultTable.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/DefaultTable.java
@@ -3,12 +3,12 @@ package com.bazaarvoice.emodb.blob.api;
 import com.bazaarvoice.emodb.sor.api.TableAvailability;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public final class DefaultTable implements Table {
     private final String _name;
@@ -20,9 +20,9 @@ public final class DefaultTable implements Table {
                         @JsonProperty("options") TableOptions options,
                         @JsonProperty("attributes") Map<String, String> attributes,
                         @JsonProperty("availability") @Nullable TableAvailability availability) {
-        _name = checkNotNull(name, "name");
-        _options = checkNotNull(options, "options");
-        _attributes = checkNotNull(attributes, "attributes");
+        _name = requireNonNull(name, "name");
+        _options = requireNonNull(options, "options");
+        _attributes = requireNonNull(attributes, "attributes");
         _availability = availability;
     }
 
@@ -58,12 +58,12 @@ public final class DefaultTable implements Table {
         return _name.equals(that._name) &&
                 _options.equals(that._options) &&
                 _attributes.equals(that._attributes) &&
-                Objects.equal(_availability, _availability);
+                Objects.equals(_availability, _availability);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_name, _options, _attributes, _availability);
+        return Objects.hash(_name, _options, _attributes, _availability);
     }
 
     @Override

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/Names.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/Names.java
@@ -1,16 +1,19 @@
 package com.bazaarvoice.emodb.blob.api;
 
-import com.google.common.base.CharMatcher;
+import java.util.BitSet;
+
+import static com.bazaarvoice.emodb.common.api.Names.anyCharExcept;
+import static com.bazaarvoice.emodb.common.api.Names.anyCharInRange;
+import static com.bazaarvoice.emodb.common.api.Names.anyCharInString;
 
 public abstract class Names {
 
     /** Prevent instantiation. */
     private Names() {}
 
-    private static final CharMatcher BLOB_ID_ALLOWED = CharMatcher
-            .inRange('\u0021', '\u007e')          // excludes whitespace, control chars, non-ascii
-            .and(CharMatcher.noneOf("\\/*?\"'<>|,#"))
-            .precomputed();
+    private static final BitSet BLOB_ID_ALLOWED = anyCharExcept(
+            anyCharInRange('\u0021', '\u007e'),          // excludes whitespace, control chars, non-ascii
+            anyCharInString("\\/*?\"'<>|,#"));
 
     public static boolean isLegalTableName(String table) {
         return com.bazaarvoice.emodb.common.api.Names.isLegalTableName(table);
@@ -22,6 +25,6 @@ public abstract class Names {
      */
     public static boolean isLegalBlobId(String blobId) {
         return blobId != null && blobId.length() > 0 && blobId.length() <= 255 &&
-                BLOB_ID_ALLOWED.matchesAllOf(blobId);
+                blobId.chars().allMatch(BLOB_ID_ALLOWED::get);
     }
 }

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/OffsetRangeSpecification.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/OffsetRangeSpecification.java
@@ -1,10 +1,7 @@
 package com.bazaarvoice.emodb.blob.api;
 
-import com.google.common.base.Objects;
-
 import javax.annotation.Nullable;
-
-import static com.google.common.base.Preconditions.checkArgument;
+import java.util.Objects;
 
 /**
  * Range specification for a subset of a blob starting at a particular offset.
@@ -14,8 +11,12 @@ class OffsetRangeSpecification implements RangeSpecification {
     private final Long _length;
 
     public OffsetRangeSpecification(long offset, @Nullable Long length) {
-        checkArgument(offset >= 0, "Range offset must be >=0");
-        checkArgument(length == null || length > 0, "Range length must be >0");
+        if (offset < 0) {
+            throw new IllegalArgumentException("Range offset must be >=0");
+        }
+        if (length != null && length <= 0) {
+            throw new IllegalArgumentException("Range length must be >0");
+        }
         _offset = offset;
         _length = length;
     }
@@ -40,12 +41,12 @@ class OffsetRangeSpecification implements RangeSpecification {
             return false;
         }
         OffsetRangeSpecification offsetRange = (OffsetRangeSpecification) o;
-        return _offset == offsetRange._offset && Objects.equal(_length, offsetRange._length);
+        return _offset == offsetRange._offset && Objects.equals(_length, offsetRange._length);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_offset, _length);
+        return Objects.hash(_offset, _length);
     }
 
     @Override

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/Range.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/Range.java
@@ -1,8 +1,6 @@
 package com.bazaarvoice.emodb.blob.api;
 
-import com.google.common.base.Objects;
-
-import static com.google.common.base.Preconditions.checkArgument;
+import java.util.Objects;
 
 public final class Range {
     private final long _offset;
@@ -16,8 +14,12 @@ public final class Range {
     }
 
     public Range(long offset, long length) {
-        checkArgument(offset >= 0, "Offset must be >=0");
-        checkArgument(length >= 0, "Length must be >=0");
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must be >=0");
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("Length must be >=0");
+        }
         _offset = offset;
         _length = length;
     }
@@ -44,7 +46,7 @@ public final class Range {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_offset, _length);
+        return Objects.hash(_offset, _length);
     }
 
     @Override

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/SuffixRangeSpecification.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/SuffixRangeSpecification.java
@@ -1,9 +1,5 @@
 package com.bazaarvoice.emodb.blob.api;
 
-import com.google.common.primitives.Longs;
-
-import static com.google.common.base.Preconditions.checkArgument;
-
 /**
  * Range specification for the last {@code N} bytes in a blob.
  */
@@ -12,7 +8,9 @@ class SuffixRangeSpecification implements RangeSpecification {
 
     public SuffixRangeSpecification(long length) {
         // For some reason HTTP spec says a suffix len of 0 is valid.  But it's always unsatisfiable.
-        checkArgument(length >= 0, "Suffix length must be >= 0");
+        if (length < 0) {
+            throw new IllegalArgumentException("Suffix length must be >= 0");
+        }
         _length = length;
     }
 
@@ -31,7 +29,7 @@ class SuffixRangeSpecification implements RangeSpecification {
 
     @Override
     public int hashCode() {
-        return Longs.hashCode(_length);
+        return Long.hashCode(_length);
     }
 
     @Override

--- a/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreAuthenticatorProxy.java
+++ b/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreAuthenticatorProxy.java
@@ -12,7 +12,6 @@ import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.TableExistsException;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
-import com.google.common.io.InputSupplier;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -21,6 +20,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * BlobStore instance that takes an {@link AuthBlobStore} and API key and proxies all calls using the API key.
@@ -82,7 +82,7 @@ class BlobStoreAuthenticatorProxy implements BlobStore {
     }
 
     @Override
-    public void put(String table, String blobId, InputSupplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
+    public void put(String table, String blobId, Supplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException {
         _authBlobStore.put(_apiKey, table, blobId, in, attributes, ttl);
     }

--- a/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreClient.java
+++ b/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreClient.java
@@ -54,6 +54,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -480,7 +481,7 @@ public class BlobStoreClient implements AuthBlobStore {
     }
 
     @Override
-    public void put(String apiKey, String table, String blobId, InputSupplier<? extends InputStream> in,
+    public void put(String apiKey, String table, String blobId, Supplier<? extends InputStream> in,
                     Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException {
         checkNotNull(table, "table");
@@ -502,7 +503,7 @@ public class BlobStoreClient implements AuthBlobStore {
             // Upload the object
             request.type(MediaType.APPLICATION_OCTET_STREAM_TYPE)
                     .header(ApiKeyRequest.AUTHENTICATION_HEADER, apiKey)
-                    .put(in.getInput());
+                    .put(in.get());
         } catch (EmoClientException e) {
             throw convertException(e);
         }

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/core/BlobStoreProviderProxy.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/core/BlobStoreProviderProxy.java
@@ -13,7 +13,6 @@ import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.io.InputSupplier;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -124,7 +123,7 @@ public class BlobStoreProviderProxy implements BlobStore {
     }
 
     @Override
-    public void put(String table, String blobId, InputSupplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
+    public void put(String table, String blobId, java.util.function.Supplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException {
         _local.get().put(table, blobId, in, attributes, ttl);
     }

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/core/DefaultBlobStore.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/core/DefaultBlobStore.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -299,7 +300,7 @@ public class DefaultBlobStore implements BlobStore {
     }
 
     @Override
-    public void put(String tableName, String blobId, InputSupplier<? extends InputStream> in, Map<String,String> attributes, @Nullable Duration ttl) throws IOException {
+    public void put(String tableName, String blobId, Supplier<? extends InputStream> in, Map<String,String> attributes, @Nullable Duration ttl) throws IOException {
         checkLegalTableName(tableName);
         checkLegalBlobId(blobId);
         checkNotNull(in, "in");
@@ -310,7 +311,7 @@ public class DefaultBlobStore implements BlobStore {
         long timestamp = _storageProvider.getCurrentTimestamp(table);
         int chunkSize = _storageProvider.getDefaultChunkSize();
 
-        DigestInputStream md5In = new DigestInputStream(in.getInput(), getMessageDigest("MD5"));
+        DigestInputStream md5In = new DigestInputStream(in.get(), getMessageDigest("MD5"));
         DigestInputStream sha1In = new DigestInputStream(md5In, getMessageDigest("SHA-1"));
 
         // A more aggressive solution like the Astyanax ObjectWriter recipe would improve performance by pipelining

--- a/common/api/pom.xml
+++ b/common/api/pom.xml
@@ -28,22 +28,19 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-guava</artifactId>
         </dependency>
 
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/common/api/pom.xml
+++ b/common/api/pom.xml
@@ -16,6 +16,12 @@
     <name>EmoDB Common API Classes</name>
 
     <dependencies>
+        <dependency>
+            <groupId>com.bazaarvoice.emodb</groupId>
+            <artifactId>emodb-common-json</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- 3rd-party dependencies -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -28,6 +34,10 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
@@ -1,6 +1,6 @@
 package com.bazaarvoice.emodb.common.api;
 
-import com.google.common.base.CharMatcher;
+import java.util.BitSet;
 
 public abstract class Names {
 
@@ -8,19 +8,37 @@ public abstract class Names {
     private Names() {}
 
     // Exclude whitespace, control chars, non-ascii, upper-case, most punctuation.
-    private static final CharMatcher TABLE_NAME_ALLOWED =
-            CharMatcher.inRange('a', 'z')
-                    .or(CharMatcher.inRange('0', '9'))
-                    .or(CharMatcher.anyOf("-.:_"))
-                    .precomputed();
+    private static final BitSet TABLE_NAME_ALLOWED = anyOf(
+            anyCharInRange('a', 'z'),
+            anyCharInRange('0', '9'),
+            anyCharInString("-.:_"));
 
     // Exclude whitespace, control chars, non-ascii, most punctuation.
-    private static final CharMatcher ROLE_NAME_ALLOWED =
-            CharMatcher.inRange('a', 'z')
-                    .or(CharMatcher.inRange('A', 'Z'))
-                    .or(CharMatcher.inRange('0', '9'))
-                    .or(CharMatcher.anyOf("-.:_"))
-                    .precomputed();
+    private static final BitSet ROLE_NAME_ALLOWED = anyOf(
+            anyCharInRange('a', 'z'),
+            anyCharInRange('A', 'Z'),
+            anyCharInRange('0', '9'),
+            anyCharInString("-.:_"));
+
+    private static BitSet anyOf(BitSet... bitSets) {
+        BitSet combined = new BitSet();
+        for (BitSet bitSet : bitSets) {
+            combined.or(bitSet);
+        }
+        return combined;
+    }
+
+    private static BitSet anyCharInRange(char from, char to) {
+        BitSet bitSet = new BitSet();
+        bitSet.set(from, to + 1);
+        return bitSet;
+    }
+
+    private static BitSet anyCharInString(String source) {
+        BitSet bitSet = new BitSet();
+        source.chars().forEach(bitSet::set);
+        return bitSet;
+    }
 
     /**
      * Table names must be lowercase ASCII strings. between 1 and 255 characters in length.  Whitespace, ISO control
@@ -34,7 +52,7 @@ public abstract class Names {
                 table.length() > 0 && table.length() <= 255 &&
                 !(table.charAt(0) == '_' && !table.startsWith("__")) &&
                 !(table.charAt(0) == '.' && (".".equals(table) || "..".equals(table))) &&
-                TABLE_NAME_ALLOWED.matchesAllOf(table);
+                table.chars().allMatch(TABLE_NAME_ALLOWED::get);
     }
 
     /**
@@ -44,7 +62,7 @@ public abstract class Names {
     public static boolean isLegalRoleName(String role) {
         return role != null &&
                 role.length() > 0 && role.length() <= 255 &&
-                ROLE_NAME_ALLOWED.matchesAllOf(role);
+                role.chars().allMatch(ROLE_NAME_ALLOWED::get);
     }
 
     /**

--- a/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
@@ -20,7 +20,7 @@ public abstract class Names {
             anyCharInRange('0', '9'),
             anyCharInString("-.:_"));
 
-    private static BitSet anyOf(BitSet... bitSets) {
+    public static BitSet anyOf(BitSet... bitSets) {
         BitSet combined = new BitSet();
         for (BitSet bitSet : bitSets) {
             combined.or(bitSet);
@@ -28,13 +28,13 @@ public abstract class Names {
         return combined;
     }
 
-    private static BitSet anyCharInRange(char from, char to) {
+    public static BitSet anyCharInRange(char from, char to) {
         BitSet bitSet = new BitSet();
         bitSet.set(from, to + 1);
         return bitSet;
     }
 
-    private static BitSet anyCharInString(String source) {
+    public static BitSet anyCharInString(String source) {
         BitSet bitSet = new BitSet();
         source.chars().forEach(bitSet::set);
         return bitSet;

--- a/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Names.java
@@ -40,6 +40,11 @@ public abstract class Names {
         return bitSet;
     }
 
+    public static BitSet anyCharExcept(BitSet bitSet, BitSet exclude) {
+        bitSet.andNot(exclude);
+        return bitSet;
+    }
+
     /**
      * Table names must be lowercase ASCII strings. between 1 and 255 characters in length.  Whitespace, ISO control
      * characters and certain punctuation characters that aren't generally allowed in file names or in elasticsearch

--- a/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Ttls.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/common/api/Ttls.java
@@ -1,20 +1,23 @@
 package com.bazaarvoice.emodb.common.api;
 
 import java.time.Duration;
-
-import static com.google.common.base.Preconditions.checkArgument;
+import java.util.concurrent.TimeUnit;
 
 public class Ttls {
 
+    private static final long MILLIS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
 
     public static Integer toSeconds(Duration ttl, int minimum, Integer forever) {
         if (ttl == null) {
             return forever;
         }
-        checkArgument(ttl.compareTo(Duration.ZERO) >= 0, "Ttl may not be negative: {}", ttl);
+        long millis = ttl.toMillis();
+        if (millis < 0) {
+            throw new IllegalArgumentException("Ttl may not be negative: " + ttl);
+        }
 
         // Convert to seconds, rounding up.
-        long seconds = ttl.plusSeconds(1).minusMillis(1).getSeconds();
+        long seconds = (millis + MILLIS_PER_SECOND - 1) / MILLIS_PER_SECOND;
 
         // No support for really large numbers, convert to forever.
         if (seconds > Integer.MAX_VALUE) {

--- a/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/Audit.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/Audit.java
@@ -2,18 +2,13 @@ package com.bazaarvoice.emodb.sor.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.base.Functions;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Ordering;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.stream.Collectors;
 
 /**
  * Metadata that is stored along with every write to help trace the source
@@ -33,7 +28,10 @@ public final class Audit {
 
     @JsonCreator
     public Audit(Map<String, ?> fields) {
-        _fields = checkNotNull(fields, "fields");
+        if (fields == null) {
+            throw new NullPointerException("Fields cannot be null");
+        }
+        _fields = fields;
     }
 
     @Nullable
@@ -59,10 +57,12 @@ public final class Audit {
     public List<String> getTags() {
         Object tags = _fields.get(TAGS);
         if (tags != null && tags instanceof Collection) {
-            return Ordering.natural().sortedCopy(FluentIterable.from((Collection<?>) tags).transform(Functions.toStringFunction())
-                    .toList());
+            return ((Collection<?>)tags).stream()
+                    .map(Object::toString)
+                    .sorted()
+                    .collect(Collectors.toList());
         }
-        return ImmutableList.of();
+        return Collections.emptyList();
     }
 
     @Nullable

--- a/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/FacadeOptions.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/FacadeOptions.java
@@ -1,15 +1,17 @@
 package com.bazaarvoice.emodb.sor.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 public final class FacadeOptions {
     private final String _placement;
 
     public FacadeOptions(@JsonProperty ("placement") String placement) {
-        _placement = checkNotNull(placement, "Facade option is required: placement");
+        if (placement == null) {
+            throw new NullPointerException("Facade option is required: placement");
+        }
+        _placement = placement;
     }
 
     /**
@@ -28,18 +30,16 @@ public final class FacadeOptions {
             return false;
         }
         FacadeOptions that = (FacadeOptions) o;
-        return Objects.equal(_placement, that._placement);
+        return _placement.equals(that._placement);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_placement);
+        return Objects.hash(_placement);
     }
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
-                .add("placement", _placement)
-                .toString();
+        return String.format("%s{placement=%s}", FacadeOptions.class.getName(), _placement);
     }
 }

--- a/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/FacadeOptionsBuilder.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/FacadeOptionsBuilder.java
@@ -1,12 +1,13 @@
 package com.bazaarvoice.emodb.sor.api;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 public final class FacadeOptionsBuilder {
     private String _placement;
 
     public FacadeOptionsBuilder setPlacement(String placement) {
-        _placement = checkNotNull(placement, "placement");
+        if (placement == null) {
+            throw new NullPointerException("placement");
+        }
+        _placement = placement;
         return this;
     }
 

--- a/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/TableAvailability.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/TableAvailability.java
@@ -1,16 +1,18 @@
 package com.bazaarvoice.emodb.sor.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 public final class TableAvailability {
     private final String _placement;
     private final boolean _facade;
 
     public TableAvailability(@JsonProperty ("placement") String placement, @JsonProperty ("facade") boolean facade) {
-        _placement = checkNotNull(placement, "Table option is required: placement");
+        if (placement == null) {
+            throw new NullPointerException("Table option is required: placement");
+        }
+        _placement = placement;
         _facade = facade;
     }
 
@@ -37,20 +39,17 @@ public final class TableAvailability {
             return false;
         }
         TableAvailability that = (TableAvailability) o;
-        return Objects.equal(_placement, that._placement) &&
-                Objects.equal(_facade, that._facade);
+        return _placement.equals(that._placement) &&
+                _facade == that._facade;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_placement, _facade);
+        return Objects.hash(_placement, _facade);
     }
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
-                .add("placement", _placement)
-                .add("facade", _facade)
-                .toString();
+        return String.format("%s{placement=%s,facade=%s}", TableAvailability.class.getName(), _placement, _facade);
     }
 }

--- a/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/TableOptions.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/TableOptions.java
@@ -1,20 +1,22 @@
 package com.bazaarvoice.emodb.sor.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 import java.util.Collections;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
+import java.util.Optional;
 
 public final class TableOptions {
     private final String _placement;
     private final List<FacadeOptions> _facades;
 
     TableOptions(@JsonProperty("placement") String placement, @JsonProperty("facades") List<FacadeOptions> facadeOptions) {
-        _placement = checkNotNull(placement, "Table option is required: placement");
-        _facades = Objects.firstNonNull(facadeOptions, Collections.<FacadeOptions>emptyList());
+        if (placement == null) {
+            throw new NullPointerException("Table option is required: placement");
+        }
+        _placement = placement;
+        _facades = Optional.ofNullable(facadeOptions).orElse(Collections.<FacadeOptions>emptyList());
     }
 
     /**
@@ -46,13 +48,11 @@ public final class TableOptions {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_placement, _facades);
+        return Objects.hash(_placement, _facades);
     }
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
-                .add("placement", _placement)
-                .toString();
+        return String.format("%s{placement=%s}", TableOptions.class.getName(), _placement);
     }
 }

--- a/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/TableOptionsBuilder.java
+++ b/common/api/src/main/java/com/bazaarvoice/emodb/sor/api/TableOptionsBuilder.java
@@ -3,19 +3,23 @@ package com.bazaarvoice.emodb.sor.api;
 import java.util.Collections;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 public final class TableOptionsBuilder {
     private String _placement;
     private List<FacadeOptions> _facades = Collections.emptyList();
 
     public TableOptionsBuilder setPlacement(String placement) {
-        _placement = checkNotNull(placement, "placement");
+        if (placement == null) {
+            throw new NullPointerException("Placement cannot be null");
+        }
+        _placement = placement;
         return this;
     }
 
     public TableOptionsBuilder setFacades(List<FacadeOptions> facades) {
-        _facades = checkNotNull(facades, "facades");
+        if (facades == null) {
+            throw new NullPointerException("Facades cannot be null");
+        }
+        _facades = facades;
         return this;
     }
 

--- a/common/api/src/test/java/com/bazaarvoice/emodb/common/api/TtlsTest.java
+++ b/common/api/src/test/java/com/bazaarvoice/emodb/common/api/TtlsTest.java
@@ -42,6 +42,6 @@ public class TtlsTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testNegativeLong() {
-        Ttls.toSeconds(Duration.ofMillis(Long.MIN_VALUE), 0, null);
+        Ttls.toSeconds(Duration.ofMillis(-86400000L), 0, null);
     }
 }

--- a/common/client/src/main/java/com/bazaarvoice/emodb/client/EntityHelper.java
+++ b/common/client/src/main/java/com/bazaarvoice/emodb/client/EntityHelper.java
@@ -3,8 +3,6 @@ package com.bazaarvoice.emodb.client;
 import com.bazaarvoice.emodb.common.json.JsonHelper;
 import com.bazaarvoice.emodb.common.json.JsonStreamingArrayParser;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.base.Throwables;
-import com.google.common.collect.PeekingIterator;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,7 +27,7 @@ abstract public class EntityHelper {
         try {
             return JsonHelper.readJson(in, clazz);
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -53,7 +51,7 @@ abstract public class EntityHelper {
         try {
             return JsonHelper.readJson(in, reference);
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -70,15 +68,13 @@ abstract public class EntityHelper {
     }
 
     private static <T> Iterator<T> streamingIterator(InputStream in, TypeReference<T> typeReference) {
-        PeekingIterator<T> iter = new JsonStreamingArrayParser<>(in, typeReference);
+        Iterator<T> iter = new JsonStreamingArrayParser<>(in, typeReference);
 
         // Fetch the first element in the result stream immediately, while still wrapped by the Ostrich retry logic.
         // If we can't get the first element then Ostrich should retry immediately.  If we fail to get subsequent
         // elements then clients must catch JsonStreamingEOFException and deal with it themselves.  They are highly
         // encouraged to use the DataStoreStreaming class which handles the restart logic automatically.
-        if (iter.hasNext()) {
-            iter.peek();
-        }
+        iter.hasNext();
 
         return iter;
     }

--- a/common/json/pom.xml
+++ b/common/json/pom.xml
@@ -21,6 +21,11 @@
             <groupId>com.bazaarvoice.jackson</groupId>
             <artifactId>rison</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.bazaarvoice.emodb</groupId>
+            <artifactId>emodb-common-streaming</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- 3rd-party dependencies -->
         <dependency>

--- a/common/json/pom.xml
+++ b/common/json/pom.xml
@@ -28,14 +28,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
@@ -44,8 +36,8 @@
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -66,6 +58,11 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/CustomJsonObjectMapperFactory.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/CustomJsonObjectMapperFactory.java
@@ -3,7 +3,6 @@ package com.bazaarvoice.emodb.common.json;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JSR310Module;
 
@@ -24,10 +23,6 @@ public class CustomJsonObjectMapperFactory {
         return mapper
                 .registerModule(new Jdk8Module())
                 .registerModule(new JSR310Module())
-                .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false)
-                // The following module present to maintain compatibility in the API clients caused by importing DropWizard.
-                // Eventually all API clients should have minimal dependencies. At that time Guava will be removed and the
-                // JSON support for Guava objects will also be removed.
-                .registerModule(new GuavaModule());
+                .configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
     }
 }

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonHelper.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonHelper.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601Utils;
-import com.google.common.base.Throwables;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -33,7 +32,7 @@ public abstract class JsonHelper {
             return writer.writeValueAsString(value);
         } catch (IOException e) {
             // Shouldn't get I/O errors writing to a string.
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -47,7 +46,7 @@ public abstract class JsonHelper {
             return writer.writeValueAsBytes(value);
         } catch (IOException e) {
             // Shouldn't get I/O errors writing to a string.
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -116,7 +115,7 @@ public abstract class JsonHelper {
                 date = ISO8601Utils.parse(string, new ParsePosition(0));
             }
         } catch (ParseException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         return date;
     }

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonStreamProcessingException.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonStreamProcessingException.java
@@ -3,14 +3,19 @@ package com.bazaarvoice.emodb.common.json;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Throwables;
 
 @JsonIgnoreProperties ({"cause", "localizedMessage", "stackTrace"})
 public class JsonStreamProcessingException extends RuntimeException {
 
     public JsonStreamProcessingException(Throwable cause) {
-        //noinspection ThrowableResultOfMethodCallIgnored
-        this(Throwables.getRootCause(cause).getMessage());
+        this(getRootCauseMessage(cause));
+    }
+
+    private static String getRootCauseMessage(Throwable cause) {
+        while (cause != null && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause != null ? cause.getMessage() : null;
     }
 
     @JsonCreator

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonStreamingArrayParser.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonStreamingArrayParser.java
@@ -1,5 +1,7 @@
 package com.bazaarvoice.emodb.common.json;
 
+import com.bazaarvoice.emodb.streaming.AbstractSpliterator;
+import com.bazaarvoice.emodb.streaming.SpliteratorIterator;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -13,22 +15,16 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
-import java.util.Iterator;
 import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.function.Consumer;
-import java.util.stream.StreamSupport;
 
 /**
  * Incrementally parses an JSON array of objects, returning the results as an iterator.  Allows parsing an
  * arbitrary amount of data, potentially more than could fit in memory at one time.
  */
-public class JsonStreamingArrayParser<T> implements Iterator<T>, Closeable {
+public class JsonStreamingArrayParser<T> extends SpliteratorIterator<T> implements Closeable {
     private final JsonParser _jp;
     private final ObjectReader _reader;
     private final Class<? extends T> _type;
-    private final Iterator<T> _finalIter;
-    private boolean _endOfStream;
 
     public JsonStreamingArrayParser(InputStream in, Class<? extends T> elementType) {
         this(in, CustomJsonObjectMapperFactory.build(), elementType);
@@ -64,58 +60,35 @@ public class JsonStreamingArrayParser<T> implements Iterator<T>, Closeable {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-
-        _finalIter = StreamSupport.stream(asSpliterator(), false).iterator();
     }
 
     @Override
-    public boolean hasNext() {
-        return _finalIter.hasNext();
-    }
-
-    @Override
-    public T next() {
-        return _finalIter.next();
-    }
-
-    private Spliterator<T> asSpliterator() {
-        return new Spliterators.AbstractSpliterator<T>(Long.MAX_VALUE, 0) {
+    protected Spliterator<T> getSpliterator() {
+        return new AbstractSpliterator<T>() {
             @Override
-            public boolean tryAdvance(Consumer<? super T> action) {
-                if (!_endOfStream) {
-                    T next = computeNext();
-                    if (!_endOfStream) {
-                        action.accept(next);
-                        return true;
+            protected T computeNext() {
+                try {
+                    if (_jp.nextToken() == JsonToken.END_ARRAY) {
+                        if (_jp.nextToken() != null) {
+                            throw new IllegalStateException("Expected EOF in JavaScript input stream.");
+                        }
+                        _jp.close();
+                        return endOfStream();
                     }
+                    return _type.cast(_reader.readValue(_jp));
+                } catch (IOException e) {
+                    // If the root cause is a JsonProcessingException then throw it as a JsonStreamProcessingException.
+                    if (isJsonProcessingException(e)) {
+                        throw new JsonStreamProcessingException(e);
+                    }
+
+                    // We already parsed the first few bytes in the constructor and verified that the InputStream looked valid
+                    // so if there's an unexpected end of input here it likely means we lost the connection to the server.
+                    // In practice this a JsonStreamingEOFException or a TruncatedChunkException or something similar.
+                    throw new JsonStreamingEOFException(e);
                 }
-                return false;
             }
         };
-    }
-
-    private T computeNext() {
-        try {
-            if (_jp.nextToken() == JsonToken.END_ARRAY) {
-                if (_jp.nextToken() != null) {
-                    throw new IllegalStateException("Expected EOF in JavaScript input stream.");
-                }
-                _jp.close();
-                _endOfStream = true;
-                return null;
-            }
-            return _type.cast(_reader.readValue(_jp));
-        } catch (IOException e) {
-            // If the root cause is a JsonProcessingException then throw it as a JsonStreamProcessingException.
-            if (isJsonProcessingException(e)) {
-                throw new JsonStreamProcessingException(e);
-            }
-
-            // We already parsed the first few bytes in the constructor and verified that the InputStream looked valid
-            // so if there's an unexpected end of input here it likely means we lost the connection to the server.
-            // In practice this a JsonStreamingEOFException or a TruncatedChunkException or something similar.
-            throw new JsonStreamingEOFException(e);
-        }
     }
 
     /**

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonStreamingArrayParser.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/JsonStreamingArrayParser.java
@@ -8,25 +8,27 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.google.common.base.Throwables;
-import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.PeekingIterator;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
-
-import static com.google.common.base.Preconditions.checkState;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
 
 /**
  * Incrementally parses an JSON array of objects, returning the results as an iterator.  Allows parsing an
  * arbitrary amount of data, potentially more than could fit in memory at one time.
  */
-public class JsonStreamingArrayParser<T> extends AbstractIterator<T> implements PeekingIterator<T>, Closeable {
+public class JsonStreamingArrayParser<T> implements Iterator<T>, Closeable {
     private final JsonParser _jp;
     private final ObjectReader _reader;
     private final Class<? extends T> _type;
+    private final Iterator<T> _finalIter;
+    private boolean _endOfStream;
 
     public JsonStreamingArrayParser(InputStream in, Class<? extends T> elementType) {
         this(in, CustomJsonObjectMapperFactory.build(), elementType);
@@ -57,18 +59,50 @@ public class JsonStreamingArrayParser<T> extends AbstractIterator<T> implements 
                 throw new JsonParseException("Invalid JSON response, expected content to start with '[': " +
                         _jp.getCurrentToken(), _jp.getTokenLocation());
             }
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
+
+        _finalIter = StreamSupport.stream(asSpliterator(), false).iterator();
     }
 
     @Override
-    protected T computeNext() {
+    public boolean hasNext() {
+        return _finalIter.hasNext();
+    }
+
+    @Override
+    public T next() {
+        return _finalIter.next();
+    }
+
+    private Spliterator<T> asSpliterator() {
+        return new Spliterators.AbstractSpliterator<T>(Long.MAX_VALUE, 0) {
+            @Override
+            public boolean tryAdvance(Consumer<? super T> action) {
+                if (!_endOfStream) {
+                    T next = computeNext();
+                    if (!_endOfStream) {
+                        action.accept(next);
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
+
+    private T computeNext() {
         try {
             if (_jp.nextToken() == JsonToken.END_ARRAY) {
-                checkState(_jp.nextToken() == null, "Expected EOF in JavaScript input stream.");
+                if (_jp.nextToken() != null) {
+                    throw new IllegalStateException("Expected EOF in JavaScript input stream.");
+                }
                 _jp.close();
-                return endOfData();
+                _endOfStream = true;
+                return null;
             }
             return _type.cast(_reader.readValue(_jp));
         } catch (IOException e) {
@@ -93,8 +127,8 @@ public class JsonStreamingArrayParser<T> extends AbstractIterator<T> implements 
         // more brittle approach of checking the exception message.
         return e instanceof JsonProcessingException &&
                 !(e instanceof JsonParseException &&
-                    e.getMessage() != null &&
-                    e.getMessage().startsWith("Unexpected end-of-input"));
+                        e.getMessage() != null &&
+                        e.getMessage().startsWith("Unexpected end-of-input"));
     }
 
     @Override

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/LoggingIterator.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/LoggingIterator.java
@@ -1,10 +1,12 @@
 package com.bazaarvoice.emodb.common.json;
 
-import com.google.common.base.Throwables;
-import com.google.common.collect.AbstractIterator;
 import org.slf4j.Logger;
 
 import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
 
 /**
  * Logs exceptions that would otherwise go unlogged while streaming results back to the client.
@@ -14,30 +16,45 @@ import java.util.Iterator;
  * {@link java.io.IOException} the Jetty catch clause in {@code org.eclipse.jetty.servlet.ServletHandler}
  * logs the exception to the {@code DEBUG} channel where it gets lost.
  */
-public class LoggingIterator<T> extends AbstractIterator<T> {
+public class LoggingIterator<T> implements Iterator<T> {
     private final Iterator<T> _delegate;
     private final Logger _log;
     private long _count;
 
     public LoggingIterator(Iterator<T> delegate, Logger log) {
-        _delegate = delegate;
+        _delegate = StreamSupport.stream(toCheckedSpliterator(delegate), false).iterator();
         _log = log;
     }
 
-    @Override
-    protected T computeNext() {
-        try {
-            _count++;
-            if (_delegate.hasNext()) {
-                return _delegate.next();
+    private Spliterator<T> toCheckedSpliterator(Iterator<T> iterator) {
+        final Spliterator<T> delegate = Spliterators.spliteratorUnknownSize(iterator, 0);
+        return new Spliterators.AbstractSpliterator<T>(delegate.estimateSize(), delegate.characteristics()) {
+            @Override
+            public boolean tryAdvance(Consumer<? super T> action) {
+                try {
+                    boolean advanced = delegate.tryAdvance(action);
+                    if (advanced) {
+                        _count++;
+                    }
+                    return advanced;
+                } catch (Exception e) {
+                    _log.error("Unexpected exception iterating through content on item #{}.", _count, e);
+                    // Propagate the exception.  Unfortunately ObjectMapper will close the JsonGenerator anyway such that
+                    // clients receive a well-formed json array response but with elements missing.  There doesn't seem to
+                    // be a good way from here to communicate to the client that something went wrong.
+                    throw e;
+                }
             }
-            return endOfData();
-        } catch (Exception e) {
-            _log.error("Unexpected exception iterating through content on item #{}.", _count, e);
-            // Propagate the exception.  Unfortunately ObjectMapper will close the JsonGenerator anyway such that
-            // clients receive a well-formed json array response but with elements missing.  There doesn't seem to
-            // be a good way from here to communicate to the client that something went wrong.
-            throw Throwables.propagate(e);
-        }
+        };
+    }
+
+    @Override
+    public boolean hasNext() {
+        return _delegate.hasNext();
+    }
+
+    @Override
+    public T next() {
+        return _delegate.next();
     }
 }

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/OrderedJson.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/OrderedJson.java
@@ -1,13 +1,11 @@
 package com.bazaarvoice.emodb.common.json;
 
-import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Ordering;
-
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -17,22 +15,18 @@ import java.util.Map;
  */
 public abstract class OrderedJson {
 
-    public static final Ordering<String> KEY_COMPARATOR = new Ordering<String>() {
-        @Override
-        public int compare(String key1, String key2) {
-            return ComparisonChain.start()
-                    .compareTrueFirst(key1.startsWith("~"), key2.startsWith("~"))
-                    .compare(key1, key2)
-                    .result();
+    public static final Comparator<String> KEY_COMPARATOR = (key1, key2) -> {
+        if (key1.startsWith("~")) {
+            if (!key2.startsWith("~")) {
+                return -1;
+            }
+        } else if (key2.startsWith("~")) {
+            return 1;
         }
+        return key1.compareTo(key2);
     };
 
-    public static final Ordering<Map.Entry<String, ?>> ENTRY_COMPARATOR = new Ordering<Map.Entry<String, ?>>() {
-        @Override
-        public int compare(Map.Entry<String, ?> left, Map.Entry<String, ?> right) {
-            return KEY_COMPARATOR.compare(left.getKey(), right.getKey());
-        }
-    };
+    public static final Comparator<Map.Entry<String, ?>> ENTRY_COMPARATOR = (left, right) -> KEY_COMPARATOR.compare(left.getKey(), right.getKey());
 
     public static Object ordered(@Nullable Object obj) {
         if (obj instanceof Map) {
@@ -47,7 +41,7 @@ public abstract class OrderedJson {
 
     private static List<Object> ordered(List<?> list) {
         // don't sort the list because that would change intent.  only maps and sets get sorted.
-        List<Object> sortedList = Lists.newArrayListWithCapacity(list.size());
+        List<Object> sortedList = new ArrayList<>(list.size());
         for (Object value : list) {
             sortedList.add(ordered(value));
         }
@@ -55,18 +49,13 @@ public abstract class OrderedJson {
     }
 
     private static Map<String, Object> ordered(Map<String, ?> map) {
-        List<? extends Map.Entry<String, ?>> entries = ENTRY_COMPARATOR.immutableSortedCopy(map.entrySet());
-
-        // use a LinkedHashMap instead of ImmutableMap because JSON may contain null values
-        Map<String, Object> sortedMap = Maps.newLinkedHashMap();
-        for (Map.Entry<String, ?> entry : entries) {
-            sortedMap.put(entry.getKey(), ordered(entry.getValue()));
-        }
+        Map<String, Object> sortedMap = new LinkedHashMap<>();
+        map.entrySet().stream().sorted(ENTRY_COMPARATOR).forEach(e -> sortedMap.put(e.getKey(), ordered(e.getValue())));
         return sortedMap;
     }
 
     public static List<String> orderedStrings(Collection<?> col) {
-        List<String> sortedStrings = Lists.newArrayListWithCapacity(col.size());
+        List<String> sortedStrings = new ArrayList<>(col.size());
         for (Object value : col) {
             sortedStrings.add(JsonHelper.asJson(ordered(value)));
         }

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/RestartingStreamingIterator.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/RestartingStreamingIterator.java
@@ -1,68 +1,92 @@
 package com.bazaarvoice.emodb.common.json;
 
-import com.google.common.collect.AbstractIterator;
-import com.google.common.io.Closeables;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.stream.StreamSupport;
 
 /**
  * Wraps a {@link JsonStreamingArrayParser} and detects early EOF and re-starts the streaming just after the last
  * object successfully parsed.
  */
-public class RestartingStreamingIterator<T, K> extends AbstractIterator<T> implements Closeable {
+public class RestartingStreamingIterator<T, K> implements Iterator<T>, Closeable {
     private final StreamingIteratorSupplier<T, K> _iterSupplier;
+    private final Iterator<T> _finalIter;
     private K _restartFromToken;
     private long _remaining;
     private Iterator<T> _iter;
+    private boolean _endOfStream;
 
     public static <T, K> Iterable<T> stream(final @Nullable K fromToken,
                                             final long limit,
                                             final StreamingIteratorSupplier<T, K> restartFn) {
-        return new Iterable<T>() {
+        return () -> new RestartingStreamingIterator<>(fromToken, limit, restartFn);
+    }
+
+    private RestartingStreamingIterator(@Nullable K fromToken, long limit, StreamingIteratorSupplier<T, K> iterSupplier) {
+        if (iterSupplier == null) {
+            throw new NullPointerException("Restart function is required");
+        }
+        _iterSupplier = iterSupplier;
+        _restartFromToken = fromToken;
+        _remaining = limit;
+        _iter = _iterSupplier.get(_restartFromToken, _remaining);
+        if (!(_iter instanceof Closeable)) {
+            // Expected to be a JsonStreamingArrayParser
+            throw new IllegalArgumentException("Iterator returned should be closeable");
+        };
+        _finalIter = StreamSupport.stream(asRestartingSpliterator(), false).iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return _finalIter.hasNext();
+    }
+
+    @Override
+    public T next() {
+        return _finalIter.next();
+    }
+
+    private Spliterator<T> asRestartingSpliterator() {
+        return new Spliterators.AbstractSpliterator<T>(Long.MAX_VALUE, 0) {
             @Override
-            public Iterator<T> iterator() {
-                return new RestartingStreamingIterator<>(fromToken, limit, restartFn);
+            public boolean tryAdvance(Consumer<? super T> action) {
+                if (!_endOfStream) {
+                    T next = computeNext();
+                    if (!_endOfStream) {
+                        action.accept(next);
+                        return true;
+                    }
+                }
+                return false;
             }
         };
     }
 
-    private RestartingStreamingIterator(@Nullable K fromToken, long limit, StreamingIteratorSupplier<T, K> iterSupplier) {
-        _iterSupplier = checkNotNull(iterSupplier, "restartFn");
-        _restartFromToken = fromToken;
-        _remaining = limit;
-        _iter = _iterSupplier.get(_restartFromToken, _remaining);
-        checkArgument(_iter instanceof Closeable);  // Expected to be a JsonStreamingArrayParser
-    }
-
-    @Override
-    protected T computeNext() {
+    private T computeNext() {
         boolean retrying = false;
         while (_remaining > 0) {
             // All calls to the iterator must be protected by a try/catch for JsonStreamingEOFException.
             T next;
             try {
                 if (!_iter.hasNext()) {
-                    try {
-                        Closeables.close((Closeable) _iter, true);
-                    } catch (IOException ex) {
-                        // swallow any exceptions since we don't care if we can't close input data
-                    }
-                    return endOfData();
+                    // swallow any exceptions since we don't care if we can't close input data
+                    closeUnchecked((Closeable) _iter);
+                    _endOfStream = true;
+                    return null;
                 }
                 next = _iter.next();
             } catch (JsonStreamingEOFException e) {
                 // Lost the underlying input stream.
-                try {
-                    Closeables.close((Closeable) _iter, true);
-                } catch (IOException ex) {
-                    // swallow any exceptions since we don't care if we can't close a bad stream
-                }
+                // swallow any exceptions since we don't care if we can't close a bad stream
+                closeUnchecked((Closeable) _iter);
 
                 // When restarting the iterator ensure we retrieve at least one value successfully to avoid the risk
                 // of entering an infinite retry loop.
@@ -82,14 +106,22 @@ public class RestartingStreamingIterator<T, K> extends AbstractIterator<T> imple
 
             return next;
         }
-        try {
-            Closeables.close((Closeable) _iter, true);
-        } catch (IOException ex) {
-            // swallow any exceptions since we don't care if we can't close input data
-        }
-        return endOfData();
+        // swallow any exceptions since we don't care if we can't close input data
+        closeUnchecked((Closeable) _iter);
+        _endOfStream = true;
+        return null;
     }
 
+    private void closeUnchecked(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                // Don't care, just log
+                LoggerFactory.getLogger(getClass()).debug("Failed to close stream", e);
+            }
+        }
+    }
     @Override
     public void close() throws IOException {
         ((Closeable) _iter).close();

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/RestartingStreamingIterator.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/RestartingStreamingIterator.java
@@ -1,5 +1,7 @@
 package com.bazaarvoice.emodb.common.json;
 
+import com.bazaarvoice.emodb.streaming.AbstractSpliterator;
+import com.bazaarvoice.emodb.streaming.SpliteratorIterator;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
@@ -7,21 +9,16 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.function.Consumer;
-import java.util.stream.StreamSupport;
 
 /**
  * Wraps a {@link JsonStreamingArrayParser} and detects early EOF and re-starts the streaming just after the last
  * object successfully parsed.
  */
-public class RestartingStreamingIterator<T, K> implements Iterator<T>, Closeable {
+public class RestartingStreamingIterator<T, K> extends SpliteratorIterator<T> implements Closeable {
     private final StreamingIteratorSupplier<T, K> _iterSupplier;
-    private final Iterator<T> _finalIter;
     private K _restartFromToken;
     private long _remaining;
     private Iterator<T> _iter;
-    private boolean _endOfStream;
 
     public static <T, K> Iterable<T> stream(final @Nullable K fromToken,
                                             final long limit,
@@ -41,75 +38,52 @@ public class RestartingStreamingIterator<T, K> implements Iterator<T>, Closeable
             // Expected to be a JsonStreamingArrayParser
             throw new IllegalArgumentException("Iterator returned should be closeable");
         };
-        _finalIter = StreamSupport.stream(asRestartingSpliterator(), false).iterator();
     }
 
     @Override
-    public boolean hasNext() {
-        return _finalIter.hasNext();
-    }
-
-    @Override
-    public T next() {
-        return _finalIter.next();
-    }
-
-    private Spliterator<T> asRestartingSpliterator() {
-        return new Spliterators.AbstractSpliterator<T>(Long.MAX_VALUE, 0) {
+    protected Spliterator<T> getSpliterator() {
+        return new AbstractSpliterator<T>() {
             @Override
-            public boolean tryAdvance(Consumer<? super T> action) {
-                if (!_endOfStream) {
-                    T next = computeNext();
-                    if (!_endOfStream) {
-                        action.accept(next);
-                        return true;
+            protected T computeNext() {
+                boolean retrying = false;
+                while (_remaining > 0) {
+                    // All calls to the iterator must be protected by a try/catch for JsonStreamingEOFException.
+                    T next;
+                    try {
+                        if (!_iter.hasNext()) {
+                            // swallow any exceptions since we don't care if we can't close input data
+                            closeUnchecked((Closeable) _iter);
+                            return endOfStream();
+                        }
+                        next = _iter.next();
+                    } catch (JsonStreamingEOFException e) {
+                        // Lost the underlying input stream.
+                        // swallow any exceptions since we don't care if we can't close a bad stream
+                        closeUnchecked((Closeable) _iter);
+
+                        // When restarting the iterator ensure we retrieve at least one value successfully to avoid the risk
+                        // of entering an infinite retry loop.
+                        if (retrying) {
+                            throw e;
+                        }
+                        retrying = true;
+
+                        // This next call may fail.  If it does, let the exception propagate.  We assume it implements
+                        // the retry logic appropriate for re-creating the stream of input values.
+                        _iter = _iterSupplier.get(_restartFromToken, _remaining);
+                        continue;
                     }
+
+                    _restartFromToken = _iterSupplier.getNextToken(next);
+                    _remaining--;
+
+                    return next;
                 }
-                return false;
+                // swallow any exceptions since we don't care if we can't close input data
+                closeUnchecked((Closeable) _iter);
+                return endOfStream();
             }
         };
-    }
-
-    private T computeNext() {
-        boolean retrying = false;
-        while (_remaining > 0) {
-            // All calls to the iterator must be protected by a try/catch for JsonStreamingEOFException.
-            T next;
-            try {
-                if (!_iter.hasNext()) {
-                    // swallow any exceptions since we don't care if we can't close input data
-                    closeUnchecked((Closeable) _iter);
-                    _endOfStream = true;
-                    return null;
-                }
-                next = _iter.next();
-            } catch (JsonStreamingEOFException e) {
-                // Lost the underlying input stream.
-                // swallow any exceptions since we don't care if we can't close a bad stream
-                closeUnchecked((Closeable) _iter);
-
-                // When restarting the iterator ensure we retrieve at least one value successfully to avoid the risk
-                // of entering an infinite retry loop.
-                if (retrying) {
-                    throw e;
-                }
-                retrying = true;
-
-                // This next call may fail.  If it does, let the exception propagate.  We assume it implements
-                // the retry logic appropriate for re-creating the stream of input values.
-                _iter = _iterSupplier.get(_restartFromToken, _remaining);
-                continue;
-            }
-
-            _restartFromToken = _iterSupplier.getNextToken(next);
-            _remaining--;
-
-            return next;
-        }
-        // swallow any exceptions since we don't care if we can't close input data
-        closeUnchecked((Closeable) _iter);
-        _endOfStream = true;
-        return null;
     }
 
     private void closeUnchecked(Closeable closeable) {

--- a/common/json/src/main/java/com/bazaarvoice/emodb/common/json/RisonHelper.java
+++ b/common/json/src/main/java/com/bazaarvoice/emodb/common/json/RisonHelper.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.io.IOContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -45,7 +44,7 @@ public class RisonHelper {
             return O_RISON.writeValueAsString(value);
         } catch (IOException e) {
             // Shouldn't get I/O errors writing to a string.
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/common/stash/pom.xml
+++ b/common/stash/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/RestartingS3InputStream.java
+++ b/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/RestartingS3InputStream.java
@@ -4,9 +4,6 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
-import com.google.common.base.Throwables;
-import com.google.common.collect.BoundType;
-import com.google.common.collect.Range;
 
 import javax.annotation.Nullable;
 import java.io.EOFException;
@@ -26,10 +23,10 @@ public class RestartingS3InputStream extends InputStream {
     private long _pos;
 
     public RestartingS3InputStream(AmazonS3 s3, String bucket, String key) {
-        this(s3, bucket, key, null);
+        this(s3, bucket, key, null, null);
     }
 
-    public RestartingS3InputStream(AmazonS3 s3, String bucket, String key, @Nullable Range<Long> range) {
+    public RestartingS3InputStream(AmazonS3 s3, String bucket, String key, @Nullable Long fromInclusive, @Nullable Long toExclusive) {
         _s3 = s3;
         _bucket = bucket;
         _key = key;
@@ -37,21 +34,31 @@ public class RestartingS3InputStream extends InputStream {
         S3Object s3Object;
 
         // Get the object synchronously so any immediate S3 errors, such as file not found, are thrown inline.
-        if (range == null) {
+        if (fromInclusive == null && toExclusive == null) {
             s3Object = _s3.getObject(new GetObjectRequest(_bucket, _key));
             _pos = 0;
             _length = s3Object.getObjectMetadata().getContentLength();
         } else {
             long start, end;
 
-            if (range.hasLowerBound()) {
-                start = range.lowerEndpoint() + (range.lowerBoundType() == BoundType.CLOSED ? 0 : 1);
+            if (fromInclusive != null) {
+                if (fromInclusive < 0) {
+                    throw new IllegalArgumentException("From must be >= 0");
+                }
+                start = fromInclusive;
             } else {
                 start = 0;
             }
 
-            if (range.hasUpperBound()) {
-                end = range.upperEndpoint() - (range.upperBoundType() == BoundType.CLOSED ? 0 : 1);
+            if (toExclusive != null) {
+                if (toExclusive <= 0) {
+                    throw new IllegalArgumentException("To must be > 0");
+                }
+                if (fromInclusive != null && toExclusive <= fromInclusive) {
+                    throw new IllegalArgumentException("From must be > to");
+                }
+                // Get object request is inclusive, so subtract 1.
+                end = toExclusive - 1;
             } else {
                 end = Long.MAX_VALUE;
             }
@@ -163,7 +170,7 @@ public class RestartingS3InputStream extends InputStream {
                 try {
                     Thread.sleep(200 * attempt);
                 } catch (InterruptedException interrupt) {
-                    throw Throwables.propagate(interrupt);
+                    throw new RuntimeException(interrupt);
                 }
             }
         }

--- a/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashFileMetadata.java
+++ b/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashFileMetadata.java
@@ -2,7 +2,8 @@ package com.bazaarvoice.emodb.common.stash;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+
+import java.util.Objects;
 
 /**
  * POJO for metadata about a single file in Stash.
@@ -55,6 +56,6 @@ public class StashFileMetadata {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_bucket, _key);
+        return Objects.hash(_bucket, _key);
     }
 }

--- a/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashSplit.java
+++ b/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashSplit.java
@@ -2,9 +2,10 @@ package com.bazaarvoice.emodb.common.stash;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Charsets;
-import com.google.common.base.Objects;
-import com.google.common.io.BaseEncoding;
+
+import java.nio.charset.Charset;
+import java.util.Base64;
+import java.util.Objects;
 
 /**
  * POJO to maintain attributes of a Stash split.
@@ -26,7 +27,7 @@ public class StashSplit {
     }
 
     public static StashSplit fromString(String split) {
-        String unencoded = new String(BaseEncoding.base64Url().omitPadding().decode(split), Charsets.UTF_8);
+        String unencoded = new String(Base64.getUrlDecoder().decode(split), Charset.forName("UTF-8"));
         String[] parts = new StringBuilder(unencoded).reverse().toString().split("\n");
         String table = parts[0];
         String key = parts[1];
@@ -53,14 +54,14 @@ public class StashSplit {
 
     @Override
     public String toString() {
-        return BaseEncoding.base64Url().omitPadding().encode(
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(
                 new StringBuilder(_table.length() + _key.length() + 10)
                         .append(_table).append("\n")
                         .append(_key).append("\n")
                         .append(_size)
                         .reverse()
                         .toString()
-                        .getBytes(Charsets.UTF_8));
+                        .getBytes(Charset.forName("UTF-8")));
     }
 
     @Override
@@ -74,13 +75,13 @@ public class StashSplit {
 
         StashSplit that = (StashSplit) o;
 
-        return Objects.equal(_table, that._table) &&
-                Objects.equal(_key, that._key) &&
+        return _table.equals(that._table) &&
+                _key.equals(that._key) &&
                 _size == that._size;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_table, _key);
+        return Objects.hash(_table, _key);
     }
 }

--- a/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashSplitIterator.java
+++ b/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashSplitIterator.java
@@ -2,27 +2,52 @@ package com.bazaarvoice.emodb.common.stash;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.bazaarvoice.emodb.common.json.JsonHelper;
-import com.google.common.base.Charsets;
-import com.google.common.base.Throwables;
-import com.google.common.collect.AbstractIterator;
-import com.google.common.io.Closeables;
-import com.google.common.io.LineReader;
+import com.bazaarvoice.emodb.streaming.AbstractSpliterator;
+import com.bazaarvoice.emodb.streaming.SpliteratorIterator;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.Map;
+import java.util.Spliterator;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Closeable iterator for Stash splits.
  */
-class StashSplitIterator extends AbstractIterator<Map<String, Object>> implements StashRowIterator {
+class StashSplitIterator extends SpliteratorIterator<Map<String, Object>> implements StashRowIterator {
     private final AtomicBoolean _closed = new AtomicBoolean(false);
     private final BufferedReader _in;
-    private final LineReader _reader;
+
+    @Override
+    protected Spliterator<Map<String, Object>> getSpliterator() {
+        return new AbstractSpliterator<Map<String, Object>>() {
+            @Override
+            protected Map<String, Object> computeNext() {
+                String line;
+                try {
+                    line = _in.readLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+                if (line == null) {
+                    try {
+                        close();
+                    } catch (IOException ignore) {
+                        // Don't worry about this, we're done iterating anyway
+                    }
+                    return endOfStream();
+                }
+
+                //noinspection unchecked
+                return JsonHelper.fromJson(line, Map.class);
+            }
+        };
+    }
 
     StashSplitIterator(AmazonS3 s3, String bucket, String key) {
         InputStream rawIn = new RestartingS3InputStream(s3, bucket, key);
@@ -32,39 +57,15 @@ class StashSplitIterator extends AbstractIterator<Map<String, Object>> implement
             //   Because the content may be concatenated gzip files we cannot use the default GZIPInputStream.
             //   GzipCompressorInputStream supports concatenated gzip files.
             GzipCompressorInputStream gzipIn = new GzipCompressorInputStream(rawIn, true);
-            _in = new BufferedReader(new InputStreamReader(gzipIn, Charsets.UTF_8));
-            // Create a line reader
-            _reader = new LineReader(_in);
+            _in = new BufferedReader(new InputStreamReader(gzipIn, Charset.forName("UTF-8")));
         } catch (Exception e) {
             try {
-                Closeables.close(rawIn, true);
+                rawIn.close();
             } catch (IOException ignore) {
-                // Won't happen, already caught and logged
+                // ignore
             }
-            throw Throwables.propagate(e);
+            throw (e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e));
         }
-    }
-
-    @Override
-    protected Map<String, Object> computeNext() {
-        String line;
-        try {
-            line = _reader.readLine();
-        } catch (IOException e) {
-            throw Throwables.propagate(e);
-        }
-
-        if (line == null) {
-            try {
-                close();
-            } catch (IOException ignore) {
-                // Don't worry about this, we're done iterating anyway
-            }
-            return endOfData();
-        }
-
-        //noinspection unchecked
-        return JsonHelper.fromJson(line, Map.class);
     }
 
     @Override

--- a/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashTable.java
+++ b/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashTable.java
@@ -2,7 +2,8 @@ package com.bazaarvoice.emodb.common.stash;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+
+import java.util.Objects;
 
 /**
  * POJO for metadata about a single table in Stash.
@@ -55,6 +56,6 @@ public class StashTable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_bucket, _prefix);
+        return Objects.hash(_bucket, _prefix);
     }
 }

--- a/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashUtil.java
+++ b/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashUtil.java
@@ -2,14 +2,13 @@ package com.bazaarvoice.emodb.common.stash;
 
 import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
-import com.google.common.collect.BiMap;
-import com.google.common.collect.ImmutableBiMap;
 
-import java.time.Instant;
 import java.text.ParseException;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -27,8 +26,12 @@ public class StashUtil {
      * Since all EmoDB tables cannot have upper-case characters they make a dense substitution without
      * possibility of collision.
      */
-    private static final BiMap<Character, Character> TABLE_CHAR_REPLACEMENTS =
-            ImmutableBiMap.of(':', '~');
+    private static final Map<Character, Character> TABLE_CHAR_REPLACEMENTS = new HashMap<>();
+    private static final Map<Character, Character> TABLE_CHAR_REPLACEMENTS_INVERTED = new HashMap<>();
+    static {
+        TABLE_CHAR_REPLACEMENTS.put(':', '~');
+        TABLE_CHAR_REPLACEMENTS.entrySet().forEach(e -> TABLE_CHAR_REPLACEMENTS_INVERTED.put(e.getValue(), e.getKey()));
+    }
 
     // Prevent instantiation
     private StashUtil() {
@@ -40,7 +43,7 @@ public class StashUtil {
     }
 
     public static String decodeStashTable(String table) {
-        return transformStashTable(table, TABLE_CHAR_REPLACEMENTS.inverse());
+        return transformStashTable(table, TABLE_CHAR_REPLACEMENTS_INVERTED);
     }
 
     private static String transformStashTable(String table, Map<Character, Character> transformCharMap) {

--- a/common/stash/src/test/java/com/bazaarvoice/emodb/common/stash/StashReaderTest.java
+++ b/common/stash/src/test/java/com/bazaarvoice/emodb/common/stash/StashReaderTest.java
@@ -64,7 +64,7 @@ public class StashReaderTest {
         });
 
         // Get the latest
-        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, 0);
+        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, Duration.ZERO);
         assertEquals("2015-01-01-00-00-00", reader.getLatest());
         assertEquals(reader.getLatestCreationTime(), new ISO8601DateFormat().parse("2015-01-01T00:00:00Z"));
 
@@ -111,7 +111,7 @@ public class StashReaderTest {
         });
 
         // Get the stash start timestamp
-        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, 0);
+        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, Duration.ZERO);
         assertEquals(reader.getStashCreationTime(), startTime, "Actual stash start timestamp");
     }
 
@@ -136,7 +136,7 @@ public class StashReaderTest {
         when(s3.listObjects(argThat(listObjectRequest("stash-bucket", "stash/test/2015-01-01-00-00-00/", null))))
                 .thenReturn(listing);
 
-        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, 0);
+        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, Duration.ZERO);
         List<StashTable> tables = ImmutableList.copyOf(reader.listTables());
 
         assertEquals(tables, ImmutableList.of(
@@ -203,7 +203,7 @@ public class StashReaderTest {
         when(s3.listObjects(argThat(listObjectRequest("stash-bucket", "stash/test/2015-01-01-00-00-00/", listing.getMarker()))))
                 .thenReturn(listing);
 
-        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, 0);
+        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, Duration.ZERO);
         List<StashTableMetadata> tables = ImmutableList.copyOf(reader.listTableMetadata());
         assertEquals(tables.size(), 100);
 
@@ -245,7 +245,7 @@ public class StashReaderTest {
         when(s3.listObjects(argThat(listObjectRequest("stash-bucket", "stash/test/2015-01-01-00-00-00/test~table/", null))))
                 .thenAnswer(objectListingAnswer(null, "test~table-split0.gz", "test~table-split1.gz", "test~table-split2.gz"));
 
-        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, 0);
+        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, Duration.ZERO);
         StashTableMetadata tableMetadata = reader.getTableMetadata("test:table");
 
         assertEquals(tableMetadata.getBucket(), "stash-bucket");
@@ -282,7 +282,7 @@ public class StashReaderTest {
         when(s3.listObjects(argThat(listObjectRequest("stash-bucket", "stash/test/2015-01-01-00-00-00/test~table/", "marker1"))))
                 .thenAnswer(objectListingAnswer(null, "split2.gz", "split3.gz"));
 
-        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, 0);
+        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, Duration.ZERO);
         List<StashSplit> splits = reader.getSplits("test:table");
         assertEquals(splits.size(), 4);
 
@@ -339,7 +339,7 @@ public class StashReaderTest {
 
         StashSplit stashSplit = new StashSplit("test:table", "2015-01-01-00-00-00/test-table/split0.gz", splitOut.size());
 
-        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, 0);
+        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, Duration.ZERO);
         StashRowIterator contentIter = reader.getSplit(stashSplit);
 
         List<Map<String, Object>> content = ImmutableList.copyOf(contentIter);
@@ -371,7 +371,7 @@ public class StashReaderTest {
         when(s3.listObjects(argThat(listObjectRequest("stash-bucket", "stash/test/2015-01-02-00-00-00/", null))))
                 .thenReturn(listing);
 
-        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, 0);
+        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, Duration.ZERO);
         assertEquals(reader.getLatest(), "2015-01-02-00-00-00");
 
         // Create a locked view
@@ -499,7 +499,7 @@ public class StashReaderTest {
 
         StashSplit stashSplit = new StashSplit("test:table", "2015-01-01-00-00-00/test-table/split0.gz", splitOut.size());
 
-        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, 0);
+        StandardStashReader reader = new StandardStashReader(URI.create("s3://stash-bucket/stash/test"), s3, Duration.ZERO);
         try (StashRowIterator rowIter = reader.getSplit(stashSplit)) {
             assertTrue(rowIter.hasNext());
             Map<String, Object> row = rowIter.next();

--- a/common/streaming/pom.xml
+++ b/common/streaming/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.bazaarvoice.emodb</groupId>
+        <artifactId>emodb-parent</artifactId>
+        <version>5.6.23-SNAPSHOT</version>
+        <relativePath>../../parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>emodb-common-streaming</artifactId>
+    <packaging>jar</packaging>
+
+    <name>EmoDB Streaming Utilities</name>
+
+</project>

--- a/common/streaming/pom.xml
+++ b/common/streaming/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.6.23-SNAPSHOT</version>
+        <version>5.6.27-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/streaming/src/main/java/com/bazaarvoice/emodb/streaming/AbstractSpliterator.java
+++ b/common/streaming/src/main/java/com/bazaarvoice/emodb/streaming/AbstractSpliterator.java
@@ -1,0 +1,36 @@
+package com.bazaarvoice.emodb.streaming;
+
+import java.util.Spliterators;
+import java.util.function.Consumer;
+
+abstract public class AbstractSpliterator<T> extends Spliterators.AbstractSpliterator<T> {
+
+    private boolean _endOfStream;
+
+    public AbstractSpliterator() {
+        this(Long.MAX_VALUE, 0);
+    }
+
+    public AbstractSpliterator(long est, int additionalCharacteristics) {
+        super(est, additionalCharacteristics);
+    }
+
+    @Override
+    public boolean tryAdvance(Consumer<? super T> action) {
+        if (!_endOfStream) {
+            T next = computeNext();
+            if (!_endOfStream) {
+                action.accept(next);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected abstract T computeNext();
+
+    protected final T endOfStream() {
+        _endOfStream = true;
+        return null;
+    }
+}

--- a/common/streaming/src/main/java/com/bazaarvoice/emodb/streaming/AppendableJoiner.java
+++ b/common/streaming/src/main/java/com/bazaarvoice/emodb/streaming/AppendableJoiner.java
@@ -1,0 +1,134 @@
+package com.bazaarvoice.emodb.streaming;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Similar to {@link java.util.stream.Collectors#joining()} except instead of producing a new string it appends to
+ * a provided {@link Appendable}.
+ */
+final public class AppendableJoiner {
+
+    private AppendableJoiner() {
+        // empty
+    }
+
+    public static <T> Collector<T, Appendable, Appendable> joining(final Appendable appendable, final String separator) {
+        return joining(appendable, separator, null, null, toStringFunction());
+    }
+
+    public static <T> Collector<T, Appendable, Appendable> joining(final Appendable appendable, final String separator,
+                                                                   final String prefix, final String suffix) {
+        return joining(appendable, separator, prefix, suffix, toStringFunction());
+    }
+
+    public static <T> Collector<T, Appendable, Appendable> joining(final Appendable appendable, final String separator,
+                                                                   final AppendingFunction<T> appendingFunction) {
+        return joining(appendable, separator, null, null, appendingFunction);
+    }
+
+    public static <T> Collector<T, Appendable, Appendable> joining(final Appendable appendable, final String separator,
+                                                                   final String prefix, final String suffix,
+                                                                   final AppendingFunction<T> appendingFunction) {
+        requireNonNull(appendable, "appendable");
+
+        return new Collector<T, Appendable, Appendable>() {
+            private boolean _first = true;
+            private AtomicBoolean _supplyProvidedAppendable = new AtomicBoolean(true);
+
+            @Override
+            public Supplier<Appendable> supplier() {
+                return () -> {
+                    if (_supplyProvidedAppendable.compareAndSet(true, false)) {
+                        if (prefix != null) {
+                            try {
+                                appendable.append(prefix);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                        return appendable;
+                    } else {
+                        return new StringWriter();
+                    }
+                };
+            }
+
+            @Override
+            public BiConsumer<Appendable, T> accumulator() {
+                return (app, t) -> {
+                    try {
+                        if (app == appendable && _first) {
+                            _first = false;
+                        } else if (separator != null) {
+                            app.append(separator);
+                        }
+                        appendingFunction.appendTo(app, t);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+            }
+
+            @Override
+            public BinaryOperator<Appendable> combiner() {
+                return (app1, app2) -> {
+                    try {
+                        if (app1 != appendable) {
+                            appendable.append(app1.toString());
+                        }
+                        if (app2 != appendable) {
+                            appendable.append(app2.toString());
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return appendable;
+                };
+            }
+
+            @Override
+            public Function<Appendable, Appendable> finisher() {
+                return app -> {
+                    if (suffix != null) {
+                        try {
+                            app.append(suffix);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                    return app;
+                };
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return EnumSet.noneOf(Characteristics.class);
+            }
+        };
+    }
+
+    public interface AppendingFunction<T> {
+        void appendTo(Appendable appendable, T t) throws IOException;
+    }
+
+    public static <T> AppendingFunction<T> toStringFunction() {
+        return (appendable, t) -> {
+            if (t != null) {
+                appendable.append(t.toString());
+            } else {
+                appendable.append("null");
+            }
+        };
+    }
+}

--- a/common/streaming/src/main/java/com/bazaarvoice/emodb/streaming/SpliteratorIterator.java
+++ b/common/streaming/src/main/java/com/bazaarvoice/emodb/streaming/SpliteratorIterator.java
@@ -1,0 +1,35 @@
+package com.bazaarvoice.emodb.streaming;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.stream.StreamSupport;
+
+abstract public class SpliteratorIterator<T> implements Iterator<T> {
+
+    private Iterator<T> _delegate;
+
+    private Iterator<T> delegate() {
+        if (_delegate == null) {
+            _delegate = StreamSupport.stream(getSpliterator(), false).iterator();
+        }
+        return _delegate;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate().hasNext();
+    }
+
+    @Override
+    public T next() {
+
+        return delegate().next();
+    }
+
+    @Override
+    public void remove() {
+        delegate().remove();
+    }
+
+    abstract protected Spliterator<T> getSpliterator();
+}

--- a/common/uuid/pom.xml
+++ b/common/uuid/pom.xml
@@ -25,10 +25,6 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/common/uuid/src/test/java/com/bazaarvoice/emodb/common/uuid/TimeUUIDsTest.java
+++ b/common/uuid/src/test/java/com/bazaarvoice/emodb/common/uuid/TimeUUIDsTest.java
@@ -1,6 +1,5 @@
 package com.bazaarvoice.emodb.common.uuid;
 
-import com.google.common.base.Throwables;
 import org.testng.annotations.Test;
 
 import java.text.ParseException;
@@ -185,15 +184,15 @@ public class TimeUUIDsTest {
 
     private void assertLessThan(UUID uuid0, UUID uuid1) {
         // Compare in both directions (a < b, b > a) to make sure the comparator is symmetric
-        assertTrue(TimeUUIDs.ordering().compare(uuid0, uuid1) < 0, uuid0 + " should be < " + uuid1);
-        assertTrue(TimeUUIDs.ordering().compare(uuid1, uuid0) > 0, uuid1 + " should be > " + uuid0);
+        assertTrue(TimeUUIDs.comparator().compare(uuid0, uuid1) < 0, uuid0 + " should be < " + uuid1);
+        assertTrue(TimeUUIDs.comparator().compare(uuid1, uuid0) > 0, uuid1 + " should be > " + uuid0);
     }
 
     private static Date parseTimestamp(String string) {
         try {
             return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS z").parse(string);
         } catch (ParseException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/databus-api/pom.xml
+++ b/databus-api/pom.xml
@@ -39,10 +39,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DefaultSubscription.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DefaultSubscription.java
@@ -4,10 +4,10 @@ import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 import java.time.Duration;
 import java.util.Date;
+import java.util.Objects;
 
 public final class DefaultSubscription implements Subscription {
     private final String _name;
@@ -64,16 +64,16 @@ public final class DefaultSubscription implements Subscription {
 
         if (o instanceof Subscription) {
             Subscription toCompare = (Subscription) o;
-            return Objects.equal(this.getName(), toCompare.getName()) &&
-                    Objects.equal(this.getTableFilter(), toCompare.getTableFilter()) &&
-                    Objects.equal(this.getExpiresAt(), toCompare.getExpiresAt()) &&
-                    Objects.equal(this.getEventTtl(), toCompare.getEventTtl());
+            return Objects.equals(this.getName(), toCompare.getName()) &&
+                    Objects.equals(this.getTableFilter(), toCompare.getTableFilter()) &&
+                    Objects.equals(this.getExpiresAt(), toCompare.getExpiresAt()) &&
+                    Objects.equals(this.getEventTtl(), toCompare.getEventTtl());
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_name, _tableFilter, _expiresAt, _eventTtl);
+        return Objects.hash(_name, _tableFilter, _expiresAt, _eventTtl);
     }
 }

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Event.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Event.java
@@ -3,14 +3,13 @@ package com.bazaarvoice.emodb.databus.api;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableList;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class Event {
 
@@ -21,10 +20,10 @@ public class Event {
     public Event(@JsonProperty("eventKey") String eventKey,
                  @JsonProperty("content") Map<String, ?> content,
                  @JsonProperty("tags") List<List<String>> tags) {
-        _eventKey = checkNotNull(eventKey, "eventKey");
-        _content = checkNotNull(content, "content");
+        _eventKey = requireNonNull(eventKey, "eventKey");
+        _content = requireNonNull(content, "content");
         // Permit nulls; older version of the API omit tags from the response
-        _tags = Objects.firstNonNull(tags, ImmutableList.<List<String>>of());
+        _tags = Optional.ofNullable(tags).orElse(Collections.emptyList());
     }
 
     @JsonView(EventViews.ContentOnly.class)
@@ -76,10 +75,9 @@ public class Event {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
-                .add("eventKey", _eventKey)
-                .add("content", _content)
-                .add("tags", _tags)
-                .toString();
+        return getClass().getSimpleName() + "[" +
+                "eventKey=" +  _eventKey + "," +
+                "content=" + _content + "," +
+                "tags=" + _tags + "]";
     }
 }

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Names.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/Names.java
@@ -1,6 +1,10 @@
 package com.bazaarvoice.emodb.databus.api;
 
-import com.google.common.base.CharMatcher;
+import java.util.BitSet;
+
+import static com.bazaarvoice.emodb.common.api.Names.anyCharInRange;
+import static com.bazaarvoice.emodb.common.api.Names.anyCharInString;
+import static com.bazaarvoice.emodb.common.api.Names.anyOf;
 
 public abstract class Names {
 
@@ -8,11 +12,10 @@ public abstract class Names {
     private Names() {}
 
     // Exclude whitespace, control chars, non-ascii, upper-case, most punctuation.
-    private static final CharMatcher SUBSCRIPTION_NAME_ALLOWED =
-            CharMatcher.inRange('a', 'z')
-                    .or(CharMatcher.inRange('0', '9'))
-                    .or(CharMatcher.anyOf("-.:@_"))
-                    .precomputed();
+    private static final BitSet SUBSCRIPTION_NAME_ALLOWED = anyOf(
+            anyCharInRange('a', 'z'),
+            anyCharInRange('0', '9'),
+            anyCharInString("-.:@_"));
 
     /**
      * Subscription names must be lowercase ASCII strings. between 1 and 255 characters in length.  Whitespace, ISO
@@ -26,6 +29,6 @@ public abstract class Names {
                 subscription.length() > 0 && subscription.length() <= 255 &&
                 !(subscription.charAt(0) == '_' && !subscription.startsWith("__")) &&
                 !(subscription.charAt(0) == '.' && (".".equals(subscription) || "..".equals(subscription))) &&
-                SUBSCRIPTION_NAME_ALLOWED.matchesAllOf(subscription);
+                subscription.chars().allMatch(SUBSCRIPTION_NAME_ALLOWED::get);
     }
 }

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/PollResult.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/PollResult.java
@@ -1,13 +1,11 @@
 package com.bazaarvoice.emodb.databus.api;
 
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
-
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Result returned from {@link Databus#poll(String, Duration, int)}.  The result contains to attributes:
@@ -35,16 +33,30 @@ public class PollResult {
     private final List<Event> _events;
     private final boolean _moreEvents;
 
-    public PollResult(Iterator<Event> eventIterator, int approximateSize, boolean moreEvents) {
-        checkNotNull(eventIterator, "eventIterator");
-        _events = Lists.newArrayListWithCapacity(approximateSize);
+    public PollResult(final Iterator<Event> eventIterator, int approximateSize, boolean moreEvents) {
+        requireNonNull(eventIterator, "eventIterator");
+        _events = new ArrayList<>(approximateSize);
         _moreEvents = moreEvents;
 
         // Wrap the event iterator such that each event returned is appended to the event list
-        _eventIterator = Iterators.transform(eventIterator, event -> {
-            _events.add(event);
-            return event;
-        });
+        _eventIterator = new Iterator<Event>() {
+            @Override
+            public boolean hasNext() {
+                return eventIterator.hasNext();
+            }
+
+            @Override
+            public Event next() {
+                Event event = eventIterator.next();
+                _events.add(event);
+                return event;
+            }
+
+            @Override
+            public void remove() {
+                _eventIterator.remove();
+            }
+        };
     }
 
     public Iterator<Event> getEventIterator() {

--- a/event/src/main/java/com/bazaarvoice/emodb/sortedq/core/PersistentSortedQueue.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/sortedq/core/PersistentSortedQueue.java
@@ -548,7 +548,7 @@ public class PersistentSortedQueue implements SortedQueue {
                 return ComparisonChain.start()
                         .compare(left.getMin(), right.getMin(), ORDERING)  // Ascending
                         .compare(leftMax, rightMax, ORDERING)                     // Ascending
-                        .compare(right.getDataId(), left.getDataId(), TimeUUIDs.ordering())  // Descending
+                        .compare(right.getDataId(), left.getDataId(), TimeUUIDs.comparator())  // Descending
                         .result();
             }
         });

--- a/event/src/test/java/com/bazaarvoice/emodb/sortedq/core/InMemoryQueueDAO.java
+++ b/event/src/test/java/com/bazaarvoice/emodb/sortedq/core/InMemoryQueueDAO.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 public class InMemoryQueueDAO implements QueueDAO {
     private final Table<String, UUID, String> _manifest = HashBasedTable.create();
     private final TreeMultimap<UUID, ByteBuffer> _records =
-            TreeMultimap.create(TimeUUIDs.ordering(), ByteBufferOrdering.INSTANCE);
+            TreeMultimap.create(TimeUUIDs.comparator(), ByteBufferOrdering.INSTANCE);
     private long _numSegmentWrites;
     private long _numSegmentDeletes;
     private long _numRecordWrites;

--- a/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/io/StashFileSystem.java
+++ b/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/io/StashFileSystem.java
@@ -372,7 +372,7 @@ public class StashFileSystem extends FileSystem implements EmoInputSplittable {
          */
         private InputStream getInputStream() {
             if (_in == null) {
-                InputStream stashIn = _stashReader.getRawSplitPart(_stashSplit, Range.closedOpen(_seekStart, _stashSplit.getSize()));
+                InputStream stashIn = _stashReader.getRawSplitPart(_stashSplit, _seekStart, _stashSplit.getSize());
                 _in = new BufferedInputStream(stashIn, _bufferSize);
             }
             return _in;
@@ -443,7 +443,7 @@ public class StashFileSystem extends FileSystem implements EmoInputSplittable {
         @Override
         public int read(long position, byte[] buffer, int offset, int length)
                 throws IOException {
-            try (InputStream in = _stashReader.getRawSplitPart(_stashSplit, Range.closedOpen(position, position + length))) {
+            try (InputStream in = _stashReader.getRawSplitPart(_stashSplit, position, position + length)) {
                 return ByteStreams.read(in, buffer, offset, length);
             }
         }
@@ -451,7 +451,7 @@ public class StashFileSystem extends FileSystem implements EmoInputSplittable {
         @Override
         public void readFully(long position, byte[] buffer, int offset, int length)
                 throws IOException {
-            try (InputStream in = _stashReader.getRawSplitPart(_stashSplit, Range.closedOpen(position, position + length))) {
+            try (InputStream in = _stashReader.getRawSplitPart(_stashSplit, position, position + length)) {
                 ByteStreams.readFully(in, buffer, offset, length);
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 
     <modules>
         <module>parent</module>
+        <module>common/streaming</module>
         <module>common/api</module>
         <module>common/astyanax</module>
         <module>common/dropwizard</module>

--- a/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest.AUTHENTICATION_HEADER;
 import static org.junit.Assert.assertArrayEquals;
@@ -680,17 +681,12 @@ public class BlobStoreJerseyTest extends ResourceTest {
 
     @Test
     public void testPut() throws IOException {
-        InputSupplier<InputStream> in = new InputSupplier<InputStream>() {
-            @Override
-            public InputStream getInput() throws IOException {
-                return new ByteArrayInputStream("blob-content".getBytes());
-            }
-        };
+        Supplier<InputStream> in = () -> new ByteArrayInputStream("blob-content".getBytes());
         Map<String, String> attributes = ImmutableMap.of("key", "value");
         blobClient().put("table-name", "blob-id", in, attributes, Duration.ofDays(30));
 
         //noinspection unchecked
-        verify(_server).put(eq("table-name"), eq("blob-id"), isA(InputSupplier.class), eq(attributes), eq(Duration.ofDays(30)));
+        verify(_server).put(eq("table-name"), eq("blob-id"), isA(Supplier.class), eq(attributes), eq(Duration.ofDays(30)));
         verifyNoMoreInteractions(_server);
     }
 

--- a/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
@@ -52,7 +52,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.io.InputSupplier;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -74,7 +73,6 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
@@ -255,12 +253,7 @@ public class CasBlobStoreTest {
 
     private void verifyPutAndGet(String blobId, final byte[] blobData, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException {
-        _store.put(TABLE, blobId, new InputSupplier<InputStream>() {
-            @Override
-            public InputStream getInput() throws IOException {
-                return new ByteArrayInputStream(blobData);
-            }
-        }, attributes, ttl);
+        _store.put(TABLE, blobId, () -> new ByteArrayInputStream(blobData), attributes, ttl);
 
         // verify that we can get what we put
         Blob blob = _store.get(TABLE, blobId);

--- a/queue-api/pom.xml
+++ b/queue-api/pom.xml
@@ -22,15 +22,16 @@
             <artifactId>emodb-auth-client</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.bazaarvoice.emodb</groupId>
+            <artifactId>emodb-common-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- 3rd-party dependencies -->
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/queue-api/src/main/java/com/bazaarvoice/emodb/queue/api/Message.java
+++ b/queue-api/src/main/java/com/bazaarvoice/emodb/queue/api/Message.java
@@ -1,18 +1,18 @@
 package com.bazaarvoice.emodb.queue.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public final class Message {
     private final String _id;
     private final Object _payload;
 
     public Message(@JsonProperty("id") String id, @JsonProperty("payload") @Nullable Object payload) {
-        _id = checkNotNull(id, "id");
+        _id = requireNonNull(id, "id");
         _payload = payload;
     }
 
@@ -34,7 +34,7 @@ public final class Message {
         }
         Message message = (Message) o;
         return _id.equals(message.getId()) &&
-                Objects.equal(_payload, message.getPayload());
+                Objects.equals(_payload, message.getPayload());
     }
 
     @Override

--- a/queue-api/src/main/java/com/bazaarvoice/emodb/queue/api/Names.java
+++ b/queue-api/src/main/java/com/bazaarvoice/emodb/queue/api/Names.java
@@ -1,6 +1,10 @@
 package com.bazaarvoice.emodb.queue.api;
 
-import com.google.common.base.CharMatcher;
+import java.util.BitSet;
+
+import static com.bazaarvoice.emodb.common.api.Names.anyCharInRange;
+import static com.bazaarvoice.emodb.common.api.Names.anyCharInString;
+import static com.bazaarvoice.emodb.common.api.Names.anyOf;
 
 public abstract class Names {
 
@@ -8,11 +12,10 @@ public abstract class Names {
     private Names() {}
 
     // Exclude whitespace, control chars, non-ascii, upper-case, most punctuation.
-    private static final CharMatcher QUEUE_NAME_ALLOWED =
-            CharMatcher.inRange('a', 'z')
-                    .or(CharMatcher.inRange('0', '9'))
-                    .or(CharMatcher.anyOf("-.:@_"))
-                    .precomputed();
+    private static final BitSet QUEUE_NAME_ALLOWED = anyOf(
+            anyCharInRange('a', 'z'),
+            anyCharInRange('0', '9'),
+            anyCharInString("-.:@_"));
 
     /**
      * Queue names must be lowercase ASCII strings. between 1 and 255 characters in length.  Whitespace, ISO control
@@ -25,6 +28,6 @@ public abstract class Names {
                 queue.length() > 0 && queue.length() <= 255 &&
                 !(queue.charAt(0) == '_' && !queue.startsWith("__")) &&
                 !(queue.charAt(0) == '.' && (".".equals(queue) || "..".equals(queue))) &&
-                QUEUE_NAME_ALLOWED.matchesAllOf(queue);
+                queue.chars().allMatch(QUEUE_NAME_ALLOWED::get);
     }
 }

--- a/sor-api/pom.xml
+++ b/sor-api/pom.xml
@@ -44,10 +44,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Change.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Change.java
@@ -6,15 +6,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.Date;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * All changes for a point-in-time, including a content delta, delta history, audit information, compaction information.
@@ -41,12 +41,12 @@ public final class Change {
            @JsonProperty("compaction") @Nullable Compaction compaction,
            @JsonProperty("history") @Nullable History history,
            @JsonProperty("tags") @Nullable Set<String> tags) {
-        _id = checkNotNull(id, "changeId");
+        _id = requireNonNull(id, "changeId");
         _delta = delta;
         _audit = audit;
         _compaction = compaction;
         _history = history;
-        _tags = Objects.firstNonNull(tags, ImmutableSet.<String>of());
+        _tags = Optional.ofNullable(tags).orElse(Collections.emptySet());
     }
 
     // Add a human-readable timestamp for debugging.  This gets serialized into the JSON

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/ChangeBuilder.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/ChangeBuilder.java
@@ -5,8 +5,6 @@ import com.bazaarvoice.emodb.sor.delta.Delta;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 /**
  * Helper for constructing instances of {@link Change}.
  */
@@ -19,7 +17,9 @@ public final class ChangeBuilder {
     private History _history;
 
     public static Change merge(Change change1, Change change2) {
-        checkArgument(change1 != null || change2 != null);
+        if (change1 == null && change2 == null) {
+            throw new IllegalArgumentException("At least one change is required");
+        }
         if (change1 == null) {
             return change2;
         } else if (change2 == null) {
@@ -40,7 +40,9 @@ public final class ChangeBuilder {
         if (change == null) {
             return this;
         }
-        checkArgument(_changeId.equals(change.getId()));
+        if (!_changeId.equals(change.getId())) {
+            throw new IllegalArgumentException("Non-matching change ID");
+        }
         if (change.getDelta() != null) {
             _delta = change.getDelta();
         }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Compaction.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Compaction.java
@@ -7,14 +7,12 @@ import com.bazaarvoice.emodb.sor.delta.deser.DeltaParser;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Placeholder for adjacent deltas that have been consolidated into a single
@@ -130,9 +128,12 @@ public final class Compaction {
                       @Nullable UUID lastContentMutation,
                       @Nullable UUID lastMutation,
                       @Nullable Set<String> lastTags) {
-        checkArgument((count > 0) || (first == null && cutoff == null));
-        checkArgument((count == 0) || (first != null && cutoff != null));
-        checkArgument((cutoff != null) == (cutoffSignature != null));
+
+        if ((count == 0 && (first != null || cutoff != null)) ||
+                (count > 0 && (first == null || cutoff == null)) ||
+                ((cutoff == null) == (cutoffSignature != null))) {
+            throw new IllegalArgumentException("Invalid initial state");
+        }
         _count = count;
         _first = first;
         _cutoff = cutoff;
@@ -141,7 +142,7 @@ public final class Compaction {
         // but not the last content mutation.  In these cases substitute the last mutation if available
         _lastContentMutation = lastContentMutation != null ? lastContentMutation : lastMutation;
         _lastMutation = lastMutation;
-        _lastTags = lastTags == null ? ImmutableSet.<String>of() : lastTags;
+        _lastTags = lastTags == null ? Collections.emptySet() : lastTags;
     }
 
 
@@ -199,15 +200,15 @@ public final class Compaction {
         }
         Compaction that = (Compaction) o;
         return _count == that._count &&
-                Objects.equal(_first, that.getFirst()) &&
-                Objects.equal(_cutoff, that.getCutoff()) &&
-                Objects.equal(_cutoffSignature, that.getCutoffSignature()) &&
-                Objects.equal(_lastMutation, that.getLastMutation()) &&
-                Objects.equal(_lastContentMutation, that.getLastContentMutation());
+                Objects.equals(_first, that.getFirst()) &&
+                Objects.equals(_cutoff, that.getCutoff()) &&
+                Objects.equals(_cutoffSignature, that.getCutoffSignature()) &&
+                Objects.equals(_lastMutation, that.getLastMutation()) &&
+                Objects.equals(_lastContentMutation, that.getLastContentMutation());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_count, _first, _cutoff, _cutoffSignature, _lastMutation, _lastContentMutation);
+        return Objects.hash(_count, _first, _cutoff, _cutoffSignature, _lastMutation, _lastContentMutation);
     }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Compaction.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Compaction.java
@@ -40,7 +40,7 @@ public final class Compaction {
 
     /**
      * UUID of the most recent consistent delta which changed the resolved object deleted by compaction.  Any delta
-     * between this and the cutoff resolve to the same content, excluding intrinsics such as version and signature.
+     * between this and the cutoff resolve to the same content, anyCharExcept intrinsics such as version and signature.
      */
      private final UUID _lastContentMutation;
 

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Coordinate.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Coordinate.java
@@ -1,11 +1,9 @@
 package com.bazaarvoice.emodb.sor.api;
 
-import com.google.common.collect.ImmutableMap;
-
+import java.util.HashMap;
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * An EmoDB coordinate consisting of the pair of a table name and a string identifier.
@@ -29,19 +27,25 @@ public final class Coordinate {
      * Parses a string in the format "&lt;table>/&lt;id>".  This is the inverse of {@link #toString()}.
      */
     public static Coordinate parse(String string) {
-        checkNotNull(string, "string");
+        requireNonNull(string, "string");
         int delim = string.indexOf('/');
-        checkArgument(delim != -1, "Invalid coordinate format.");
+        if (delim == -1) {
+            throw new IllegalArgumentException("Invalid coordinate format.");
+        }
         String table = string.substring(0, delim);
         String id = string.substring(delim + 1);
-        checkArgument(com.bazaarvoice.emodb.common.api.Names.isLegalTableName(table), "Invalid coordinate format: invalid table name");
-        checkArgument(!id.isEmpty(), "Invalid coordinate format: missing identifier");
+        if (!com.bazaarvoice.emodb.common.api.Names.isLegalTableName(table)) {
+            throw new IllegalArgumentException("Invalid coordinate format: invalid table name");
+        }
+        if (id.isEmpty()) {
+            throw new IllegalArgumentException("Invalid coordinate format: missing identifier");
+        }
         return new Coordinate(table, id);
     }
 
     private Coordinate(String table, String id) {
-        _table = checkNotNull(table, "table");
-        _id = checkNotNull(id, "id");
+        _table = requireNonNull(table, "table");
+        _id = requireNonNull(id, "id");
     }
 
     public String getTable() {
@@ -56,9 +60,10 @@ public final class Coordinate {
      * Returns a Json map with two entries, one for "~table" and one for "~id", similar to all System of Record objects.
      */
     public Map<String, Object> asJson() {
-        return ImmutableMap.<String, Object>of(
-                Intrinsic.TABLE, _table,
-                Intrinsic.ID, _id);
+        Map<String, Object> map = new HashMap<>();
+        map.put(Intrinsic.TABLE, _table);
+        map.put(Intrinsic.ID, _id);
+        return map;
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/DefaultTable.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/DefaultTable.java
@@ -1,12 +1,12 @@
 package com.bazaarvoice.emodb.sor.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public final class DefaultTable implements Table {
     private final String _name;
@@ -18,9 +18,9 @@ public final class DefaultTable implements Table {
                         @JsonProperty("options") TableOptions options,
                         @JsonProperty("template") Map<String, Object> template,
                         @JsonProperty("availability") @Nullable TableAvailability availability) {
-        _name = checkNotNull(name, "name");
-        _options = checkNotNull(options, "options");
-        _template = checkNotNull(template, "template");
+        _name = requireNonNull(name, "name");
+        _options = requireNonNull(options, "options");
+        _template = requireNonNull(template, "template");
         _availability = availability;
     }
 
@@ -56,12 +56,12 @@ public final class DefaultTable implements Table {
         return _name.equals(that._name) &&
                 _options.equals(that._options) &&
                 _template.equals(that._template) &&
-                Objects.equal(_availability, _availability);
+                Objects.equals(_availability, _availability);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_name,  _options, _template, _availability);
+        return Objects.hash(_name,  _options, _template, _availability);
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Intrinsic.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Intrinsic.java
@@ -1,13 +1,15 @@
 package com.bazaarvoice.emodb.sor.api;
 
 import com.bazaarvoice.emodb.common.json.JsonHelper;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public abstract class Intrinsic {
     // Data Fields
@@ -22,9 +24,8 @@ public abstract class Intrinsic {
     public static final String LAST_MUTATE_AT = "~lastMutateAt";
     public static final String PLACEMENT = "~placement";
 
-    public static final Set<String> DATA_FIELDS =
-            ImmutableSet.of(ID, TABLE, VERSION, SIGNATURE, DELETED, FIRST_UPDATE_AT, LAST_UPDATE_AT,
-                    LAST_MUTATE_AT, PLACEMENT);
+    public static final Set<String> DATA_FIELDS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            ID, TABLE, VERSION, SIGNATURE, DELETED, FIRST_UPDATE_AT, LAST_UPDATE_AT, LAST_MUTATE_AT, PLACEMENT)));
 
     // Audit Fields
 
@@ -36,11 +37,11 @@ public abstract class Intrinsic {
     private Intrinsic() {}
 
     public static String getId(Map<String, ?> content) {
-        return (String) checkNotNull(content.get(ID), ID);
+        return (String) requireNonNull(content.get(ID), ID);
     }
 
     public static String getTable(Map<String, ?> content) {
-        return (String) checkNotNull(content.get(TABLE), TABLE);
+        return (String) requireNonNull(content.get(TABLE), TABLE);
     }
 
     public static Long getVersion(Map<String, ?> content) {
@@ -49,11 +50,11 @@ public abstract class Intrinsic {
     }
 
     public static String getSignature(Map<String, ?> content) {
-        return (String) checkNotNull(content.get(SIGNATURE), SIGNATURE);
+        return (String) requireNonNull(content.get(SIGNATURE), SIGNATURE);
     }
 
     public static boolean isDeleted(Map<String, ?> content) {
-        return (Boolean) checkNotNull(content.get(DELETED), DELETED);
+        return (Boolean) requireNonNull(content.get(DELETED), DELETED);
     }
 
     public static Date getFirstUpdateAt(Map<String, ?> content) {

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Update.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Update.java
@@ -4,14 +4,13 @@ import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.uuid.TimeUUIDs;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
-import com.google.common.base.Strings;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public final class Update {
     private final String _table;
@@ -29,18 +28,24 @@ public final class Update {
     public Update(@JsonProperty("table") String table, @JsonProperty("key") String key,
                   @JsonProperty("changeId") @Nullable UUID changeId, @JsonProperty("delta") Delta delta,
                   @JsonProperty("audit") Audit audit, @JsonProperty("consistency") @Nullable WriteConsistency consistency) {
-        _table = checkNotNull(table, "table");
-        checkArgument(Names.isLegalTableName(table),
-                "Table name must be a lowercase ASCII string between 1 and 255 characters in length. " +
-                        "Allowed punctuation characters are -.:@_ and the table name may not start with a single underscore character. " +
-                        "An example of a valid table name would be 'review:testcustomer'.");
-        checkArgument(!Strings.isNullOrEmpty(key), "key must be a non-empty string");
+        _table = requireNonNull(table, "table");
+        if (!Names.isLegalTableName(table)) {
+            throw new IllegalArgumentException(
+                    "Table name must be a lowercase ASCII string between 1 and 255 characters in length. " +
+                            "Allowed punctuation characters are -.:@_ and the table name may not start with a single underscore character. " +
+                            "An example of a valid table name would be 'review:testcustomer'.");
+        }
+        if (key == null || key.isEmpty()) {
+            throw new IllegalArgumentException("key must be a non-empty string");
+        }
         _key = key;
-        _changeId = Objects.firstNonNull(changeId, TimeUUIDs.newUUID());
-        checkArgument(_changeId.version() == 1, "The changeId must be an RFC 4122 version 1 UUID (a time UUID).");
-        _delta = checkNotNull(delta, "delta");
-        _audit = checkNotNull(audit, "audit");
-        _consistency = Objects.firstNonNull(consistency, WriteConsistency.STRONG);
+        _changeId = Optional.ofNullable(changeId).orElse(TimeUUIDs.newUUID());
+        if (_changeId.version() != 1) {
+            throw new IllegalArgumentException("The changeId must be an RFC 4122 version 1 UUID (a time UUID).");
+        }
+        _delta = requireNonNull(delta, "delta");
+        _audit = requireNonNull(audit, "audit");
+        _consistency = Optional.ofNullable(consistency).orElse(WriteConsistency.STRONG);
     }
 
     public String getTable() {
@@ -86,7 +91,7 @@ public final class Update {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_table, _key, _changeId, _delta, _audit, _consistency);
+        return Objects.hash(_table, _key, _changeId, _delta, _audit, _consistency);
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/DateStatistics.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/DateStatistics.java
@@ -2,15 +2,15 @@ package com.bazaarvoice.emodb.sor.api.report;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
 public class DateStatistics extends Statistics<Date> {
 
     public DateStatistics() {
-        this(null, null, null, 0, ImmutableList.<Date>of());
+        this(null, null, null, 0, Collections.emptyList());
     }
 
     @JsonCreator

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/LongStatistics.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/LongStatistics.java
@@ -2,18 +2,16 @@ package com.bazaarvoice.emodb.sor.api.report;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 
+import java.util.Collections;
 import java.util.List;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class LongStatistics extends Statistics<Long> {
 
     private final long _sum;
 
     public LongStatistics() {
-        this(null, null, null, null, 0, ImmutableList.<Long>of());
+        this(null, null, null, null, 0, Collections.emptyList());
     }
 
     @JsonCreator
@@ -22,7 +20,9 @@ public class LongStatistics extends Statistics<Long> {
             @JsonProperty ("mean") Long mean, @JsonProperty ("stdev") double stdev,
             @JsonProperty ("sample") List<Long> sample) {
         super(min, max, mean, stdev, sample);
-        checkArgument((sum == null) == (min == null), "Inconsistent null value for sum");
+        if ((sum == null) != (min == null)) {
+            throw new IllegalArgumentException("Inconsistent null value for sum");
+        }
         _sum = sum;
     }
 

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/TableReportEntry.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/TableReportEntry.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class TableReportEntry {
     private final String _tableName;
@@ -14,8 +14,8 @@ public class TableReportEntry {
     @JsonCreator
     public TableReportEntry(
             @JsonProperty ("tableName") String tableName, @JsonProperty ("tables") List<TableReportEntryTable> tables) {
-        _tableName = checkNotNull(tableName, "tableName");
-        _tables = checkNotNull(tables, "tables");
+        _tableName = requireNonNull(tableName, "tableName");
+        _tables = requireNonNull(tables, "tables");
     }
 
     public String getTableName() {

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/TableReportEntryTable.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/TableReportEntryTable.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class TableReportEntryTable {
     private final String _id;
@@ -28,9 +28,9 @@ public class TableReportEntryTable {
             @JsonProperty ("sizeStatistics") LongStatistics sizeStatistics,
             @JsonProperty ("updateTimeStatistics") DateStatistics updateTimeStatistics) {
 
-        _id = checkNotNull(id, "id");
-        _placement = checkNotNull(placement, "placement");
-        _shardIds = Collections.unmodifiableList(checkNotNull(shardIds, "shardIds"));
+        _id = requireNonNull(id, "id");
+        _placement = requireNonNull(placement, "placement");
+        _shardIds = Collections.unmodifiableList(requireNonNull(shardIds, "shardIds"));
         _dropped = dropped;
         _facade = facade;
         _rowCount = rowCount;

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/TableReportMetadata.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/report/TableReportMetadata.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 import java.util.Date;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class TableReportMetadata {
     private final String _id;
@@ -22,11 +22,11 @@ public class TableReportMetadata {
                                @JsonProperty("endTime") @Nullable Date endTime,
                                @JsonProperty("success") @Nullable Boolean success,
                                @JsonProperty("placements") List<String> placements) {
-        _id = checkNotNull(id, "id");
-        _startTime = checkNotNull(startTime, "startTime");
+        _id = requireNonNull(id, "id");
+        _startTime = requireNonNull(startTime, "startTime");
         _endTime = endTime;
         _success = success;
-        _placements = checkNotNull(placements, "placements");
+        _placements = requireNonNull(placements, "placements");
     }
 
     public String getId() {

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/Conditions.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/Conditions.java
@@ -13,11 +13,11 @@ import com.bazaarvoice.emodb.sor.condition.impl.NotConditionImpl;
 import com.bazaarvoice.emodb.sor.condition.impl.OrConditionBuilderImpl;
 import com.bazaarvoice.emodb.sor.delta.deser.DeltaParser;
 import com.bazaarvoice.emodb.sor.delta.impl.ContainsConditionImpl;
-import com.google.common.collect.Sets;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public abstract class Conditions {
@@ -52,7 +52,7 @@ public abstract class Conditions {
         } else if (json.size() == 1) {
             return equal(json.iterator().next());
         }
-        Set<Object> set = Sets.newLinkedHashSet(json);
+        Set<Object> set = new LinkedHashSet<>(json);
         if (set.size() == 1) {
             return equal(set.iterator().next());
         } else {
@@ -160,7 +160,7 @@ public abstract class Conditions {
             // Every possible value satisfies the condition containing an empty subset
             return alwaysTrue();
         }
-        Set<Object> values = Sets.newLinkedHashSet(json);
+        Set<Object> values = new LinkedHashSet<>(json);
         return new ContainsConditionImpl(values, containment);
     }
 

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluator.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluator.java
@@ -19,18 +19,16 @@ import com.bazaarvoice.emodb.sor.condition.OrCondition;
 import com.bazaarvoice.emodb.sor.condition.State;
 import com.bazaarvoice.emodb.sor.delta.eval.DeltaEvaluator;
 import com.bazaarvoice.emodb.sor.delta.eval.Intrinsics;
-import com.google.common.base.Objects;
-import com.google.common.collect.Sets;
-import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Longs;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class ConditionEvaluator implements ConditionVisitor<Object, Boolean> {
 
@@ -51,7 +49,7 @@ public class ConditionEvaluator implements ConditionVisitor<Object, Boolean> {
 
     @Override
     public Boolean visit(EqualCondition condition, @Nullable Object json) {
-        return Objects.equal(condition.getValue(), json);
+        return Objects.equals(condition.getValue(), json);
     }
 
     @Override
@@ -65,7 +63,7 @@ public class ConditionEvaluator implements ConditionVisitor<Object, Boolean> {
     }
 
     private Object getIntrinsicValue(String name) {
-        Intrinsics intrinsics = checkNotNull(_intrinsics, "May not reference intrinsic values from this context.");
+        Intrinsics intrinsics = requireNonNull(_intrinsics, "May not reference intrinsic values from this context.");
         if (Intrinsic.ID.equals(name)) {
             return intrinsics.getId();
         } else if (Intrinsic.TABLE.equals(name)) {
@@ -130,9 +128,9 @@ public class ConditionEvaluator implements ConditionVisitor<Object, Boolean> {
             Number nLeft = (Number) json;
             Number nRight = (Number) value;
             if (promoteToDouble(nLeft) || promoteToDouble(nRight)) {
-                return matchesComparison(comparison, Doubles.compare(nLeft.doubleValue(), nRight.doubleValue()));
+                return matchesComparison(comparison, Double.compare(nLeft.doubleValue(), nRight.doubleValue()));
             } else {
-                return matchesComparison(comparison, Longs.compare(nLeft.longValue(), nRight.longValue()));
+                return matchesComparison(comparison, Long.compare(nLeft.longValue(), nRight.longValue()));
             }
         }
         if (json instanceof String && value instanceof String) {
@@ -182,7 +180,7 @@ public class ConditionEvaluator implements ConditionVisitor<Object, Boolean> {
         // If we're going to traverse the values more than once then convert it into a set
         // Skip if it is already a Set type
         if (!isSetType && (values.size() > 1 || conditionValues.size() > 1)) {
-            values = Sets.newHashSet(values);
+            values = new HashSet<>(values);
         }
 
         boolean isAny = containment == ContainsCondition.Containment.ANY;

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/eval/SubsetEvaluator.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/eval/SubsetEvaluator.java
@@ -15,12 +15,13 @@ import com.bazaarvoice.emodb.sor.condition.MapCondition;
 import com.bazaarvoice.emodb.sor.condition.NotCondition;
 import com.bazaarvoice.emodb.sor.condition.OrCondition;
 import com.bazaarvoice.emodb.sor.condition.State;
-import com.google.common.base.Objects;
-import com.google.common.collect.Sets;
 
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Evaluator for determining if, for two conditions left and right, left is a subset of right.  This relationship
@@ -37,7 +38,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class SubsetEvaluator implements ConditionVisitor<Condition, Boolean> {
 
     public static boolean isSubset(Condition left, Condition right) {
-        return new SubsetEvaluator().checkIsSubset(checkNotNull(left, "left"), checkNotNull(right, "right"));
+        return new SubsetEvaluator().checkIsSubset(requireNonNull(left, "left"), requireNonNull(right, "right"));
     }
 
     private boolean checkIsSubset(Condition left, Condition right) {
@@ -60,7 +61,7 @@ public class SubsetEvaluator implements ConditionVisitor<Condition, Boolean> {
             @Override
             public Boolean visit(EqualCondition right, Void context) {
                 // Example: "value" subset? "value"
-                return Objects.equal(_left.getValue(), right.getValue());
+                return Objects.equals(_left.getValue(), right.getValue());
             }
 
             @Override
@@ -115,7 +116,9 @@ public class SubsetEvaluator implements ConditionVisitor<Condition, Boolean> {
             @Override
             public Boolean visit(EqualCondition right, Void context) {
                 // Example: in("value") subset? "value"
-                return _left.getValues().equals(Sets.newHashSet(right.getValue()));
+                Set<Object> rightSet = new LinkedHashSet<>();
+                rightSet.add(right);
+                return _left.getValues().equals(rightSet);
             }
 
             @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AbstractCondition.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AbstractCondition.java
@@ -1,7 +1,6 @@
 package com.bazaarvoice.emodb.sor.condition.impl;
 
 import com.bazaarvoice.emodb.sor.condition.Condition;
-import com.google.common.base.Throwables;
 
 import java.io.IOException;
 
@@ -13,7 +12,7 @@ public abstract class AbstractCondition implements Condition {
         try {
             appendTo(buf);
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         return buf.toString();
     }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AndConditionBuilderImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AndConditionBuilderImpl.java
@@ -3,14 +3,14 @@ package com.bazaarvoice.emodb.sor.condition.impl;
 import com.bazaarvoice.emodb.sor.condition.AndConditionBuilder;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
-import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 public class AndConditionBuilderImpl implements AndConditionBuilder {
 
-    private final List<Condition> _conditions = Lists.newArrayList();
+    private final List<Condition> _conditions = new ArrayList<>();
 
     @Override
     public AndConditionBuilder and(Condition condition) {

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AndConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AndConditionImpl.java
@@ -3,19 +3,20 @@ package com.bazaarvoice.emodb.sor.condition.impl;
 import com.bazaarvoice.emodb.sor.condition.AndCondition;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
+import com.bazaarvoice.emodb.streaming.AppendableJoiner;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collection;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class AndConditionImpl extends AbstractCondition implements AndCondition {
 
     private final Collection<Condition> _conditions;
 
     public AndConditionImpl(Collection<Condition> conditions) {
-        _conditions = checkNotNull(conditions, "conditions");
+        _conditions = requireNonNull(conditions, "conditions");
     }
 
     @Override
@@ -30,14 +31,7 @@ public class AndConditionImpl extends AbstractCondition implements AndCondition 
 
     @Override
     public void appendTo(Appendable buf) throws IOException {
-        buf.append("and(");
-        String sep = "";
-        for (Condition condition : _conditions) {
-            buf.append(sep);
-            condition.appendTo(buf);
-            sep = ",";
-        }
-        buf.append(")");
+        _conditions.stream().collect(AppendableJoiner.joining(buf, ",", "and(", ")", (app, cond) -> cond.appendTo(app)));
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/ComparisonConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/ComparisonConditionImpl.java
@@ -4,15 +4,10 @@ import com.bazaarvoice.emodb.sor.condition.Comparison;
 import com.bazaarvoice.emodb.sor.condition.ComparisonCondition;
 import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 import com.bazaarvoice.emodb.sor.delta.deser.DeltaJson;
-import com.google.common.base.Objects;
-import com.google.common.io.CharStreams;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.Writer;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
 
 public class ComparisonConditionImpl extends AbstractCondition implements ComparisonCondition {
 
@@ -20,9 +15,17 @@ public class ComparisonConditionImpl extends AbstractCondition implements Compar
     private final Object _value;
 
     public ComparisonConditionImpl(Comparison comparison, Object value) {
-        _comparison = checkNotNull(comparison, "comparison");
-        _value = checkNotNull(value, "value");
-        checkArgument(value instanceof Number || value instanceof String, "%s only supports numbers and strings", comparison.getDeltaFunction());
+        if (comparison == null) {
+            throw new NullPointerException("comparison");
+        }
+        if (value == null) {
+            throw new NullPointerException("value");
+        }
+        _comparison = comparison;
+        _value = value;
+        if (!(value instanceof Number || value instanceof String)) {
+            throw new IllegalArgumentException(String.format("%s only supports numbers and strings", comparison.getDeltaFunction()));
+        }
     }
 
     @Override
@@ -38,12 +41,10 @@ public class ComparisonConditionImpl extends AbstractCondition implements Compar
     @Override
     public void appendTo(Appendable buf)
             throws IOException {
-        // Use a writer so the value can be correctly converted to json using DeltaJson.
-        Writer out = CharStreams.asWriter(buf);
-        out.write(_comparison.getDeltaFunction());
-        out.write("(");
-        DeltaJson.write(out, _value);
-        out.write(")");
+        buf.append(_comparison.getDeltaFunction());
+        buf.append("(");
+        DeltaJson.append(buf, _value);
+        buf.append(")");
     }
 
     @Override
@@ -147,6 +148,6 @@ public class ComparisonConditionImpl extends AbstractCondition implements Compar
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_comparison, _value);
+        return Objects.hash(_comparison, _value);
     }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/EqualConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/EqualConditionImpl.java
@@ -5,11 +5,10 @@ import com.bazaarvoice.emodb.common.json.OrderedJson;
 import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 import com.bazaarvoice.emodb.sor.condition.EqualCondition;
 import com.bazaarvoice.emodb.sor.delta.deser.DeltaJson;
-import com.google.common.base.Objects;
-import com.google.common.io.CharStreams;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Objects;
 
 public class EqualConditionImpl extends AbstractCondition implements EqualCondition {
 
@@ -31,12 +30,12 @@ public class EqualConditionImpl extends AbstractCondition implements EqualCondit
 
     @Override
     public void appendTo(Appendable buf) throws IOException {
-        DeltaJson.write(CharStreams.asWriter(buf), OrderedJson.ordered(_value));
+        DeltaJson.append(buf, OrderedJson.ordered(_value));
     }
 
     @Override
     public boolean equals(Object o) {
-        return (this == o) || (o instanceof EqualCondition) && Objects.equal(_value, ((EqualCondition) o).getValue());
+        return (this == o) || (o instanceof EqualCondition) && Objects.equals(_value, ((EqualCondition) o).getValue());
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/InConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/InConditionImpl.java
@@ -4,7 +4,7 @@ import com.bazaarvoice.emodb.common.json.JsonValidator;
 import com.bazaarvoice.emodb.common.json.OrderedJson;
 import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 import com.bazaarvoice.emodb.sor.condition.InCondition;
-import com.google.common.base.Joiner;
+import com.bazaarvoice.emodb.streaming.AppendableJoiner;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -33,9 +33,7 @@ public class InConditionImpl extends AbstractCondition implements InCondition {
 
     @Override
     public void appendTo(Appendable buf) throws IOException {
-        buf.append("in(");
-        Joiner.on(',').appendTo(buf, OrderedJson.orderedStrings(_values));
-        buf.append(")");
+        OrderedJson.orderedStrings(_values).stream().collect(AppendableJoiner.joining(buf, ",", "in(", ")"));
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/IsConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/IsConditionImpl.java
@@ -7,14 +7,14 @@ import com.bazaarvoice.emodb.sor.condition.State;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class IsConditionImpl extends AbstractCondition implements IsCondition {
 
     private final State _state;
 
     public IsConditionImpl(State state) {
-        _state = checkNotNull(state);
+        _state = requireNonNull(state);
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/MapConditionBuilderImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/MapConditionBuilderImpl.java
@@ -3,16 +3,14 @@ package com.bazaarvoice.emodb.sor.condition.impl;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.condition.MapConditionBuilder;
-import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
+import java.util.HashMap;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class MapConditionBuilderImpl implements MapConditionBuilder {
 
-    private final Map<String, Condition> _entries = Maps.newHashMap();
+    private final Map<String, Condition> _entries = new HashMap<>();
 
     @Override
     public MapConditionBuilder containsKey(String key) {
@@ -35,7 +33,10 @@ public class MapConditionBuilderImpl implements MapConditionBuilder {
     @Override
     public MapConditionBuilder matches(String key, Condition condition) {
         Condition previous = _entries.put(key, condition);
-        checkArgument(previous == null, "Multiple operations against the same key are not allowed: %s", key);
+        if (previous != null) {
+            throw new IllegalArgumentException(String.format(
+                    "Multiple operations against the same key are not allowed: %s", key));
+        }
         return this;
     }
 

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/MapConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/MapConditionImpl.java
@@ -10,6 +10,7 @@ import com.google.common.io.CharStreams;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Iterator;
 import java.util.Map;
 
 public class MapConditionImpl extends AbstractCondition implements MapCondition {
@@ -34,7 +35,8 @@ public class MapConditionImpl extends AbstractCondition implements MapCondition 
     public void appendTo(Appendable buf) throws IOException {
         buf.append("{..");
         Writer writer = CharStreams.asWriter(buf);
-        for (Map.Entry<String, Condition> entry : OrderedJson.ENTRY_COMPARATOR.immutableSortedCopy(_entries.entrySet())) {
+        for (Iterator<Map.Entry<String, Condition>> iter = _entries.entrySet().stream().sorted(OrderedJson.ENTRY_COMPARATOR).iterator(); iter.hasNext(); ) {
+            Map.Entry<String, Condition> entry = iter.next();
             buf.append(',');
             DeltaJson.write(writer, entry.getKey());
             buf.append(':');

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/MapConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/MapConditionImpl.java
@@ -5,11 +5,9 @@ import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 import com.bazaarvoice.emodb.sor.condition.MapCondition;
 import com.bazaarvoice.emodb.sor.delta.deser.DeltaJson;
-import com.google.common.io.CharStreams;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.Writer;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -34,11 +32,10 @@ public class MapConditionImpl extends AbstractCondition implements MapCondition 
     @Override
     public void appendTo(Appendable buf) throws IOException {
         buf.append("{..");
-        Writer writer = CharStreams.asWriter(buf);
         for (Iterator<Map.Entry<String, Condition>> iter = _entries.entrySet().stream().sorted(OrderedJson.ENTRY_COMPARATOR).iterator(); iter.hasNext(); ) {
             Map.Entry<String, Condition> entry = iter.next();
             buf.append(',');
-            DeltaJson.write(writer, entry.getKey());
+            DeltaJson.append(buf, entry.getKey());
             buf.append(':');
             entry.getValue().appendTo(buf);
         }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/NotConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/NotConditionImpl.java
@@ -7,14 +7,14 @@ import com.bazaarvoice.emodb.sor.condition.NotCondition;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class NotConditionImpl extends AbstractCondition implements NotCondition {
 
     private final Condition _condition;
 
     public NotConditionImpl(Condition condition) {
-        _condition = checkNotNull(condition, "condition");
+        _condition = requireNonNull(condition, "condition");
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/OrConditionBuilderImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/OrConditionBuilderImpl.java
@@ -93,10 +93,9 @@ public class OrConditionBuilderImpl implements OrConditionBuilder {
             conditions.add(Conditions.in(_values));
         }
         if (_intrinsics != null) {
-            for (Map.Entry<String, Collection<Condition>> entry :
-                    OrderedJson.ENTRY_COMPARATOR.immutableSortedCopy(_intrinsics.asMap().entrySet())) {
-                conditions.add(Conditions.intrinsic(entry.getKey(), Conditions.or(entry.getValue())));
-            }
+            _intrinsics.asMap().entrySet().stream()
+                    .sorted(OrderedJson.ENTRY_COMPARATOR)
+                    .forEach(e -> conditions.add(Conditions.intrinsic(e.getKey(), Conditions.or(e.getValue()))));
         }
         if (_conditions != null) {
             conditions.addAll(_conditions);

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/OrConditionBuilderImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/OrConditionBuilderImpl.java
@@ -9,19 +9,18 @@ import com.bazaarvoice.emodb.sor.condition.InCondition;
 import com.bazaarvoice.emodb.sor.condition.IntrinsicCondition;
 import com.bazaarvoice.emodb.sor.condition.OrCondition;
 import com.bazaarvoice.emodb.sor.condition.OrConditionBuilder;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class OrConditionBuilderImpl implements OrConditionBuilder {
 
     private List<Condition> _conditions;
     private List<Object> _values;
-    private ListMultimap<String, Condition> _intrinsics;
+    private ConcurrentMap<String, List<Condition>> _intrinsics;
     private boolean _alwaysTrue;
 
     @Override
@@ -46,29 +45,30 @@ public class OrConditionBuilderImpl implements OrConditionBuilder {
 
         } else if (condition instanceof EqualCondition) {
             if (_values == null) {
-                _values = Lists.newArrayList();
+                _values = new ArrayList<>();
             }
             _values.add(((EqualCondition) condition).getValue());
 
         } else if (condition instanceof InCondition) {
             if (_values == null) {
-                _values = Lists.newArrayList();
+                _values =  new ArrayList<>();
             }
             _values.addAll(((InCondition) condition).getValues());
 
         } else if (condition instanceof IntrinsicCondition) {
             if (_intrinsics == null) {
-                _intrinsics = ArrayListMultimap.create();
+                _intrinsics = new ConcurrentHashMap<>();
             }
             IntrinsicCondition intrinsic = (IntrinsicCondition) condition;
-            _intrinsics.put(intrinsic.getName(), intrinsic.getCondition());
+            _intrinsics.computeIfAbsent(intrinsic.getName(), ignore -> new ArrayList())
+                    .add(intrinsic.getCondition());
 
         } else if (condition instanceof OrCondition) {
             orAny(((OrCondition) condition).getConditions());
 
         } else {
             if (_conditions == null) {
-                _conditions = Lists.newArrayList();
+                _conditions = new ArrayList<>();
             }
             _conditions.add(condition);
         }
@@ -88,12 +88,12 @@ public class OrConditionBuilderImpl implements OrConditionBuilder {
             return Conditions.alwaysTrue();
         }
 
-        List<Condition> conditions = Lists.newArrayList();
+        List<Condition> conditions = new ArrayList<>();
         if (_values != null) {
             conditions.add(Conditions.in(_values));
         }
         if (_intrinsics != null) {
-            _intrinsics.asMap().entrySet().stream()
+            _intrinsics.entrySet().stream()
                     .sorted(OrderedJson.ENTRY_COMPARATOR)
                     .forEach(e -> conditions.add(Conditions.intrinsic(e.getKey(), Conditions.or(e.getValue()))));
         }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/OrConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/OrConditionImpl.java
@@ -3,19 +3,20 @@ package com.bazaarvoice.emodb.sor.condition.impl;
 import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 import com.bazaarvoice.emodb.sor.condition.OrCondition;
+import com.bazaarvoice.emodb.streaming.AppendableJoiner;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collection;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class OrConditionImpl extends AbstractCondition implements OrCondition {
 
     private final Collection<Condition> _conditions;
 
     public OrConditionImpl(Collection<Condition> conditions) {
-        _conditions = checkNotNull(conditions, "conditions");
+        _conditions = requireNonNull(conditions, "conditions");
     }
 
     @Override
@@ -30,14 +31,7 @@ public class OrConditionImpl extends AbstractCondition implements OrCondition {
 
     @Override
     public void appendTo(Appendable buf) throws IOException {
-        buf.append("or(");
-        String sep = "";
-        for (Condition condition : _conditions) {
-            buf.append(sep);
-            condition.appendTo(buf);
-            sep = ",";
-        }
-        buf.append(")");
+        _conditions.stream().collect(AppendableJoiner.joining(buf, ",", "or(", ")", (app, cond) -> cond.appendTo(app)));
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/DeltaJson.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/DeltaJson.java
@@ -36,4 +36,72 @@ public abstract class DeltaJson {
         gen.writeString(string);
         gen.close();
     }
+
+    public static Appendable append(Appendable appendable, Object value) {
+        try {
+            write(asWriter(appendable), value);
+        } catch (IOException e) {
+            // Not expected writing to appendable
+            throw new RuntimeException(e);
+        }
+        return appendable;
+    }
+
+    public static Appendable append(Appendable appendable, String string) {
+        try {
+            write(asWriter(appendable), string);
+        } catch (IOException e) {
+            // Not expected writing to appendable
+            throw new RuntimeException(e);
+        }
+        return appendable;
+    }
+
+    private static Writer asWriter(final Appendable appendable) {
+        return new Writer() {
+            @Override
+            public void write(char[] cbuf, int off, int len) throws IOException {
+                for (int i=0; i < len; i++) {
+                    appendable.append(cbuf[off+i]);
+                }
+            }
+
+            @Override
+            public void write(String str) throws IOException {
+                appendable.append(str);
+            }
+
+            @Override
+            public void write(String str, int off, int len) throws IOException {
+                appendable.append(str.substring(off, off+len));
+            }
+
+            @Override
+            public Writer append(CharSequence chars) throws IOException {
+                appendable.append(chars);
+                return this;
+            }
+
+            @Override
+            public Writer append(CharSequence chars, int start, int end) throws IOException {
+                appendable.append(chars, start, end);
+                return this;
+            }
+
+            @Override
+            public Writer append(char c) throws IOException {
+                return super.append(c);
+            }
+
+            @Override
+            public void flush() throws IOException {
+                // No-op
+            }
+
+            @Override
+            public void close() throws IOException {
+                // No-op
+            }
+        };
+    }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/DeltaStreamSplitter.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/DeltaStreamSplitter.java
@@ -1,13 +1,11 @@
 package com.bazaarvoice.emodb.sor.delta.deser;
 
-import com.google.common.base.Throwables;
-import com.google.common.collect.UnmodifiableIterator;
+import com.bazaarvoice.emodb.streaming.AbstractSpliterator;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.NoSuchElementException;
 
-class DeltaStreamSplitter extends UnmodifiableIterator<String> {
+class DeltaStreamSplitter extends AbstractSpliterator<String> {
 
     private final Reader _in;
     private final boolean _array;
@@ -29,7 +27,7 @@ class DeltaStreamSplitter extends UnmodifiableIterator<String> {
                 setFirstCharOfNextValue(ch);
             }
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -40,16 +38,15 @@ class DeltaStreamSplitter extends UnmodifiableIterator<String> {
         _firstCharOfNextValue = ch;
     }
 
-    @Override
     public boolean hasNext() {
         int ch = _firstCharOfNextValue;
         return ch != -1 && ch != ']';
     }
 
     @Override
-    public String next() {
+    protected String computeNext() {
         if (!hasNext()) {
-            throw new NoSuchElementException();
+            return endOfStream();
         }
         try {
             StringBuilder buf = new StringBuilder();
@@ -95,10 +92,10 @@ class DeltaStreamSplitter extends UnmodifiableIterator<String> {
             setFirstCharOfNextValue(ch);
             return buf.toString();
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
-
+    
     /**
      * Get the next char in the stream, skipping whitespace.
      * @return  A character, or -1 if there are no more characters.

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/JsonTokener.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/JsonTokener.java
@@ -15,14 +15,11 @@ limitations under the License.
 */
 package com.bazaarvoice.emodb.sor.delta.deser;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkState;
 
 /**
  * A JsonTokener parses JSON strings.
@@ -67,7 +64,9 @@ public class JsonTokener {
      * the next number or identifier.
      */
     public void back() {
-        checkState(myIndex > 0);
+        if (myIndex <= 0) {
+            throw new IllegalStateException();
+        }
         this.myIndex -= 1;
     }
 
@@ -301,7 +300,7 @@ public class JsonTokener {
     }
 
     public List<Object> nextArray() {
-        List<Object> list = Lists.newArrayList();
+        List<Object> list = new ArrayList<>();
         if (startArgs('[', ']')) {
             do {
                 list.add(nextValue());
@@ -311,7 +310,7 @@ public class JsonTokener {
     }
 
     public Map<String, Object> nextObject() {
-        Map<String, Object> map = Maps.newLinkedHashMap();
+        Map<String, Object> map = new LinkedHashMap<>();
         if (startArgs('{', '}')) {
             do {
                 // The key must be a quoted string.

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/AbstractDelta.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/AbstractDelta.java
@@ -1,7 +1,6 @@
 package com.bazaarvoice.emodb.sor.delta.impl;
 
 import com.bazaarvoice.emodb.sor.delta.Delta;
-import com.google.common.base.Throwables;
 
 import java.io.IOException;
 
@@ -13,7 +12,7 @@ public abstract class AbstractDelta implements Delta {
         try {
             appendTo(buf);
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         return buf.toString();
     }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/ConditionalDeltaBuilderImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/ConditionalDeltaBuilderImpl.java
@@ -4,30 +4,32 @@ import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.delta.ConditionalDeltaBuilder;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class ConditionalDeltaBuilderImpl implements ConditionalDeltaBuilder {
 
-    private final List<Map.Entry<Condition, Delta>> _clauses = Lists.newArrayList();
+    private final List<Map.Entry<Condition, Delta>> _clauses = new ArrayList<>();
     private Delta _otherwise;
 
     @Override
     public ConditionalDeltaBuilder add(Condition condition, Delta delta) {
-        _clauses.add(Maps.immutableEntry(checkNotNull(condition, "condition"), checkNotNull(delta, "delta")));
+        _clauses.add(new AbstractMap.SimpleImmutableEntry<>(
+                requireNonNull(condition, "condition"), requireNonNull(delta, "delta")));
         return this;
     }
 
     @Override
     public ConditionalDeltaBuilder otherwise(Delta delta) {
-        checkArgument(_otherwise == null, "Multiple otherwise deltas.");
-        _otherwise = checkNotNull(delta);
+        if (_otherwise != null) {
+            throw new IllegalArgumentException("Multiple otherwise deltas.");
+        }
+        _otherwise = requireNonNull(delta);
         return this;
     }
 

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/ConditionalDeltaImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/ConditionalDeltaImpl.java
@@ -9,7 +9,7 @@ import com.bazaarvoice.emodb.sor.delta.NoopDelta;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class ConditionalDeltaImpl extends AbstractDelta implements ConditionalDelta {
 
@@ -18,9 +18,9 @@ public class ConditionalDeltaImpl extends AbstractDelta implements ConditionalDe
     private final Delta _else;
 
     public ConditionalDeltaImpl(Condition test, Delta then, Delta anElse) {
-        _test = checkNotNull(test);
-        _then = checkNotNull(then);
-        _else = checkNotNull(anElse);
+        _test = requireNonNull(test);
+        _then = requireNonNull(then);
+        _else = requireNonNull(anElse);
     }
 
     @Override

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/LiteralImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/LiteralImpl.java
@@ -5,10 +5,6 @@ import com.bazaarvoice.emodb.common.json.OrderedJson;
 import com.bazaarvoice.emodb.sor.delta.DeltaVisitor;
 import com.bazaarvoice.emodb.sor.delta.Literal;
 import com.bazaarvoice.emodb.sor.delta.deser.DeltaJson;
-import com.google.common.base.Throwables;
-import com.google.common.io.CharStreams;
-import com.google.common.primitives.Doubles;
-import com.google.common.primitives.Longs;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -45,7 +41,7 @@ public class LiteralImpl extends AbstractDelta implements Literal {
     public void appendTo(Appendable buf) throws IOException {
         // nested content is sorted so toString() is deterministic.  this is valuable in tests and for
         // comparing hashes of deltas for equality.
-        DeltaJson.write(CharStreams.asWriter(buf), OrderedJson.ordered(_value));
+        DeltaJson.append(buf, OrderedJson.ordered(_value));
     }
 
     @SuppressWarnings("unchecked")
@@ -104,9 +100,9 @@ public class LiteralImpl extends AbstractDelta implements Literal {
             // If both values are numeric then use numeric comparison regardless of the underlying type (int, double, and so on)
             if (isNumber(thisClass) && isNumber(thatClass)) {
                 if (isDouble((Class<? extends Number>) thisClass) || isDouble((Class<? extends Number>) thatClass)) {
-                    return Doubles.compare(((Number) _value).doubleValue(), ((Number) that).doubleValue());
+                    return Double.compare(((Number) _value).doubleValue(), ((Number) that).doubleValue());
                 } else {
-                    return Longs.compare(((Number) _value).longValue(), ((Number) that).longValue());
+                    return Long.compare(((Number) _value).longValue(), ((Number) that).longValue());
                 }
             }
 
@@ -127,7 +123,7 @@ public class LiteralImpl extends AbstractDelta implements Literal {
             return thisStr.toString().compareTo(thatStr.toString());
         } catch (IOException e) {
             // Should never happen
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
 
     }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/MapDeltaImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/MapDeltaImpl.java
@@ -11,6 +11,7 @@ import com.google.common.io.CharStreams;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Iterator;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -79,7 +80,8 @@ public class MapDeltaImpl extends AbstractDelta implements MapDelta {
             sep = ",";
         }
         Writer writer = CharStreams.asWriter(buf);
-        for (Map.Entry<String, Delta> entry : OrderedJson.ENTRY_COMPARATOR.immutableSortedCopy(_entries.entrySet())) {
+        for (Iterator<Map.Entry<String, Delta>> iter =  _entries.entrySet().stream().sorted(OrderedJson.ENTRY_COMPARATOR).iterator(); iter.hasNext(); ) {
+            Map.Entry<String, Delta> entry = iter.next();
             buf.append(sep);
             sep = ",";
             DeltaJson.write(writer, entry.getKey());

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/MapDeltaImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/MapDeltaImpl.java
@@ -5,16 +5,14 @@ import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.DeltaVisitor;
 import com.bazaarvoice.emodb.sor.delta.MapDelta;
 import com.bazaarvoice.emodb.sor.delta.deser.DeltaJson;
-import com.google.common.base.Objects;
-import com.google.common.io.CharStreams;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.Writer;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class MapDeltaImpl extends AbstractDelta implements MapDelta {
 
@@ -25,7 +23,7 @@ public class MapDeltaImpl extends AbstractDelta implements MapDelta {
 
     public MapDeltaImpl(boolean removeRest, Map<String, Delta> entries, boolean deleteIfEmpty) {
         _removeRest = removeRest;
-        _entries = checkNotNull(entries, "entries");
+        _entries = requireNonNull(entries, "entries");
         _deleteIfEmpty = deleteIfEmpty;
         _constant = computeConstant();
     }
@@ -79,12 +77,11 @@ public class MapDeltaImpl extends AbstractDelta implements MapDelta {
             buf.append("..");
             sep = ",";
         }
-        Writer writer = CharStreams.asWriter(buf);
         for (Iterator<Map.Entry<String, Delta>> iter =  _entries.entrySet().stream().sorted(OrderedJson.ENTRY_COMPARATOR).iterator(); iter.hasNext(); ) {
             Map.Entry<String, Delta> entry = iter.next();
             buf.append(sep);
             sep = ",";
-            DeltaJson.write(writer, entry.getKey());
+            DeltaJson.append(buf, entry.getKey());
             buf.append(':');
             entry.getValue().appendTo(buf);
         }
@@ -110,6 +107,6 @@ public class MapDeltaImpl extends AbstractDelta implements MapDelta {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(3169, _removeRest, _entries, _deleteIfEmpty);
+        return Objects.hash(3169, _removeRest, _entries, _deleteIfEmpty);
     }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/SetDeltaImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/SetDeltaImpl.java
@@ -3,16 +3,18 @@ package com.bazaarvoice.emodb.sor.delta.impl;
 import com.bazaarvoice.emodb.sor.delta.DeltaVisitor;
 import com.bazaarvoice.emodb.sor.delta.Literal;
 import com.bazaarvoice.emodb.sor.delta.SetDelta;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 public class SetDeltaImpl extends AbstractDelta implements SetDelta {
 
@@ -23,8 +25,8 @@ public class SetDeltaImpl extends AbstractDelta implements SetDelta {
 
     public SetDeltaImpl(boolean removeRest, Collection<Literal> addedValues, Collection<Literal> removedValues, boolean deleteIfEmpty) {
         _removeRest = removeRest;
-        _addedValues = sorted(checkNotNull(addedValues, "addedValues"));
-        _removedValues = sorted(checkNotNull(removedValues, "removedValues"));
+        _addedValues = sorted(requireNonNull(addedValues, "addedValues"));
+        _removedValues = sorted(requireNonNull(removedValues, "removedValues"));
         _deleteIfEmpty = deleteIfEmpty;
     }
 
@@ -83,12 +85,13 @@ public class SetDeltaImpl extends AbstractDelta implements SetDelta {
         // Optimize the simple cases
         switch (literals.size()) {
             case 0:
-                return ImmutableSet.of();
+                return Collections.emptySet();
             case 1:
-                return ImmutableSet.of(literals.iterator().next());
+                return Collections.unmodifiableSet(new LinkedHashSet<>(literals));
         }
 
-        return ImmutableSortedSet.copyOf(literals);
+        Set<Literal> sortedSet = literals.stream().sorted().collect(Collectors.toCollection(TreeSet::new));
+        return Collections.unmodifiableSet(sortedSet);
     }
 
     private String appendLiterals(Appendable buf, Set<Literal> literals, String sep, String prefix)
@@ -125,6 +128,6 @@ public class SetDeltaImpl extends AbstractDelta implements SetDelta {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(9532, _removeRest, _addedValues, _removedValues, _deleteIfEmpty);
+        return Objects.hash(9532, _removeRest, _addedValues, _removedValues, _deleteIfEmpty);
     }
 }

--- a/sor-api/src/test/java/com/bazaarvoice/emodb/sor/delta/deser/DeltaStreamSplitterTest.java
+++ b/sor-api/src/test/java/com/bazaarvoice/emodb/sor/delta/deser/DeltaStreamSplitterTest.java
@@ -9,6 +9,7 @@ import java.io.StringReader;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.StreamSupport;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -108,6 +109,6 @@ public class DeltaStreamSplitterTest {
     }
 
     private Iterator<String> splitter(String string) {
-        return new DeltaStreamSplitter(new StringReader(string));
+        return StreamSupport.stream(new DeltaStreamSplitter(new StringReader(string)), false).iterator();
     }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataTools.java
@@ -53,7 +53,7 @@ public interface DataTools {
     TableSet createTableSet();
 
     /**
-     * Create a snapshot of all tables excluding the ones listed in the {@link StashBlackListTableCondition} in the provided placements and their token ranges for Stash.  Must be called
+     * Create a snapshot of all tables anyCharExcept the ones listed in the {@link StashBlackListTableCondition} in the provided placements and their token ranges for Stash.  Must be called
      * prior to {@link #stashMultiTableScan(String, String, ScanRange, LimitCounter, ReadConsistency, Instant)}
      * otherwise that call will return no results.
      */

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
@@ -162,7 +162,7 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
 
         // consider compactionControlTimestamp here (one case could be that there is a stash run in progress) and not include those Ids.
         // With this, we are halting the deletion of these deltas in this run.
-        // We could have not included these Ids at the first place in the top section, but just to be cleaner and for better separation, excluding these Ids here.
+        // We could have not included these Ids at the first place in the top section, but just to be cleaner and for better separation, anyCharExcept these Ids here.
         keysToDelete = keysToDelete.stream().filter(keyToDelete -> (TimeUUIDs.getTimeMillis(keyToDelete) > compactionControlTimestamp)).collect(Collectors.toList());
         compactionKeysToDelete = compactionKeysToDelete.stream().filter(compactionKeyToDelete -> (TimeUUIDs.getTimeMillis(compactionKeyToDelete) > compactionControlTimestamp)).collect(Collectors.toList());
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/MergeIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/MergeIterator.java
@@ -5,9 +5,9 @@ import com.bazaarvoice.emodb.sor.api.Change;
 import com.bazaarvoice.emodb.sor.api.ChangeBuilder;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.PeekingIterator;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.UUID;
 
@@ -18,7 +18,7 @@ import java.util.UUID;
 class MergeIterator extends AbstractIterator<Change> {
     private final PeekingIterator<Change> _iter1;
     private final PeekingIterator<Change> _iter2;
-    private final Ordering<UUID> _ordering;
+    private final Comparator<UUID> _comparator;
 
     static Iterator<Change> merge(Iterator<Change> iter1, Iterator<Change> iter2, boolean reversed) {
         if (!iter2.hasNext()) {
@@ -26,14 +26,14 @@ class MergeIterator extends AbstractIterator<Change> {
         } else if (!iter1.hasNext()) {
             return iter2;
         }
-        Ordering<UUID> ordering = TimeUUIDs.ordering();
-        return new MergeIterator(iter1, iter2, reversed ? ordering.reverse() : ordering);
+        Comparator<UUID> comparator = TimeUUIDs.comparator();
+        return new MergeIterator(iter1, iter2, reversed ? comparator.reversed() : comparator);
     }
 
-    private MergeIterator(Iterator<Change> iter1, Iterator<Change> iter2, Ordering<UUID> ordering) {
+    private MergeIterator(Iterator<Change> iter1, Iterator<Change> iter2, Comparator<UUID> comparator) {
         _iter1 = Iterators.peekingIterator(iter1);
         _iter2 = Iterators.peekingIterator(iter2);
-        _ordering = ordering;
+        _comparator = comparator;
     }
 
     @Override
@@ -41,7 +41,7 @@ class MergeIterator extends AbstractIterator<Change> {
         if (_iter1.hasNext() && _iter2.hasNext()) {
             UUID id1 = _iter1.peek().getId();
             UUID id2 = _iter2.peek().getId();
-            UUID minId = _ordering.min(id1, id2);
+            UUID minId = _comparator.compare(id1, id2) < 0 ? id1 : id2;
             ChangeBuilder builder = new ChangeBuilder(minId);
             if (minId.equals(id1)) {
                 builder.merge(_iter1.next());

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
@@ -132,8 +133,8 @@ public class InMemoryDataReaderDAO implements DataReaderDAO, DataWriterDAO, Migr
 
         String table = key.getTable().getName();
 
-        Ordering<UUID> ordering = reversed ? TimeUUIDs.ordering().reverse() : TimeUUIDs.ordering();
-        NavigableMap<UUID, Change> map = Maps.newTreeMap(ordering);
+        Comparator<UUID> comparator = reversed ? TimeUUIDs.comparator().reversed() : TimeUUIDs.comparator();
+        NavigableMap<UUID, Change> map = Maps.newTreeMap(comparator);
         if (includeContentData) {
             map.putAll(safeGet(_contentChanges, table, key.getKey()));
         }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/StashTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/StashTableDAO.java
@@ -10,7 +10,7 @@ import java.util.Set;
 public interface StashTableDAO {
 
     /**
-     * Create a snapshot of all tables excluding the ones listed in the blackListTableCondition in the provided placements and their token ranges for Stash.
+     * Create a snapshot of all tables anyCharExcept the ones listed in the blackListTableCondition in the provided placements and their token ranges for Stash.
      */
     void createStashTokenRangeSnapshot(String stashId, Set<String> placements, Condition blackListTableCondition);
 

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/Storage.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/Storage.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Ordering;
 
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -243,7 +244,7 @@ class Storage extends JsonMap implements Comparable<Storage> {
         return ComparisonChain.start()
                 .compareTrueFirst(isConsistent(), o.isConsistent())  // Primaries *must* be consistent.
                 .compareTrueFirst(_masterPrimary, o._masterPrimary)  // Master primary sorts first
-                .compare(o.getPromotionId(), getPromotionId(), TimeUUIDs.ordering().nullsLast())  // Facade primary sorts first
+                .compare(o.getPromotionId(), getPromotionId(), Comparator.nullsLast(TimeUUIDs.comparator()))  // Facade primary sorts first
                 .compare(_uuid, o._uuid)  // Break ties in a way that's compatible with equals()
                 .result();
     }

--- a/uac-api/pom.xml
+++ b/uac-api/pom.xml
@@ -34,10 +34,6 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/CreateEmoApiKeyRequest.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/CreateEmoApiKeyRequest.java
@@ -1,9 +1,9 @@
 package com.bazaarvoice.emodb.uac.api;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -14,7 +14,7 @@ public class CreateEmoApiKeyRequest extends UserAccessControlRequest {
 
     private String _owner;
     private String _description;
-    private Set<EmoRoleKey> _roles = ImmutableSet.of();
+    private Set<EmoRoleKey> _roles = Collections.emptySet();
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getOwner() {
@@ -42,7 +42,7 @@ public class CreateEmoApiKeyRequest extends UserAccessControlRequest {
     }
 
     public CreateEmoApiKeyRequest setRoles(Set<EmoRoleKey> roles) {
-        _roles = Objects.firstNonNull(roles, ImmutableSet.<EmoRoleKey>of());
+        _roles = Optional.ofNullable(roles).orElse(Collections.emptySet());
         return this;
     }
 }

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/CreateEmoApiKeyResponse.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/CreateEmoApiKeyResponse.java
@@ -3,8 +3,7 @@ package com.bazaarvoice.emodb.uac.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
+import static java.util.Objects.requireNonNull;
 /**
  * Response object when creating an API key.  This object contains the private key and the ID for the new API key.
  */
@@ -15,8 +14,8 @@ public class CreateEmoApiKeyResponse {
 
     @JsonCreator
     public CreateEmoApiKeyResponse(@JsonProperty("key") String key, @JsonProperty("id") String id) {
-        _key = checkNotNull(key, "key");
-        _id = checkNotNull(id, "id");
+        _key = requireNonNull(key, "key");
+        _id = requireNonNull(id, "id");
     }
 
     public String getKey() {

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/CreateEmoRoleRequest.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/CreateEmoRoleRequest.java
@@ -3,12 +3,12 @@ package com.bazaarvoice.emodb.uac.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Request object for creating new roles.  Parameters include the key for the new role (group and ID),
@@ -20,7 +20,7 @@ public class CreateEmoRoleRequest extends UserAccessControlRequest {
     private EmoRoleKey _roleKey;
     private String _name;
     private String _description;
-    private Set<String> _permissions = ImmutableSet.of();
+    private Set<String> _permissions = Collections.emptySet();
 
     @JsonCreator
     public CreateEmoRoleRequest() {
@@ -36,7 +36,7 @@ public class CreateEmoRoleRequest extends UserAccessControlRequest {
     }
 
     public CreateEmoRoleRequest setRoleKey(EmoRoleKey roleKey) {
-        _roleKey = checkNotNull(roleKey, "roleKey");
+        _roleKey = requireNonNull(roleKey, "roleKey");
         return this;
     }
 
@@ -71,7 +71,7 @@ public class CreateEmoRoleRequest extends UserAccessControlRequest {
     }
 
     public CreateEmoRoleRequest setPermissions(Set<String> permissions) {
-        _permissions = Objects.firstNonNull(permissions, ImmutableSet.<String>of());
+        _permissions = Optional.ofNullable(permissions).orElse(Collections.emptySet());
         return this;
     }
 }

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoApiKey.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoApiKey.java
@@ -3,13 +3,12 @@ package com.bazaarvoice.emodb.uac.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * API key object for an Emo user.  Each API key has two identifiers:  The private key used for authentication and
@@ -25,14 +24,14 @@ public class EmoApiKey {
     private final Date _issued;
     private String _owner;
     private String _description;
-    private Set<EmoRoleKey> _roles = ImmutableSet.of();
+    private Set<EmoRoleKey> _roles = Collections.emptySet();
 
     @JsonCreator
     public EmoApiKey(@JsonProperty("id") String id, @JsonProperty("maskedKey") String maskedKey,
                      @JsonProperty("issued") Date issued) {
-        _id = checkNotNull(id, "id");
-        _maskedKey = checkNotNull(maskedKey, "maskedKey");
-        _issued = checkNotNull(issued, "issued");
+        _id = requireNonNull(id, "id");
+        _maskedKey = requireNonNull(maskedKey, "maskedKey");
+        _issued = requireNonNull(issued, "issued");
     }
 
     public String getId() {
@@ -71,17 +70,17 @@ public class EmoApiKey {
     }
 
     public EmoApiKey setRoles(Set<EmoRoleKey> roles) {
-        _roles = checkNotNull(roles, "roles");
+        _roles = requireNonNull(roles, "roles");
         return this;
     }
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(EmoApiKey.class)
-                .add("id", getId())
-                .add("owner", getOwner())
-                .add("description", getDescription())
-                .add("roles", getRoles())
-                .toString();
+        return "EmoApiKey{" +
+                "_id='" + _id + '\'' +
+                ", _owner='" + _owner + '\'' +
+                ", _description='" + _description + '\'' +
+                ", _roles=" + _roles +
+                '}';
     }
 }

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoRole.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoRole.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
-import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Role object for an Emo role.  Each role is uniquely identified by a {@link EmoRoleKey}.  Although it is useful
@@ -21,17 +22,17 @@ public class EmoRole {
     private final EmoRoleKey _id;
     private String _name;
     private String _description;
-    private Set<String> _permissions = ImmutableSet.of();
+    private Set<String> _permissions = Collections.emptySet();
 
     @JsonCreator
     private EmoRole(@JsonProperty("group") String group, @JsonProperty("id") String id) {
         this(new EmoRoleKey(
-                Objects.firstNonNull(group, EmoRoleKey.NO_GROUP),
-                checkNotNull(id, "id")));
+                Optional.ofNullable(group).orElse(EmoRoleKey.NO_GROUP),
+                requireNonNull(id, "id")));
     }
 
     public EmoRole(EmoRoleKey id) {
-        _id = checkNotNull(id, "id");
+        _id = requireNonNull(id, "id");
     }
 
     @JsonProperty("group")
@@ -76,19 +77,13 @@ public class EmoRole {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof EmoRole)) {
-            return false;
-        }
-
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         EmoRole emoRole = (EmoRole) o;
-
-        return _id.equals(emoRole.getId()) &&
-                Objects.equal(_name, emoRole.getName()) &&
-                Objects.equal(_description, emoRole.getDescription()) &&
-                _permissions.equals(emoRole.getPermissions());
+        return Objects.equals(_id, emoRole.getId()) &&
+                Objects.equals(_name, emoRole.getName()) &&
+                Objects.equals(_description, emoRole.getDescription()) &&
+                Objects.equals(_permissions, emoRole.getPermissions());
     }
 
     @Override
@@ -98,12 +93,11 @@ public class EmoRole {
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(getClass())
-                .add("id", getId())
-                .add("name", getName())
-                .add("description", getDescription())
-                .add("permissions", getPermissions())
-                .toString();
-
+        return "EmoRole{" +
+                "id=" + _id +
+                ", name='" + _name + '\'' +
+                ", description='" + _description + '\'' +
+                ", permissions=" + _permissions +
+                '}';
     }
 }

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoRoleExistsException.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoRoleExistsException.java
@@ -3,7 +3,8 @@ package com.bazaarvoice.emodb.uac.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+
+import java.util.Optional;
 
 /**
  * Exception thrown when attempting to create a role which already exists.
@@ -20,7 +21,7 @@ public class EmoRoleExistsException extends RuntimeException {
     @JsonCreator
     public EmoRoleExistsException(@JsonProperty("group") String group, @JsonProperty("id") String id) {
         super("Role exists");
-        _group = Objects.firstNonNull(group, EmoRoleKey.NO_GROUP);
+        _group = Optional.ofNullable(group).orElse(EmoRoleKey.NO_GROUP);
         _id = id;
     }
 

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoRoleKey.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoRoleKey.java
@@ -2,9 +2,11 @@ package com.bazaarvoice.emodb.uac.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Unique key for identifying a role.  Each key consists of a group and an ID.  It is possible for a role to belong to
@@ -25,8 +27,8 @@ public class EmoRoleKey {
 
     @JsonCreator
     public EmoRoleKey(@JsonProperty("group") String group, @JsonProperty("id") String id) {
-        _group = Objects.firstNonNull(group, NO_GROUP);
-        _id = checkNotNull(id, "id");
+        _group = Optional.ofNullable(group).orElse(NO_GROUP);
+        _id = requireNonNull(id, "id");
     }
 
     /**
@@ -60,7 +62,7 @@ public class EmoRoleKey {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_group, _id);
+        return Objects.hash(_group, _id);
     }
 
     public String toString() {

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoRoleNotFoundException.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/EmoRoleNotFoundException.java
@@ -3,7 +3,8 @@ package com.bazaarvoice.emodb.uac.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+
+import java.util.Optional;
 
 /**
  * Exception thrown when attempting to modify a role which does not exist.
@@ -20,7 +21,7 @@ public class EmoRoleNotFoundException extends RuntimeException {
     @JsonCreator
     public EmoRoleNotFoundException(@JsonProperty("group") String group, @JsonProperty("id") String id) {
         super("Role not found");
-        _group = Objects.firstNonNull(group, EmoRoleKey.NO_GROUP);
+        _group = Optional.ofNullable(group).orElse(EmoRoleKey.NO_GROUP);
         _id = id;
     }
 

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/MigrateEmoApiKeyRequest.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/MigrateEmoApiKeyRequest.java
@@ -2,9 +2,7 @@ package com.bazaarvoice.emodb.uac.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.base.Strings;
 
-import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Request object for migrating API keys.  In most cases only the single required attribute, "id", should be set.
@@ -23,7 +21,9 @@ public class MigrateEmoApiKeyRequest extends UserAccessControlRequest {
     }
 
     public MigrateEmoApiKeyRequest setId(String id) {
-        checkArgument(!Strings.isNullOrEmpty(id), "id");
+        if (id == null || id.isEmpty()) {
+            throw new IllegalArgumentException(("Id must not be null nor empty"));
+        }
         _id = id;
         return this;
     }

--- a/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/UserAccessControlRequest.java
+++ b/uac-api/src/main/java/com/bazaarvoice/emodb/uac/api/UserAccessControlRequest.java
@@ -1,17 +1,18 @@
 package com.bazaarvoice.emodb.uac.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Base class for all non-trivial calls to {@link UserAccessControl}.
  */
 abstract public class UserAccessControlRequest {
 
-    private Multimap<String, String> _customRequestParameters = ArrayListMultimap.create();
+    private Map<String, Collection<String>> _customRequestParameters = new HashMap<>();
 
     /**
      * Sets custom request parameters.  Custom parameters may include new features not yet officially supported or
@@ -19,11 +20,15 @@ abstract public class UserAccessControlRequest {
      * used by most clients.  Furthermore, adding additional parameters may cause the request to fail.
      */
     public void setCustomRequestParameter(String param, String... values) {
-        _customRequestParameters.putAll(param, Arrays.asList(values));
+        if (_customRequestParameters.get(param) == null) {
+            _customRequestParameters.put(param, Arrays.asList(values));
+        } else {
+            _customRequestParameters.get(param).addAll(Arrays.asList(values));
+        }
     }
 
     @JsonIgnore
-    public Multimap<String, String> getCustomRequestParameters() {
+    public Map<String, Collection<String>> getCustomRequestParameters() {
         return _customRequestParameters;
     }
 

--- a/uac-client/src/main/java/com/bazaarvoice/emodb/uac/client/UserAccessControlClient.java
+++ b/uac-client/src/main/java/com/bazaarvoice/emodb/uac/client/UserAccessControlClient.java
@@ -34,8 +34,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -251,8 +250,10 @@ public class UserAccessControlClient implements AuthUserAccessControl {
                     .build();
             EmoResource resource = _client.resource(uri);
 
-            for (Map.Entry<String, String> customQueryParam : request.getCustomRequestParameters().entries()) {
-                resource = resource.queryParam(customQueryParam.getKey(), customQueryParam.getValue());
+            for (Map.Entry<String, Collection<String>> customQueryParams : request.getCustomRequestParameters().entrySet()) {
+                for (String customQueryParamValue : Optional.ofNullable(customQueryParams.getValue()).orElse(Collections.emptySet())) {
+                    resource = resource.queryParam(customQueryParams.getKey(), customQueryParamValue);
+                }
             }
 
             return resource
@@ -307,8 +308,10 @@ public class UserAccessControlClient implements AuthUserAccessControl {
 
             EmoResource resource = _client.resource(uri);
 
-            for (Map.Entry<String, String> customQueryParam : request.getCustomRequestParameters().entries()) {
-                resource = resource.queryParam(customQueryParam.getKey(), customQueryParam.getValue());
+            for (Map.Entry<String, Collection<String>> customQueryParams : request.getCustomRequestParameters().entrySet()) {
+                for (String customQueryParamValue : Optional.of(customQueryParams.getValue()).orElse(Collections.emptySet())) {
+                    resource = resource.queryParam(customQueryParams.getKey(), customQueryParamValue);
+                }
             }
 
             CreateEmoApiKeyResponse response = resource

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/DefaultRoles.java
@@ -40,7 +40,7 @@ public enum DefaultRoles {
             Permissions.createSorTable(NON_SYSTEM_TABLE),
             Permissions.setSorTableAttributes(NON_SYSTEM_TABLE)),
 
-    // sor_standard with excluding pii tables/placements.
+    // sor_standard with anyCharExcept pii tables/placements.
     // Pii tables contain personally identifiable information, so in a way they are special compared to the rest of the sor tables.
     // this role can be used where we would like to give standard permissions to all sor tables except the pii & system tables.
     sor_standard_without_pii (

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/Permissions.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/Permissions.java
@@ -77,7 +77,7 @@ public class Permissions {
                             Conditions.intrinsic(Intrinsic.PLACEMENT, Conditions.like("*:sys")))));
 
     /**
-     * NON_SYSTEM_TABLE along with excluding PII table/placements.
+     * NON_SYSTEM_TABLE along with anyCharExcept PII table/placements.
      */
     public final static ConditionResource NON_SYSTEM_NON_PII_TABLE = new ConditionResource(
             Conditions.not(

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
@@ -24,7 +24,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.PeekingIterator;
-import com.google.common.io.InputSupplier;
 import com.sun.jersey.api.client.ClientResponse;
 import io.dropwizard.jersey.params.AbstractParam;
 import io.dropwizard.jersey.params.LongParam;
@@ -67,6 +66,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.StreamSupport;
 
@@ -459,16 +459,13 @@ public class BlobStoreResource1 {
      * Returns an InputSupplier that throws an exception if the caller attempts to consume the input stream
      * multiple times.
      */
-    private InputSupplier<InputStream> onceOnlySupplier(final InputStream in) {
+    private Supplier<InputStream> onceOnlySupplier(final InputStream in) {
         final AtomicBoolean once = new AtomicBoolean();
-        return new InputSupplier<InputStream>() {
-            @Override
-            public InputStream getInput() throws IOException {
-                if (!once.compareAndSet(false, true)) {
-                    throw new IllegalStateException("Input stream may be consumed only once per BlobStore call.");
-                }
-                return in;
+        return () -> {
+            if (!once.compareAndSet(false, true)) {
+                throw new IllegalStateException("Input stream may be consumed only once per BlobStore call.");
             }
+            return in;
         };
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/uac/LocalSubjectUserAccessControl.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/uac/LocalSubjectUserAccessControl.java
@@ -49,10 +49,7 @@ import org.apache.shiro.authz.permission.InvalidPermissionStringException;
 import org.apache.shiro.authz.permission.PermissionResolver;
 
 import java.security.SecureRandom;
-import java.util.Iterator;
-import java.util.Random;
-import java.util.Set;
-import java.util.Spliterators;
+import java.util.*;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -312,7 +309,14 @@ public class LocalSubjectUserAccessControl implements SubjectUserAccessControl {
     @Override
     public CreateEmoApiKeyResponse createApiKey(Subject subject, CreateEmoApiKeyRequest request) {
         verifyPermission(subject, Permissions.createApiKey());
-        String exactKey = request.getCustomRequestParameters().get("key").stream().findFirst().orElse(null);
+        String exactKey = null;
+        Collection<String> keyList = request.getCustomRequestParameters().get("key");
+        if (keyList != null) {
+            Iterator<String> keyIterator = keyList.iterator();
+            if (keyIterator.hasNext()) {
+                exactKey = keyIterator.next();
+            }
+        }
 
         if (exactKey != null) {
             // Typically the system creates a random API key for the caller, so the caller has no a-priori knowledge of what
@@ -473,7 +477,14 @@ public class LocalSubjectUserAccessControl implements SubjectUserAccessControl {
         verifyPermission(subject, Permissions.updateApiKey());
 
         String id = request.getId();
-        String key = request.getCustomRequestParameters().get("key").stream().findFirst().orElse(null);
+        String key = null;
+        Collection<String> keyList = request.getCustomRequestParameters().get("key");
+        if (keyList != null) {
+            Iterator<String> keyIterator = keyList.iterator();
+            if (keyIterator.hasNext()) {
+                key = keyIterator.next();
+            }
+        }
 
         if (key != null) {
             // As with create, verify the caller has permission to migrate to an exact key and that the key is valid

--- a/web/src/main/java/com/bazaarvoice/emodb/web/util/EmoServiceObjectMapperFactory.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/util/EmoServiceObjectMapperFactory.java
@@ -4,6 +4,7 @@ import com.bazaarvoice.emodb.common.json.CustomJsonObjectMapperFactory;
 import com.bazaarvoice.emodb.common.json.ISO8601DateFormat;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import io.dropwizard.jackson.AnnotationSensitivePropertyNamingStrategy;
 import io.dropwizard.jackson.DiscoverableSubtypeResolver;
 import io.dropwizard.jackson.LogbackModule;
@@ -26,6 +27,7 @@ public class EmoServiceObjectMapperFactory {
 
     public static ObjectMapper configure(ObjectMapper mapper) {
         return CustomJsonObjectMapperFactory.configure(mapper)
+                .registerModule(new GuavaModule())
                 .registerModule(new LogbackModule())
                 .setDateFormat(new ISO8601DateFormat())
                 .setPropertyNamingStrategy(new AnnotationSensitivePropertyNamingStrategy())


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?
Currently the emodb client libraries are extremely hard to use because they wrap in outdated version of many common libraries, such as guava, that lead to dependency conflicts for the user. This PR is the first step of many to remove guava from our client libraries.

This PR removes guava only from client modules that directly depend on guava. If they wrap in guava indirectly, such as through Dropwizard, then they are not addressed here and will be addressed later.

## How to Test and Verify

1. Check out this PR
2. Review the changes from each commit individually
3. For each commit, run `mvn dependency:tree -Dverbose` inside of each affected module and confirm that it no longer contains guava in its dependency tree.

## Risk

### Level 

`Medium`

### Required Testing

`Regression` and `Manual`

### Risk Summary

There are no intended functionality changes from this PR, so the only place for error is in edge cases introduced in logic meant to replicate guava conveniences.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
