### PR TITLE
Remove migrator overrun check

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/LocalMigratorMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/LocalMigratorMonitor.java
@@ -43,9 +43,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class LocalMigratorMonitor extends AbstractService {
 
-    private static final Duration OVERRUN_MIGRATION_TIME = Duration.ofDays(1);
-
-
     private final Logger _log = LoggerFactory.getLogger(LocalMigratorMonitor.class);
 
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Currently the delta migrator has a built in overrun check that cancels any migration after it has been running for longer than a day. In testing we have seen that it is not uncommon at all for a migration to take longer than a day, and therefore this cancellation must be removed.

## How to Test and Verify

Testing this is extremely difficult without starting a very large migration and making sure it continues to run after a day. A code review alone should be enough to verify that this functionality has been removed.

Further, when perf testing this change, a migration of one of our larger placements will confirm that this works.

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The real risk here is what could happen if we leave the existing functionality in place.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
