### PR TITLE
Fix stash time parser

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScheduledDailyScanUpload.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/scheduling/ScheduledDailyScanUpload.java
@@ -2,10 +2,7 @@ package com.bazaarvoice.emodb.web.scanner.scheduling;
 
 import com.bazaarvoice.emodb.web.scanner.ScanDestination;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalTime;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -14,7 +11,7 @@ import java.util.List;
  */
 public class ScheduledDailyScanUpload {
 
-    private static final DateTimeFormatter TIME_OF_DAY_FORMAT = DateTimeFormatter.ofPattern("HH:mmX").withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter TIME_OF_DAY_FORMAT = DateTimeFormatter.ofPattern("HH:mmXXX").withZone(ZoneOffset.UTC);
 
     private final String _id;
     private final String _timeOfDay;
@@ -94,10 +91,10 @@ public class ScheduledDailyScanUpload {
      * Gets the first execution time for the given scan and upload which is at or after "now".
      */
     public Instant getNextExecutionTimeAfter(Instant now) {
-        LocalTime timeOfDay = LocalTime.from(TIME_OF_DAY_FORMAT.parse(getTimeOfDay()));
+        OffsetTime timeOfDay = OffsetTime.from(TIME_OF_DAY_FORMAT.parse(getTimeOfDay()));
 
         // The time of the next run is based on the time past midnight UTC relative to the current time
-        Instant nextExecTime = now.atZone(ZoneOffset.UTC).with(timeOfDay).toInstant();
+        Instant nextExecTime = now.atOffset(ZoneOffset.UTC).with(timeOfDay).toInstant();
 
         // If the first execution would have been for earlier today move to the next execution.
         while (nextExecTime.isBefore(now)) {


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

When we replaced joda-time with java time, we broke the the date parser that reads in the time in which to run stash times. I have replaced the `X` with `XXX` in accordance with the following:

```Offset X and x: This formats the offset based on the number of pattern letters. One letter outputs just the hour, such as '+01', unless the minute is non-zero in which case the minute is also output, such as '+0130'. Two letters outputs the hour and minute, without a colon, such as '+0130'. Three letters outputs the hour and minute, with a colon, such as '+01:30'. Four letters outputs the hour and minute and optional second, without a colon, such as '+013015'. Five letters outputs the hour and minute and optional second, with a colon, such as '+01:30:15'. Six or more letters throws IllegalArgumentException. Pattern letter 'X' (upper case) will output 'Z' when the offset to be output would be zero, whereas pattern letter 'x' (lower case) will output '+00', '+0000', or '+00:00'.```

Additionally, I have replaced `LocalTime` with `OffsetTime` because local time is not compatible with an offset, and therefore ignores the one provided and gives the incorrect time.

## How to Test and Verify

It is possible to test this locally by running stash, but it is more than sufficient to review my changes and the unit test I wrote confirming the results.

## Risk

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

There is very little risk in this change, and stash is currently not operational without it. However, this is a good time to point out that there is no guarantee that stash will work properly with this alone, and there are other known remaining joda time issues still unresolved.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
