### PR TITLE
Upgrade aws-sdk to fix S3 joda bug

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,6 +39,7 @@
         <slf4j.version>1.7.4</slf4j.version>
         <commons-io.version>2.1</commons-io.version>
         <aws-sdk.version>1.10.1</aws-sdk.version>
+        <jodatime-version>2.8.2</jodatime-version>
         <jersey.version>1.18.1</jersey.version>
         <jacoco.version>0.7.2.201409121644</jacoco.version>
         <cassandra.driver.version>3.1.1</cassandra.driver.version>
@@ -205,6 +206,11 @@
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>1.1.0.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>${jodatime-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.cassandra</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -38,7 +38,7 @@
         <rison.version>2.1.1</rison.version>
         <slf4j.version>1.7.4</slf4j.version>
         <commons-io.version>2.1</commons-io.version>
-        <aws-sdk.version>1.9.34</aws-sdk.version>
+        <aws-sdk.version>1.10.1</aws-sdk.version>
         <jersey.version>1.18.1</jersey.version>
         <jacoco.version>0.7.2.201409121644</jacoco.version>
         <cassandra.driver.version>3.1.1</cassandra.driver.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -158,6 +158,16 @@
             <artifactId>guice-assistedinject</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
         </dependency>
@@ -184,16 +194,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -228,6 +228,10 @@
             </exclusions>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Although Emodb recently stops relying on joda-time as a direct dependency, joda-time still exists as a transitive dependency. The version of joda used by emo used to be 2.8.2, but is now currently 2.3 as that is what dropwizard pulls in, and dropwizard is the first dependency listed in the web module to pull in joda. This has exposed us to [this aws-sdk bug](https://github.com/aws/aws-sdk-java/issues/444), which was fixed in version 1.10.1 of the aws-sdk. This bug prevents traditional stash from writing to S3.

In this PR i updated our aws-sdk version to 1.10.1 to resolve this issue, and additionally adds joda-time 2.8.2 as a direct dependency of the web module.

## How to Test and Verify

1. Build using `mvn clean install`
2. Run mvn dependency:tree -Dverbose | grep joda
3. Confirm through the output of the above command that joda 2.8.2 is now the version being compiled.

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The main risk here is that the upgrade of the aws-sdk negatively affects a different, unidentified, non-stash process of Emo.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
