### PR TITLE
Compaction control getAll API now returns with correct keys

### DIFF
--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/CompactionControlSource.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/CompactionControlSource.java
@@ -16,7 +16,7 @@ public interface CompactionControlSource {
 
     StashRunTimeInfo getStashTime(String id, String dataCenter);
 
-    Map<String, StashRunTimeInfo> getAllStashTimes();
+    Map<StashTimeKey, StashRunTimeInfo> getAllStashTimes();
 
-    Map<String, StashRunTimeInfo> getStashTimesForPlacement(String placement);
+    Map<StashTimeKey, StashRunTimeInfo> getStashTimesForPlacement(String placement);
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/StashTimeKey.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/StashTimeKey.java
@@ -1,0 +1,58 @@
+package com.bazaarvoice.emodb.sor.api;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class StashTimeKey {
+
+    public static final String ZK_STRING_DELIMITER = "@";
+
+    private final String _id;
+    private final String _datacenter;
+
+    public StashTimeKey(String id, String datacenter) {
+        _id = checkNotNull(id, "id");
+        _datacenter = checkNotNull(datacenter, "datacenter");
+    }
+
+    public static StashTimeKey of(String id, String datacenter) {
+        return new StashTimeKey(id, datacenter);
+    }
+
+    public String getId() {
+        return _id;
+    }
+
+    public String getDatacenter() {
+        return _datacenter;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof StashTimeKey)) {
+            return false;
+        }
+        StashTimeKey stashTimeInfoKey = (StashTimeKey) o;
+        return _id.equals(stashTimeInfoKey._id) && _datacenter.equals(stashTimeInfoKey._datacenter);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * _id.hashCode() + _datacenter.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return _id + "@" + _datacenter;
+    }
+
+    public static StashTimeKey fromString(String stashTimeKeyString) {
+        String[] stashTimeKeyStringSplits = stashTimeKeyString.split(ZK_STRING_DELIMITER);
+        if (stashTimeKeyStringSplits.length != 2) {
+            throw new IllegalStateException("key string can only contain one '@' character. Pattern is ID@datacenter");
+        }
+        return StashTimeKey.of(stashTimeKeyStringSplits[0], stashTimeKeyStringSplits[1]);
+    }
+}

--- a/sor-client/src/main/java/com/bazaarvoice/emodb/sor/client/CompactionControlClient.java
+++ b/sor-client/src/main/java/com/bazaarvoice/emodb/sor/client/CompactionControlClient.java
@@ -4,6 +4,7 @@ import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
 import com.bazaarvoice.emodb.client.EmoClient;
 import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.bazaarvoice.emodb.sor.api.StashTimeKey;
 import com.google.common.base.Preconditions;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.UniformInterfaceException;
@@ -93,7 +94,7 @@ public class CompactionControlClient implements CompactionControlSource {
     }
 
     @Override
-    public Map<String, StashRunTimeInfo> getAllStashTimes() {
+    public Map<StashTimeKey, StashRunTimeInfo> getAllStashTimes() {
         try {
             URI uri = _compactionControlSource.clone()
                     .segment("_compcontrol", "stash-time")
@@ -108,7 +109,7 @@ public class CompactionControlClient implements CompactionControlSource {
     }
 
     @Override
-    public Map<String, StashRunTimeInfo> getStashTimesForPlacement(String placement) {
+    public Map<StashTimeKey, StashRunTimeInfo> getStashTimesForPlacement(String placement) {
         checkNotNull(placement, "placement");
 
         try {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
@@ -17,6 +17,7 @@ import com.bazaarvoice.emodb.sor.api.Names;
 import com.bazaarvoice.emodb.sor.api.ReadConsistency;
 import com.bazaarvoice.emodb.sor.api.StashNotAvailableException;
 import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.bazaarvoice.emodb.sor.api.StashTimeKey;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.UnknownPlacementException;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
@@ -385,7 +386,7 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
     private Expanded expand(final Record record, boolean ignoreRecent, final ReadConsistency consistency) {
         long fullConsistencyTimeStamp = _dataWriterDao.getFullConsistencyTimestamp(record.getKey().getTable());
         long rawConsistencyTimeStamp = _dataWriterDao.getRawConsistencyTimestamp(record.getKey().getTable());
-        Map<String, StashRunTimeInfo> stashTimeInfoMap = _compactionControlSource.getStashTimesForPlacement(record.getKey().getTable().getAvailability().getPlacement());
+        Map<StashTimeKey, StashRunTimeInfo> stashTimeInfoMap = _compactionControlSource.getStashTimesForPlacement(record.getKey().getTable().getAvailability().getPlacement());
         // we will consider the earliest timestamp found as our compactionControlTimestamp.
         // we are also filtering out any expired timestamps. (CompactionControlMonitor should do this for us, but for now it's running every hour. So, just to fill that gap, we are filtering here.)
         // If no timestamps are found, then taking minimum value because we want all the deltas after the compactionControlTimestamp to be deleted as per the compaction rules as usual.

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/DelegateCompactionControlSource.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/DelegateCompactionControlSource.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.web.compactioncontrol;
 
 import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.bazaarvoice.emodb.sor.api.StashTimeKey;
 import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
@@ -68,7 +69,7 @@ public class DelegateCompactionControlSource implements CompactionControlSource 
     }
 
     @Override
-    public Map<String, StashRunTimeInfo> getAllStashTimes() {
+    public Map<StashTimeKey, StashRunTimeInfo> getAllStashTimes() {
         try {
             return _localCompactionControl.getAllStashTimes();
         } catch (Exception e) {
@@ -78,7 +79,7 @@ public class DelegateCompactionControlSource implements CompactionControlSource 
     }
 
     @Override
-    public Map<String, StashRunTimeInfo> getStashTimesForPlacement(String placement) {
+    public Map<StashTimeKey, StashRunTimeInfo> getStashTimesForPlacement(String placement) {
         try {
             return _localCompactionControl.getStashTimesForPlacement(placement);
         } catch (Exception e) {

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/compactioncontrol/CompactionControlResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/compactioncontrol/CompactionControlResource1.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.web.resources.compactioncontrol;
 
 import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.bazaarvoice.emodb.sor.api.StashTimeKey;
 import com.bazaarvoice.emodb.web.resources.SuccessResponse;
 import com.google.common.base.Strings;
 import io.dropwizard.jersey.params.LongParam;
@@ -75,7 +76,7 @@ public class CompactionControlResource1 {
     @GET
     @Path ("/stash-time")
     @RequiresPermissions ("system|comp_control")
-    public Map<String, StashRunTimeInfo> getStashTimesForPlacement(@QueryParam ("placement") String placement) {
+    public Map<StashTimeKey, StashRunTimeInfo> getStashTimesForPlacement(@QueryParam ("placement") String placement) {
         return Strings.isNullOrEmpty(placement) ? _compactionControlSource.getAllStashTimes() : _compactionControlSource.getStashTimesForPlacement(placement);
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/rangescan/LocalRangeScanUploader.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/rangescan/LocalRangeScanUploader.java
@@ -7,6 +7,7 @@ import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.Intrinsic;
 import com.bazaarvoice.emodb.sor.api.ReadConsistency;
 import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
+import com.bazaarvoice.emodb.sor.api.StashTimeKey;
 import com.bazaarvoice.emodb.sor.compactioncontrol.DelegateCompactionControl;
 import com.bazaarvoice.emodb.sor.core.DataTools;
 import com.bazaarvoice.emodb.sor.db.MultiTableScanResult;
@@ -263,7 +264,7 @@ public class LocalRangeScanUploader implements RangeScanUploader, Managed {
             Batch batch = new Batch(context, partCountForFirstShard);
 
             // check if there is a stash cut off time.
-            Map<String, StashRunTimeInfo> stashTimeInfoMap = _compactionControlSource.getStashTimesForPlacement(placement);
+            Map<StashTimeKey, StashRunTimeInfo> stashTimeInfoMap = _compactionControlSource.getStashTimesForPlacement(placement);
             Instant cutoffTime = stashTimeInfoMap.values().stream()
                     .map(StashRunTimeInfo::getTimestamp)
                     .min(Long::compareTo)

--- a/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/ScanOperationsTimeUpdateTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/ScanOperationsTimeUpdateTest.java
@@ -7,6 +7,7 @@ import com.bazaarvoice.emodb.plugin.stash.StashStateListener;
 import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.Intrinsic;
 import com.bazaarvoice.emodb.sor.api.ReadConsistency;
+import com.bazaarvoice.emodb.sor.api.StashTimeKey;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
 import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSource;
 import com.bazaarvoice.emodb.sor.core.DataTools;
@@ -76,12 +77,12 @@ public class ScanOperationsTimeUpdateTest {
         // sleeping for 1 sec just to be certain that the thread was executed in scanAndUpload process.
         Thread.sleep(Duration.ofSeconds(1).toMillis());
         Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 1);
-        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("test1"), true);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey(StashTimeKey.of("test1", "us-east")), true);
 
         // cancel the scan
         scanUploader.cancel("test1");
         Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 0);
-        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("test1"), false);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey(StashTimeKey.of("test1", "us-east")), false);
     }
 
     @Test
@@ -113,7 +114,7 @@ public class ScanOperationsTimeUpdateTest {
         // sleeping for 1 sec just to be certain that the thread was executed in scanAndUpload process.
         Thread.sleep(Duration.ofSeconds(1).toMillis());
         Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 0);
-        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey("test1"), false);
+        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey(StashTimeKey.of("test1", "us-east")), false);
     }
 
     /***


### PR DESCRIPTION

In bazaar the compaction control metrics were showing an extremely long lived compaction control record.  It had expired months ago but wasn't being reaped automatically.  The following was in the logs every 5 minutes:
```
WARN  [2018-08-17 06:09:52,238] com.bazaarvoice.emodb.web.compactioncontrol.CompactionControlMonitor: Deleting the stash time entry for id: daily-2018-05-26-00-00-00-eu-west-1-prod
WARN  [2018-08-17 06:14:52,242] com.bazaarvoice.emodb.web.compactioncontrol.CompactionControlMonitor: Deleting the stash time entry for id: daily-2018-05-26-00-00-00-eu-west-1-prod
WARN  [2018-08-17 06:19:52,245] com.bazaarvoice.emodb.web.compactioncontrol.CompactionControlMonitor: Deleting the stash time entry for id: daily-2018-05-26-00-00-00-eu-west-1-prod
```
The issue is that the entry's ID is actually "daily-2018-05-26-00-00-00", but the API is returning the full name as it appears in ZooKeeper with the data center suffix. The keys in the map returned by CompactionControlSource.getAllStashTimes() should contain only the actual compaction control ID and not the data center suffix. As a result this record was never deleted even though it had long ago expired.
