### PR TITLE
Fix delta migrator concurrency issue

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
@@ -267,7 +267,7 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
         Session session = placement.getKeyspace().getCqlSession();
         BatchStatement statement = new BatchStatement(BatchStatement.Type.LOGGED);
         AtomicReference<Throwable> error = new AtomicReference<>();
-        Phaser phaser = new Phaser();
+        Phaser phaser = new Phaser(1);
         ByteBuffer lastRowKey = null;
         int currentStatementSize = 0;
         FutureCallback<ResultSet> callback = new FutureCallback<ResultSet>() {


### PR DESCRIPTION
## Github Issue #

`None

## What Are We Doing Here?

Current the delta migrator uses a `java.util.concurrent.Phaser` in order ensure that the `writeRows` function in the `CqlDataWriterDAO` does not exit until after all asynchronous write requests to Cassandra have completed successfully. The current implementation is flawed in that the call to `arriveAndAwaitAdvance()` will take the advance before the final registration to the phaser has arrived. This is because the call to `arriveAndAwaitAdvance` arrives at the phaser itself and takes the remaining outstanding registration. This can be fixed by giving the phaser one initial registered party.
 
## How to Test and Verify

1. Check out this PR
2. Build emo and run `./start-migrator-role`
3. Write some data to ugc_global:ugc
4. Run `curl -XPOST localhost:8082/migrator/1/migrator/ugc_global:ugc`
5. Wait for the migration to complete
6. Run a count of both `ugc_delta` and `ugc_delta_v2` using cqlsh and ensure that they are the same.

Note: If you write deltas larger than 64 kb, they end up as multiple rows in cassandra, which will make the count of `ugc_delta_v2` higher than `ugc_delta`


## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The migrator is not running yet, so there is little to no risk.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
