### PR TITLE
Change event store manifest reads to use LOCAL_QUORUM

### DIFF
--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -306,7 +306,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
         boolean firstSlab = true;
 
         Iterable<Column<ByteBuffer>> manifestColumns = executePaginated(
-                _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_LOCAL_ONE)
+                _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_LOCAL_QUORUM)
                         .getKey(channel)
                         .withColumnRange(range.build())
                         .autoPaginate(true));


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

In AstyanaxEventReaderDAO there is a method `readNewer()` which is used whenever the databus is polled.  At a high level this does two things:

1. Scan the "manifest" column for the list of slabs in the event queue.
2. For each slab in the manifest scan the columns for the queue content.

Currently the query for the first part uses `LOCAL_ONE` consistency:

```
Iterable<Column<ByteBuffer>> manifestColumns = executePaginated(
        _keyspace.prepareQuery(ColumnFamilies.MANIFEST, ConsistencyLevel.CL_LOCAL_ONE)
                .getKey(channel)
                .withColumnRange(range.build())
                .autoPaginate(true));
```
In aggregate this is likely safe since polling happens frequently and queries to the manifest column should eventually be directed to each server in the replication facter, so even an slab written to only 2 servers' manifest should still be eventually returned. However, "should" is a far cry from "definitely". This line should be changed to use `CL_LOCAL_QUORUM`. The only possible negative would be if polling/fanout performance suffers due to the slower manifest read.

## How to Test and Verify

1. Check out this PR
2. Observe that the manifest are now read with `LOCAL_QUORUM`
3. Run Gatekeeper and observe that all is running normally

## Risk

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

The main risk here is performance degradation to the databus due to slower responses. If we do observe a performance degradation, we can make the event store read from `CL_LOCAL_QUORUM` at least once every *n* seconds to ensure every manifest slab is read in a timely manner, but for interim reads use `CL_LOCAL_ONE`. However, we should avoid something like this or similar unless absolutely necessary. 

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
