### PR TITLE
Revert "Added caching of oldest slab to readAll() queries (#193)"

### DIFF
--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventWriterDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventWriterDAO.java
@@ -153,7 +153,7 @@ public class AstyanaxEventWriterDAO implements EventWriterDAO {
 
             void run() {
                 _manifestRow = update.updateRow(ColumnFamilies.MANIFEST, channel);
-                _eventReaderDAO.readAll(channel, this, this);
+                _eventReaderDAO.readAll(channel, this, this, ConsistencyLevel.CL_LOCAL_QUORUM);
             }
 
             // SlabFilter interface, called before scanning events in a slab.

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/OneTimeIterable.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/OneTimeIterable.java
@@ -1,0 +1,29 @@
+package com.bazaarvoice.emodb.event.db.astyanax;
+
+import java.util.Iterator;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Wraps an {@code Iterator} as an {@code Iterable} that can only be used once.
+ */
+class OneTimeIterable<T> implements Iterable<T> {
+    private final Iterator<T> _iterator;
+    private boolean _consumed;
+
+    static <T> Iterable<T> wrap(Iterator<T> iterator) {
+        return new OneTimeIterable<>(iterator);
+    }
+
+    private OneTimeIterable(Iterator<T> iterator) {
+        _iterator = checkNotNull(iterator, "iterator");
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        checkState(!_consumed);
+        _consumed = true;
+        return _iterator;
+    }
+}


### PR DESCRIPTION
This reverts commit 5ffa3ab945ee0ecffee042358677776e024b8b27.

There was a spike of timeouts after deploying EmoDB 5.7.0 to a test environment.  To help diagnose root cause this update is being removed, whether temporarily or permanently is TBD.
