### PR TITLE
Added configurable API key rate limiting for data store updates

### DIFF
--- a/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/PrincipalWithRoles.java
+++ b/auth/auth-core/src/main/java/com/bazaarvoice/emodb/auth/shiro/PrincipalWithRoles.java
@@ -2,6 +2,7 @@ package com.bazaarvoice.emodb.auth.shiro;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import org.apache.http.auth.BasicUserPrincipal;
 import org.eclipse.jetty.security.DefaultUserIdentity;
 import org.eclipse.jetty.server.UserIdentity;
 
@@ -49,7 +50,7 @@ public class PrincipalWithRoles implements Principal {
 
             _userIdentity = new DefaultUserIdentity(
                     new javax.security.auth.Subject(true, ImmutableSet.of(this), ImmutableSet.of(), ImmutableSet.of()),
-                    this, roles);
+                    new BasicUserPrincipal(getId()), roles);
         }
         return _userIdentity;
     }

--- a/quality/integration/src/test/java/test/integration/sor/CompactionControlJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/CompactionControlJerseyTest.java
@@ -17,6 +17,7 @@ import com.bazaarvoice.emodb.test.ResourceTest;
 import com.bazaarvoice.emodb.web.auth.DefaultRoles;
 import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
 import com.bazaarvoice.emodb.web.resources.sor.DataStoreResource1;
+import com.bazaarvoice.emodb.web.throttling.UnlimitedDataStoreUpdateThrottler;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.sun.jersey.api.client.ClientResponse;
@@ -42,8 +43,9 @@ public class CompactionControlJerseyTest extends ResourceTest {
     private CompactionControlSource _compactionControlSourceServer = mock(CompactionControlSource.class);
 
     @Rule
-    public ResourceTestRule _resourceTestRule = setupReplicationResourceTestRule(ImmutableList.<Object>of(new DataStoreResource1(_dataStoreServer, mock(DataStoreAsync.class),
-                    _compactionControlSourceServer)));
+    public ResourceTestRule _resourceTestRule = setupReplicationResourceTestRule(ImmutableList.<Object>of(
+            new DataStoreResource1(_dataStoreServer, mock(DataStoreAsync.class), _compactionControlSourceServer,
+                    new UnlimitedDataStoreUpdateThrottler())));
 
     protected static ResourceTestRule setupReplicationResourceTestRule(List<Object> resourceList) {
         InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();

--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -47,6 +47,7 @@ import com.bazaarvoice.emodb.test.ResourceTest;
 import com.bazaarvoice.emodb.web.auth.DefaultRoles;
 import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
 import com.bazaarvoice.emodb.web.resources.sor.DataStoreResource1;
+import com.bazaarvoice.emodb.web.throttling.UnlimitedDataStoreUpdateThrottler;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
@@ -143,7 +144,9 @@ public class DataStoreJerseyTest extends ResourceTest {
         createRole(roleManager, null, "standard", DefaultRoles.standard.getPermissions());
         createRole(roleManager, null, "update-with-events", ImmutableSet.of("sor|update|*"));
 
-        return setupResourceTestRule(Collections.<Object>singletonList(new DataStoreResource1(_server, mock(DataStoreAsync.class), new InMemoryCompactionControlSource())), authIdentityManager, permissionManager);
+        return setupResourceTestRule(Collections.<Object>singletonList(
+                new DataStoreResource1(_server, mock(DataStoreAsync.class), new InMemoryCompactionControlSource(), new UnlimitedDataStoreUpdateThrottler())),
+                authIdentityManager, permissionManager);
     }
 
     @After

--- a/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/AdHocThrottleTest.java
@@ -26,6 +26,7 @@ import com.bazaarvoice.emodb.web.throttling.AdHocThrottleManager;
 import com.bazaarvoice.emodb.web.throttling.ConcurrentRequestRegulator;
 import com.bazaarvoice.emodb.web.throttling.ConcurrentRequestRegulatorSupplier;
 import com.bazaarvoice.emodb.web.throttling.ConcurrentRequestsThrottlingFilter;
+import com.bazaarvoice.emodb.web.throttling.UnlimitedDataStoreUpdateThrottler;
 import com.bazaarvoice.emodb.web.throttling.ZkAdHocThrottleSerializer;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Charsets;
@@ -111,7 +112,9 @@ public class AdHocThrottleTest extends ResourceTest {
         createRole(roleManager, null, "all-sor-role", ImmutableSet.of("sor|*|*"));
 
         return setupResourceTestRule(
-                Collections.<Object>singletonList(new DataStoreResource1(_dataStore, new DefaultDataStoreAsync(_dataStore, mock(JobService.class), mock(JobHandlerRegistry.class)), new InMemoryCompactionControlSource())),
+                Collections.<Object>singletonList(new DataStoreResource1(
+                        _dataStore, new DefaultDataStoreAsync(_dataStore, mock(JobService.class), mock(JobHandlerRegistry.class)),
+                        new InMemoryCompactionControlSource(), new UnlimitedDataStoreUpdateThrottler())),
                 Collections.<Object>singletonList(new ConcurrentRequestsThrottlingFilter(_deferringRegulatorSupplier)),
                 authIdentityManager, permissionManager);
     }

--- a/quality/integration/src/test/java/test/integration/throttle/DataStoreUpdateThrottleTest.java
+++ b/quality/integration/src/test/java/test/integration/throttle/DataStoreUpdateThrottleTest.java
@@ -1,0 +1,336 @@
+package test.integration.throttle;
+
+import com.bazaarvoice.emodb.auth.apikey.ApiKey;
+import com.bazaarvoice.emodb.auth.apikey.ApiKeyModification;
+import com.bazaarvoice.emodb.auth.identity.InMemoryAuthIdentityManager;
+import com.bazaarvoice.emodb.auth.permissions.InMemoryPermissionManager;
+import com.bazaarvoice.emodb.auth.role.InMemoryRoleManager;
+import com.bazaarvoice.emodb.blob.api.BlobStore;
+import com.bazaarvoice.emodb.common.jersey.dropwizard.JerseyEmoClient;
+import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.common.zookeeper.store.ZkMapStore;
+import com.bazaarvoice.emodb.job.api.JobHandlerRegistry;
+import com.bazaarvoice.emodb.job.api.JobService;
+import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.Update;
+import com.bazaarvoice.emodb.sor.client.DataStoreAuthenticator;
+import com.bazaarvoice.emodb.sor.client.DataStoreClient;
+import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSource;
+import com.bazaarvoice.emodb.sor.core.DefaultDataStoreAsync;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.bazaarvoice.emodb.test.ResourceTest;
+import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
+import com.bazaarvoice.emodb.web.resources.sor.DataStoreResource1;
+import com.bazaarvoice.emodb.web.throttling.DataStoreUpdateThrottle;
+import com.bazaarvoice.emodb.web.throttling.DataStoreUpdateThrottleManager;
+import com.bazaarvoice.emodb.web.throttling.DataStoreUpdateThrottler;
+import com.bazaarvoice.emodb.web.throttling.ZkDataStoreUpdateThrottleSerializer;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryNTimes;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class DataStoreUpdateThrottleTest extends ResourceTest {
+
+    private final static String API_KEY_LIMITED = "apikeylimited";
+    private final static String API_KEY_UNLIMITED = "apikeyunlimited";
+
+    private static TestingServer _testingServer;
+    private static CuratorFramework _rootCurator;
+
+    private final DataStore _dataStore = mock(DataStore.class);
+    private String _limitedId;
+    private String _unlimitedId;
+    private CuratorFramework _curator;
+    private ZkMapStore<DataStoreUpdateThrottle> _mapStore;
+    private DataStoreUpdateThrottleManager _throttleManager;
+    private String _zkNamespace;
+    private Instant _now;
+    private volatile RateLimiterFactory _rateLimiterFactory;
+
+    @Rule
+    public ResourceTestRule _resourceTestRule = setupDataStoreResourceTestRule();
+
+    private ResourceTestRule setupDataStoreResourceTestRule() {
+        InMemoryAuthIdentityManager<ApiKey> authIdentityManager = new InMemoryAuthIdentityManager<>();
+        _limitedId = authIdentityManager.createIdentity(API_KEY_LIMITED, new ApiKeyModification().addRoles("all-sor-role"));
+        _unlimitedId = authIdentityManager.createIdentity(API_KEY_UNLIMITED, new ApiKeyModification().addRoles("all-sor-role"));
+        EmoPermissionResolver permissionResolver = new EmoPermissionResolver(_dataStore, mock(BlobStore.class));
+        InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
+        InMemoryRoleManager roleManager = new InMemoryRoleManager(permissionManager);
+
+        createRole(roleManager, null, "all-sor-role", ImmutableSet.of("sor|*|*"));
+
+        // Since a unique throttler will be created for each test construct the resource with a throttle which delegates
+        // the the test-specific instance.
+
+        DataStoreUpdateThrottler throttler = id -> _throttleManager.beforeUpdate(id);
+
+        return setupResourceTestRule(
+                Collections.<Object>singletonList(new DataStoreResource1(
+                        _dataStore, new DefaultDataStoreAsync(_dataStore, mock(JobService.class), mock(JobHandlerRegistry.class)),
+                        new InMemoryCompactionControlSource(), throttler)),
+                ImmutableList.of(),
+                authIdentityManager, permissionManager);
+    }
+
+    @BeforeClass
+    public static void startZookeeper() throws Exception {
+        _testingServer = new TestingServer();
+        _rootCurator = CuratorFrameworkFactory.builder()
+                .connectString(_testingServer.getConnectString())
+                .retryPolicy(new RetryNTimes(3, 100))
+                .threadFactory(new ThreadFactoryBuilder().setNameFormat("test-%d").setDaemon(true).build())
+                .build();
+        _rootCurator.start();
+    }
+
+    @AfterClass
+    public static void stopZookeeper() throws Exception {
+        _rootCurator.close();
+        _testingServer.stop();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        // Create a unique base path for each test so each tests ZooKeeper data is independent.
+        _zkNamespace = "emodb/test" + UUID.randomUUID();
+        _curator = _rootCurator.usingNamespace(_zkNamespace);
+
+        _mapStore = new ZkMapStore<>(_curator, "sor-update-throttle", new ZkDataStoreUpdateThrottleSerializer());
+        _mapStore.start();
+
+        Clock clock = mock(Clock.class);
+        when(clock.instant()).then(ignore -> _now);
+        when(clock.millis()).then(ignore-> _now.toEpochMilli());
+        _now = Instant.ofEpochMilli(1514764800000L);
+
+        _rateLimiterFactory = mock(RateLimiterFactory.class);
+
+        _throttleManager = new DataStoreUpdateThrottleManager(_mapStore, clock, new MetricRegistry()) {
+            // Defer rate limit generation to our controlled mock
+            @Override
+            protected RateLimiter createRateLimiter(double rate) {
+                return _rateLimiterFactory.create(rate);
+            }
+        };
+
+        // Whenever an update to the data store occurs it is passed in a list of updates.  Rate limiting is applied
+        // as the list is iterated, so we have to configure the mock data store accordingly.
+        doAnswer(invocation -> {
+            //noinspection unchecked
+            Iterable<Update> updates = (Iterable<Update>) invocation.getArguments()[0];
+            updates.forEach(ignore -> {});
+            return null;
+        }).when(_dataStore).updateAll(any(), any());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        _mapStore.stop();
+        reset(_dataStore);
+        verifyNoMoreInteractions(_rateLimiterFactory);
+    }
+
+    @Test
+    public void testNoLimits() throws Exception {
+        // Simply update a document with no rate limits applied
+        createClient(API_KEY_LIMITED).update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+    }
+
+    @Test
+    public void testApiKeyLimited() throws Exception {
+        final RateLimiter rateLimiter = mock(RateLimiter.class);
+        when(_rateLimiterFactory.create(10)).thenReturn(rateLimiter);
+
+        updateAPIKeyRateLimit(_limitedId, new DataStoreUpdateThrottle(10, _now.plusSeconds(1)));
+
+        createClient(API_KEY_LIMITED).update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+
+        verify(_rateLimiterFactory).create(10);
+        verify(rateLimiter).acquire();
+    }
+
+    @Test
+    public void testNotThisApiKeyLimited() throws Exception {
+        final RateLimiter rateLimiter = mock(RateLimiter.class);
+        when(rateLimiter.acquire()).thenThrow(new AssertionError("Unlimited key should not have been rate limited"));
+        when(_rateLimiterFactory.create(anyDouble())).thenReturn(rateLimiter);
+
+        updateAPIKeyRateLimit(_limitedId, new DataStoreUpdateThrottle(10, _now.plusSeconds(1)));
+
+        createClient(API_KEY_UNLIMITED).update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+
+        verify(_rateLimiterFactory).create(10);
+    }
+
+    @Test
+    public void testInstanceRateLimited() throws Exception {
+        final RateLimiter keyRateLimiter = mock(RateLimiter.class);
+        final RateLimiter instanceRateLimiter = mock(RateLimiter.class);
+        when(_rateLimiterFactory.create(10)).thenReturn(keyRateLimiter);
+        when(_rateLimiterFactory.create(20)).thenReturn(instanceRateLimiter);
+
+        updateAPIKeyRateLimit(_limitedId, new DataStoreUpdateThrottle(10, _now.plusSeconds(1)));
+        updateAPIKeyRateLimit("*", new DataStoreUpdateThrottle(20, _now.plusSeconds(1)));
+
+        createClient(API_KEY_LIMITED).update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+        createClient(API_KEY_UNLIMITED).update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+
+        verify(_rateLimiterFactory).create(10);
+        verify(_rateLimiterFactory).create(20);
+
+        verify(keyRateLimiter).acquire();
+        verify(instanceRateLimiter, times(2)).acquire();
+    }
+
+    @Test
+    public void testStreamRateLimited() throws Exception {
+        final RateLimiter rateLimiter = mock(RateLimiter.class);
+        when(_rateLimiterFactory.create(10)).thenReturn(rateLimiter);
+
+        updateAPIKeyRateLimit(_limitedId, new DataStoreUpdateThrottle(10, _now.plusSeconds(1)));
+
+        List<Update> updates = Lists.newArrayListWithCapacity(20);
+        for (int i=0; i < 20; i++) {
+            updates.add(new Update("table", "key" + i, TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build()));
+        }
+        createClient(API_KEY_LIMITED).updateAll(updates);
+
+        verify(_rateLimiterFactory).create(10);
+        verify(rateLimiter, times(20)).acquire();
+    }
+
+    @Test
+    public void testRemoveRateLimit() throws Exception {
+        final RateLimiter rateLimiter = mock(RateLimiter.class);
+        when(_rateLimiterFactory.create(10)).thenReturn(rateLimiter);
+        when(rateLimiter.acquire()).thenReturn(0.0).thenThrow(new AssertionError("Rate limit should only have been applied once"));
+
+        updateAPIKeyRateLimit(_limitedId, new DataStoreUpdateThrottle(10, _now.plusSeconds(1)));
+        createClient(API_KEY_LIMITED).update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+
+        clearAPIKeyRateLimit(_limitedId);
+        createClient(API_KEY_LIMITED).update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+
+        verify(_rateLimiterFactory).create(10);
+        verify(rateLimiter).acquire();
+    }
+
+    @Test
+    public void testRateLimitExpiration() throws Exception {
+        final RateLimiter rateLimiter = mock(RateLimiter.class);
+        when(_rateLimiterFactory.create(10)).thenReturn(rateLimiter);
+        when(rateLimiter.acquire()).thenReturn(0.0).thenThrow(new AssertionError("Rate limit should only have been applied once"));
+
+        updateAPIKeyRateLimit(_limitedId, new DataStoreUpdateThrottle(10, _now.plusSeconds(1)));
+        createClient(API_KEY_LIMITED).update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+
+        // Advance time to just after the rate limit's expiration
+        _now = _now.plusSeconds(1).plusMillis(1);
+
+        createClient(API_KEY_LIMITED).update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+        verify(_rateLimiterFactory).create(10);
+        verify(rateLimiter).acquire();
+    }
+
+    /**
+     * Behind the scenes when the rate limit for an API key is changed the manager creates a new {@link RateLimiter}.
+     * This test depends on that behavior.  If it is changed such that the same RateLimiter instance is updated
+     * using {@link RateLimiter#setRate(double)} then this test will fail unless it is similarly updated.
+     */
+    @Test
+    public void testRateLimitChange() throws Exception {
+        final RateLimiter rateLimiter10 = mock(RateLimiter.class);
+        when(_rateLimiterFactory.create(10)).thenReturn(rateLimiter10);
+        final RateLimiter rateLimiter20 = mock(RateLimiter.class);
+        when(_rateLimiterFactory.create(20)).thenReturn(rateLimiter20);
+
+        updateAPIKeyRateLimit(_limitedId, new DataStoreUpdateThrottle(10, _now.plusSeconds(1)));
+        DataStore client = createClient(API_KEY_LIMITED);
+        for (int i=0; i < 3; i++) {
+            client.update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+        }
+
+        updateAPIKeyRateLimit(_limitedId, new DataStoreUpdateThrottle(20, _now.plusSeconds(1)));
+        client.update("table", "key", TimeUUIDs.newUUID(), Deltas.delete(), new AuditBuilder().build());
+
+        verify(_rateLimiterFactory).create(10);
+        verify(_rateLimiterFactory).create(20);
+
+        verify(rateLimiter10, times(3)).acquire();
+        verify(rateLimiter20).acquire();
+    }
+
+    private void updateAPIKeyRateLimit(String id, DataStoreUpdateThrottle throttle) throws Exception {
+        // Make the underlying call
+        _throttleManager.updateAPIKeyRateLimit(id, throttle);
+        // Wait up to 10 seconds for the MapStore on the throttle manager to be updated.
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        while (stopwatch.elapsed(TimeUnit.SECONDS) < 10) {
+            Thread.sleep(10);
+            DataStoreUpdateThrottle actualThrottle = _throttleManager.getThrottle(id);
+            if (actualThrottle != null && actualThrottle.equals(throttle)) {
+                return;
+            }
+        }
+        fail("Updated rate limit was not applied after 10 seconds");
+    }
+
+    private void clearAPIKeyRateLimit(String id) throws Exception {
+        // Make the underlying call
+        _throttleManager.clearAPIKeyRateLimit(id);
+        // Wait up to 10 seconds for the MapStore on the throttle manager to be updated.
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        while (stopwatch.elapsed(TimeUnit.SECONDS) < 10) {
+            Thread.sleep(10);
+            if (_throttleManager.getThrottle(id) == null) {
+                return;
+            }
+        }
+        fail("Updated rate limit was not applied after 10 seconds");
+    }
+
+    private DataStore createClient(String apiKey) {
+        return DataStoreAuthenticator.proxied(new DataStoreClient(URI.create("/sor/1"), new JerseyEmoClient(_resourceTestRule.client())))
+                .usingCredentials(apiKey);
+    }
+
+    private interface RateLimiterFactory {
+        RateLimiter create(double rate);
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottle.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottle.java
@@ -1,0 +1,49 @@
+package com.bazaarvoice.emodb.web.throttling;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Throttle for updates to the DataStore.  This consists of two attributes:
+ * <ol>
+ *     <li>The rate limit in terms of updates per second.</li>
+ *     <li>A expiration time after which the rate limit will no longer be enforced.</li>
+ * </ol>
+ */
+public class DataStoreUpdateThrottle {
+
+    private final double _rateLimit;
+    private final Instant _expirationTime;
+
+    public DataStoreUpdateThrottle(double rateLimit, Instant expirationTime) {
+        _rateLimit = rateLimit;
+        _expirationTime = expirationTime;
+    }
+
+    public double getRateLimit() {
+        return _rateLimit;
+    }
+
+    public Instant getExpirationTime() {
+        return _expirationTime;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DataStoreUpdateThrottle)) {
+            return false;
+        }
+        DataStoreUpdateThrottle that = (DataStoreUpdateThrottle) o;
+        return that._rateLimit == _rateLimit &&
+                Objects.equals(_expirationTime, that._expirationTime);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(_rateLimit, _expirationTime);
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottleControlTask.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottleControlTask.java
@@ -1,0 +1,154 @@
+package com.bazaarvoice.emodb.web.throttling;
+
+import com.bazaarvoice.emodb.common.dropwizard.task.TaskRegistry;
+import com.bazaarvoice.emodb.common.zookeeper.store.ZkDurationSerializer;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.inject.Inject;
+import io.dropwizard.servlets.tasks.Task;
+
+import java.io.PrintWriter;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Dropwizard task to throttle DataStore updates via the REST API by API key and/or instance wide.  When a rate limit
+ * is active for the instance then all API updates are rate limited.  No guarantees to fairness are made for which API
+ * keys get rate limited.  When an API key is rate limited and there is an instance rate limit then both are applied.
+ * For example, if the instance rate limit is set to 500 wps and an API key is rate limited to 100 wps then a write by
+ * the API key may be rate limited even if it is writing at below 100 wps if in aggregate the instance is receiving over
+ * 500 wps.
+ *
+ * Note that the actual number of updates are what is rate limited by this task, not the number of update API calls.
+ * For example, 500 individual calls to update 500 documents is throttled at the same rate as if a single streaming call
+ * were made which updates the same 500 documents.   Additionally, only updates made via the API are rate limited.
+ * Updates made internally by EmoDB, such as during a purge operation, or as a consequence of another action, such as
+ * by creating a table, are not rate limited by this task.
+ *
+ * Whether per API key or instance wide all rate limits are expressed and enforced at the instance level.  There is no way
+ * to specify a global rate limit across the entire cluster.  If an API key is rate limited to 200 wps and there are 4
+ * instances in the cluster then, assuming the API key is maximally utilizing all four instances, it can achieve an
+ * aggregate 800 wps across the cluster.  If a fifth server is added to the cluster its maximum throughput rises to
+ * 1,000 wps.
+ *
+ * Throttles are applied only within the local data center.  For example, rate limiting an API key in us-east-1 will
+ * have no effect on throttling writes in eu-west-1.  This task would have to be called on a server in each data center
+ * to rate limit the API key in both.  However, any updates made using this task are automatically propagated to every
+ * server in the local data center.
+ *
+ * All throttles must expire after a specific duration.  If none is provided the default is 24 hours.  To remove all
+ * throttling for an API key set the rate limit to 0.  Note that it is not possible to completely block update access
+ * using this task, but it can be set remarkably low, such as to 0.1 (1 update every 10 seconds).
+ *
+ * API keys are expressed using their IDs, not the private keys.  Using this task with a key and not the key's ID will
+ * not return an error but it will also not rate limit any API keys.  To throttle updates instance wide across all API keys
+ * use the wildcard API key, "*".
+ *
+ * Usage:
+ * <pre>
+ *     # Set a throttle for a single API key, with the default and with an explicit expiration
+ *     curl -s -XPOST 'localhost:8081/tasks/sor-api-update-throttle?id=ID01&limit=100'
+ *     curl -s -XPOST 'localhost:8081/tasks/sor-api-update-throttle?id=ID02&limit=100&duration=PT1H'
+ *
+ *     # Set an instance wide throttle
+ *     curl -s -XPOST 'localhost:8081/tasks/sor-api-update-throttle?id=*&limit=500&duration=PT30M'
+ *
+ *     # Remove a throttle
+ *      curl -s -XPOST 'localhost:8081/tasks/sor-api-update-throttle?id=ID02&limit=0'
+ *
+ *     # List all throttled endpoints
+ *      curl -s -XPOST 'localhost:8081/tasks/sor-api-update-throttle'
+ *
+ *     # Clear all throttled endpoints
+ *     curl -s -XPOST 'localhost:8081/tasks/sor-api-update-throttle?clear'
+ * </pre>
+ */
+public class DataStoreUpdateThrottleControlTask extends Task {
+    private final DataStoreUpdateThrottleManager _throttleManager;
+
+    @Inject
+    public DataStoreUpdateThrottleControlTask(TaskRegistry taskRegistry,
+                                              DataStoreUpdateThrottleManager throttleManager) {
+        super("sor-api-update-throttle");
+        _throttleManager = requireNonNull(throttleManager, "throttleManager");
+        taskRegistry.addTask(this);
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter out) throws Exception {
+        // Default duration
+        Duration expiryDuration = Duration.ofHours(24);
+        Collection<String> values = parameters.get("duration");
+        if (values.size() == 1) {
+            expiryDuration = new ZkDurationSerializer().fromString(values.iterator().next());
+        } else if (values.size() > 1) {
+            throw new IllegalArgumentException("At most one duration parameter is permitted");
+        }
+
+        double limit = 0;
+        values = parameters.get("limit");
+        if (values.size() == 1) {
+            limit = Double.parseDouble(values.iterator().next());
+        } else if (values.size() > 1) {
+            throw new IllegalArgumentException("At most one limit parameter is permitted");
+        }
+
+        boolean throttlesChanged = false;
+
+        if (parameters.keySet().contains("clear")) {
+            for (String apiKey : _throttleManager.getAllThrottles().keySet()) {
+                _throttleManager.clearAPIKeyRateLimit(apiKey);
+            }
+            out.println("All throttles cleared");
+            throttlesChanged = true;
+        }
+
+        if (!parameters.get("id").isEmpty()) {
+            DataStoreUpdateThrottle throttle = null;
+            if (limit > 0) {
+                throttle = new DataStoreUpdateThrottle(limit, Instant.now().plus(expiryDuration));
+                out.printf("Applying throttled rate limit %f expires at %s:\n", limit, throttle.getExpirationTime());
+            } else {
+                out.printf("Removing throttles:\n");
+            }
+
+            for (String id : parameters.get("id")) {
+                if (throttle != null) {
+                    _throttleManager.updateAPIKeyRateLimit(id, throttle);
+                } else {
+                    _throttleManager.clearAPIKeyRateLimit(id);
+                }
+                out.printf("- Applied to %s\n", id);
+            }
+
+            throttlesChanged = true;
+        }
+
+        if (throttlesChanged) {
+            out.println();
+            out.println("NOTE: Due to propagation delays the effects of these changes may not be immediately reflected " +
+                    "in the following list of active throttles.");
+            out.println();
+
+            // Wait 500ms to give propagation a better chance at having been applied when dumping the list of active throttles
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException ignore) {
+                // ignore
+            }
+        }
+
+        out.println("Active throttles:\n");
+        for (Map.Entry<String, DataStoreUpdateThrottle> entry : _throttleManager.getAllThrottles().entrySet()) {
+            String apiKey = entry.getKey();
+            DataStoreUpdateThrottle throttle = entry.getValue();
+
+            out.printf("- %s (limit %f expires at %s)\n", apiKey, throttle.getRateLimit(), throttle.getExpirationTime());
+        }
+
+        out.println();
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottleManager.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottleManager.java
@@ -1,0 +1,232 @@
+package com.bazaarvoice.emodb.web.throttling;
+
+import com.bazaarvoice.emodb.common.zookeeper.store.ChangeType;
+import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class serves two purposes:
+ * <ol>
+ *     <li>It manages the set of active throttles and distributes them system wide within the local data center.</li>
+ *     <li>It satisfies the {@link DataStoreUpdateThrottler} interface so it can be injected into the API to throttle
+ *         calls in accordance with the currently active throttles.</li>
+ * </ol>
+ *
+ * The set of throttles themselves are distributed to the local data center via ZooKeeper.  A {@link MapStore} updates
+ * the active throttles in ZooKeeper, and a listener updates the local throttles to match the ZooKeeper state.  For this
+ * reason there is a slight propagation delay between updating the rate limit locally and it being enforced throughout
+ * the data center, including on the local instance.
+ */
+public class DataStoreUpdateThrottleManager implements DataStoreUpdateThrottler {
+
+    // Reserved string used for instance-wide rate limiting in ZooKeeper
+    private static final String INSTANCE_RATE_LIMIT_ZK_KEY = "_";
+    /**
+     * A more natural value to indicate the instance-wide rate limit for this class' API would be a wildcard, "*",
+     * but this value could inter-operate in unexpected ways as a path wildcard.  Therefore use "*" for the API
+     * but use "_" when persisted in Zookeeper.
+     */
+    public static final String INSTANCE_RATE_LIMIT_KEY = "*";
+
+    private final Logger _log = LoggerFactory.getLogger(DataStoreUpdateThrottleManager.class);
+
+    private final Clock _clock;
+    private final MapStore<DataStoreUpdateThrottle> _currentRateLimits;
+    private volatile ExpiringRateLimiter _instanceRateLimit = null;
+    private final ConcurrentMap<String, ExpiringRateLimiter> _rateLimitByApiKey = Maps.newConcurrentMap();
+    private final Histogram _throttleWaitTimeMs;
+
+    @Inject
+    public DataStoreUpdateThrottleManager(@DataStoreUpdateThrottleMapStore MapStore<DataStoreUpdateThrottle> currentRateLimits,
+                                          Clock clock, MetricRegistry metricRegistry) {
+        _currentRateLimits = currentRateLimits;
+        _clock = clock;
+        _currentRateLimits.addListener((key, changeType) -> onRateLimitChanged(fromZKPath(key), changeType));
+
+        _throttleWaitTimeMs = metricRegistry.histogram(MetricRegistry.name("bv.emodb.web", "Throttle", "throttled-sor-update-ms"));
+    }
+
+    public void updateAPIKeyRateLimit(String id, DataStoreUpdateThrottle throttle) {
+        checkNotNull(id, "id");
+        try {
+            _currentRateLimits.set(toZKPath(id), throttle);
+        } catch (Exception e) {
+            _log.warn("Failed to update rate limit for {}", INSTANCE_RATE_LIMIT_KEY.equals(id) ? "instance" : id, e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public void clearAPIKeyRateLimit(String id) {
+        try {
+            _currentRateLimits.remove(toZKPath(id));
+        } catch (Exception e) {
+            _log.warn("Failed to clear rate limit for {}", INSTANCE_RATE_LIMIT_KEY.equals(id) ? "instance" : id, e);
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public DataStoreUpdateThrottle getThrottle(String id) {
+        return _currentRateLimits.get(toZKPath(id));
+    }
+
+    public Map<String, DataStoreUpdateThrottle> getAllThrottles() {
+        return _currentRateLimits.getAll().entrySet().stream()
+                .filter(e -> _clock.instant().isBefore(e.getValue().getExpirationTime()))
+                .collect(Collectors.toMap(e -> fromZKPath(e.getKey()), Map.Entry::getValue));
+    }
+
+    @Override
+    public void beforeUpdate(String id) {
+        checkNotNull(id, "Rate limiting of SOR updates should only be applied to API requests with an API key");
+
+        double microsWaited = 0;
+        double maybeMicrosWaited;
+
+        // First, apply instance rate limit
+        ExpiringRateLimiter rateLimiter = _instanceRateLimit;
+        if (rateLimiter != null) {
+            if ((maybeMicrosWaited = rateLimiter.rateLimit()) != -1) {
+                microsWaited = maybeMicrosWaited;
+            } else {
+                synchronized (this) {
+                    if (_instanceRateLimit != null && !_instanceRateLimit.isActive()) {
+                        // There is a slight race condition here if an admin re-creates the throttle at the exact moment
+                        // this throttle is noted to have expired.  However, this is extremely unlikely so we favor
+                        // clearing out expired throttles rather than keeping them indefinitely to avoid race conditions.
+                        _instanceRateLimit = null;
+                        clearAPIKeyRateLimit(INSTANCE_RATE_LIMIT_KEY);
+                    }
+                }
+            }
+        }
+
+        // Next apply API Key rate limit
+        rateLimiter = _rateLimitByApiKey.get(id);
+        if (rateLimiter != null) {
+            if ((maybeMicrosWaited = rateLimiter.rateLimit()) != -1) {
+                microsWaited += maybeMicrosWaited;
+            } else {
+                // Same as with the instance throttle we accept an edge race condition so we can clear expired throttles.
+                _rateLimitByApiKey.remove(id, rateLimiter);
+                clearAPIKeyRateLimit(id);
+            }
+        }
+
+        // Consider any wait of longer than 1 millisecond to be throttled
+        if (microsWaited >= 1000) {
+            _throttleWaitTimeMs.update((long) (microsWaited * 1000));
+        }
+    }
+
+    private void onRateLimitChanged(String key, ChangeType changeType) {
+        if (INSTANCE_RATE_LIMIT_KEY.equals(key)) {
+            onInstanceRateLimitChanged(changeType == ChangeType.REMOVE);
+        } else {
+            onAPIKeyRateLimitChanged(key, changeType == ChangeType.REMOVE);
+        }
+    }
+
+    synchronized private void onInstanceRateLimitChanged(boolean removed) {
+        final DataStoreUpdateThrottle rateLimit = removed ? null : _currentRateLimits.get(INSTANCE_RATE_LIMIT_ZK_KEY);
+
+        if (removed || rateLimit == null) {
+            _instanceRateLimit = null;
+        } else if (_instanceRateLimit == null) {
+            _instanceRateLimit = new ExpiringRateLimiter(createRateLimiter(rateLimit.getRateLimit()), rateLimit.getExpirationTime());
+        } else {
+            _instanceRateLimit = _instanceRateLimit.updated(rateLimit.getRateLimit(), rateLimit.getExpirationTime());
+        }
+    }
+
+    private void onAPIKeyRateLimitChanged(String id, boolean removed) {
+        final DataStoreUpdateThrottle rateLimit = removed ? null : _currentRateLimits.get(id);
+
+        if (removed || rateLimit == null) {
+            _rateLimitByApiKey.remove(id);
+        } else {
+            _rateLimitByApiKey.compute(id, (s, rateLimiter) -> {
+                if (rateLimiter == null) {
+                    return new ExpiringRateLimiter(createRateLimiter(rateLimit.getRateLimit()), rateLimit.getExpirationTime());
+                } else {
+                    return rateLimiter.updated(rateLimit.getRateLimit(), rateLimit.getExpirationTime());
+                }
+            });
+        }
+    }
+
+    private String toZKPath(String apiKey) {
+        requireNonNull(apiKey, "API key cannot be null");
+        checkArgument(!INSTANCE_RATE_LIMIT_ZK_KEY.equals(apiKey), "Invalid use of reserved API key");
+        return INSTANCE_RATE_LIMIT_KEY.equals(apiKey) ? INSTANCE_RATE_LIMIT_ZK_KEY : apiKey;
+    }
+
+    private String fromZKPath(String path) {
+        return INSTANCE_RATE_LIMIT_ZK_KEY.equals(path) ? INSTANCE_RATE_LIMIT_KEY : path;
+    }
+
+    private final class ExpiringRateLimiter {
+        final RateLimiter _rateLimiter;
+        final Instant _expirationTime;
+
+        ExpiringRateLimiter(RateLimiter rateLimiter, Instant expirationTime) {
+            _rateLimiter = rateLimiter;
+            _expirationTime = expirationTime;
+        }
+
+        /**
+         * Applies the rate limiter if it has not expired.
+         * @return The number of microseconds spent waiting due to rate limiting, or -1 if the rate limit was inactive.
+         */
+        double rateLimit() {
+            if (isActive()) {
+                return _rateLimiter.acquire();
+            } else {
+                return -1;
+            }
+        }
+
+        boolean isActive() {
+            return _clock.instant().isBefore(_expirationTime);
+        }
+
+        ExpiringRateLimiter updated(double newRate, Instant expirationTime) {
+            // If only the expiration time is changing don't adjust the rate limiter
+            if (_rateLimiter.getRate() == newRate) {
+                return new ExpiringRateLimiter(_rateLimiter, expirationTime);
+            } else {
+                return new ExpiringRateLimiter(createRateLimiter(newRate), expirationTime);
+            }
+        }
+
+        DataStoreUpdateThrottle getMetadata() {
+            return new DataStoreUpdateThrottle(_rateLimiter.getRate(), _expirationTime);
+        }
+    }
+
+    /**
+     * Simple method to create a rate limiter.  It is exposed as a protected method to allow unit tests to override
+     * to enable introspecting rate limit calls.
+     */
+    @VisibleForTesting
+    protected RateLimiter createRateLimiter(double rate) {
+        return RateLimiter.create(rate);
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottleManager.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottleManager.java
@@ -132,7 +132,7 @@ public class DataStoreUpdateThrottleManager implements DataStoreUpdateThrottler 
 
         // Consider any wait of longer than 1 millisecond to be throttled
         if (microsWaited >= 1000) {
-            _throttleWaitTimeMs.update((long) (microsWaited * 1000));
+            _throttleWaitTimeMs.update((long) (microsWaited / 1000));
         }
     }
 
@@ -214,10 +214,6 @@ public class DataStoreUpdateThrottleManager implements DataStoreUpdateThrottler 
             } else {
                 return new ExpiringRateLimiter(createRateLimiter(newRate), expirationTime);
             }
-        }
-
-        DataStoreUpdateThrottle getMetadata() {
-            return new DataStoreUpdateThrottle(_rateLimiter.getRate(), _expirationTime);
         }
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottleMapStore.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottleMapStore.java
@@ -1,0 +1,16 @@
+package com.bazaarvoice.emodb.web.throttling;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface DataStoreUpdateThrottleMapStore {
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottler.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/throttling/DataStoreUpdateThrottler.java
@@ -1,0 +1,17 @@
+package com.bazaarvoice.emodb.web.throttling;
+
+/**
+ * Interface to enable the DataStore API to enforce all active update throttles.
+ */
+public interface DataStoreUpdateThrottler {
+    /**
+     * Should be called before each update applied at the API level.  If there is an instance-wide or API-key level rate
+     * limit active on this instance this method will block if necessary to satisfy the rate limit.  In a more
+     * sophisticated implementation this could reject an update if the wait is too long, allowing the API to return
+     * a meaningful "rate limit exceeded" response.  However, until the EmoDB clients are updated to handle this
+     * condition the safest approach is to wait instead of fail.
+     *
+     * @param id The ID of the API key making the update request.
+     */
+    void beforeUpdate(String id);
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/throttling/UnlimitedDataStoreUpdateThrottler.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/throttling/UnlimitedDataStoreUpdateThrottler.java
@@ -1,0 +1,12 @@
+package com.bazaarvoice.emodb.web.throttling;
+
+/**
+ * Implementation of {@link DataStoreUpdateThrottler} which never throttles.  Useful for testing.
+ */
+public class UnlimitedDataStoreUpdateThrottler implements DataStoreUpdateThrottler {
+
+    @Override
+    public void beforeUpdate(String id) {
+        // no-op
+    }
+}

--- a/web/src/main/java/com/bazaarvoice/emodb/web/throttling/ZkDataStoreUpdateThrottleSerializer.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/throttling/ZkDataStoreUpdateThrottleSerializer.java
@@ -1,0 +1,31 @@
+package com.bazaarvoice.emodb.web.throttling;
+
+import com.bazaarvoice.emodb.common.zookeeper.store.ZkValueSerializer;
+
+import java.time.Instant;
+
+/**
+ * Simple serializer for storing {@link DataStoreUpdateThrottle} configurations in ZooKeeper.
+ */
+public class ZkDataStoreUpdateThrottleSerializer implements ZkValueSerializer<DataStoreUpdateThrottle> {
+
+    @Override
+    public String toString(DataStoreUpdateThrottle value) {
+        return String.format("%.8f,%s", value.getRateLimit(), value.getExpirationTime());
+    }
+
+    @Override
+    public DataStoreUpdateThrottle fromString(String string) {
+        if (string == null) {
+            return null;
+        }
+
+        int comma = string.indexOf(',');
+        if (comma <= 0) {
+            throw new IllegalArgumentException("Rate limit value cannot be parsed: " + string);
+        }
+        double rateLimit = Double.parseDouble(string.substring(0, comma));
+        Instant expirationTime = Instant.parse(string.substring(comma+1));
+        return new DataStoreUpdateThrottle(rateLimit, expirationTime);
+    }
+}

--- a/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
@@ -26,6 +26,7 @@ import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
 import com.bazaarvoice.emodb.web.resources.sor.AuditParam;
 import com.bazaarvoice.emodb.web.resources.sor.DataStoreResource1;
+import com.bazaarvoice.emodb.web.throttling.UnlimitedDataStoreUpdateThrottler;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.io.Closeables;
 import org.apache.curator.framework.CuratorFramework;
@@ -36,7 +37,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.time.Clock;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
@@ -85,7 +85,8 @@ public class PurgeTest {
                 1, Duration.ZERO, 100, Duration.ofHours(1));
 
         _store = new InMemoryDataStore(new MetricRegistry());
-        _dataStoreResource = new DataStoreResource1(_store, new DefaultDataStoreAsync(_store, _service, _jobHandlerRegistry), mock(CompactionControlSource.class));
+        _dataStoreResource = new DataStoreResource1(_store, new DefaultDataStoreAsync(_store, _service, _jobHandlerRegistry),
+                mock(CompactionControlSource.class), new UnlimitedDataStoreUpdateThrottler());
 
     }
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

This PR adds the ability to rate limit updates to the data store by API key.  These rate limits are enforced per-instance but are automatically replicated to all instances in the local data center.  Additionally an instance-wide rate rate limit can be applied to cap the updates from all API keys to a maximum rate per instance.

Additionally this PR also closes a hole where the API keys were being printed to the request log.  Now the API key IDs are printed instead.

## How to Test and Verify

1. Check out this PR
2. Follow the instructions in `DataStoreUpdateThrottleControlTask` to enforce rate limits.
3. Perform updates via the data store REST API and verify they conform to the defined rate limits.

## Risk

### Level 

`Low`.  Although there is a non-trivial amount of code in this PR most of it is new and does not affect the existing data store workflow.  The bulk of the changes to existing classes involve dependency injection such that if there is an error in the code the service simply won't start.

### Required Testing

`Manual`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
