### PR TITLE
Upgrade Guava to 20.0

### DIFF
--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/AuthBlobStore.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/AuthBlobStore.java
@@ -5,8 +5,8 @@ import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.TableExistsException;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
-import com.google.common.io.InputSupplier;
 
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -102,7 +102,7 @@ public interface AuthBlobStore {
     Blob get(@Credential String apiKey, String table, String blobId, @Nullable RangeSpecification rangeSpec)
             throws BlobNotFoundException, RangeNotSatisfiableException;
 
-    void put(@Credential String apiKey, String table, String blobId, InputSupplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
+    void put(@Credential String apiKey, String table, String blobId, Supplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException;
 
     void delete(@Credential String apiKey, String table, String blobId);

--- a/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/BlobStore.java
+++ b/blob-api/src/main/java/com/bazaarvoice/emodb/blob/api/BlobStore.java
@@ -4,8 +4,8 @@ import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.TableExistsException;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
-import com.google.common.io.InputSupplier;
 
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -96,7 +96,7 @@ public interface BlobStore {
     Blob get(String table, String blobId, @Nullable RangeSpecification rangeSpec)
             throws BlobNotFoundException, RangeNotSatisfiableException;
 
-    void put(String table, String blobId, InputSupplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
+    void put(String table, String blobId, Supplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException;
 
     void delete(String table, String blobId);

--- a/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreAuthenticatorProxy.java
+++ b/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreAuthenticatorProxy.java
@@ -12,8 +12,8 @@ import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.TableExistsException;
 import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
-import com.google.common.io.InputSupplier;
 
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -82,7 +82,7 @@ class BlobStoreAuthenticatorProxy implements BlobStore {
     }
 
     @Override
-    public void put(String table, String blobId, InputSupplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
+    public void put(String table, String blobId, Supplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException {
         _authBlobStore.put(_apiKey, table, blobId, in, attributes, ttl);
     }

--- a/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreClient.java
+++ b/blob-client-common/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreClient.java
@@ -30,9 +30,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closeables;
-import com.google.common.io.InputSupplier;
 import com.google.common.net.HttpHeaders;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.function.Supplier;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
 
@@ -480,7 +480,7 @@ public class BlobStoreClient implements AuthBlobStore {
     }
 
     @Override
-    public void put(String apiKey, String table, String blobId, InputSupplier<? extends InputStream> in,
+    public void put(String apiKey, String table, String blobId, Supplier<? extends InputStream> in,
                     Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException {
         checkNotNull(table, "table");
@@ -502,7 +502,7 @@ public class BlobStoreClient implements AuthBlobStore {
             // Upload the object
             request.type(MediaType.APPLICATION_OCTET_STREAM_TYPE)
                     .header(ApiKeyRequest.AUTHENTICATION_HEADER, apiKey)
-                    .put(in.getInput());
+                    .put(in.get());
         } catch (EmoClientException e) {
             throw convertException(e);
         }

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/core/BlobStoreProviderProxy.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/core/BlobStoreProviderProxy.java
@@ -13,7 +13,6 @@ import com.bazaarvoice.emodb.sor.api.TableOptions;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.io.InputSupplier;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -124,7 +123,7 @@ public class BlobStoreProviderProxy implements BlobStore {
     }
 
     @Override
-    public void put(String table, String blobId, InputSupplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
+    public void put(String table, String blobId, java.util.function.Supplier<? extends InputStream> in, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException {
         _local.get().put(table, blobId, in, attributes, ttl);
     }

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/core/DefaultBlobStore.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/core/DefaultBlobStore.java
@@ -26,8 +26,8 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.InputSupplier;
 import com.google.inject.Inject;
+import java.util.function.Supplier;
 import org.apache.commons.codec.binary.Hex;
 
 import javax.annotation.Nullable;
@@ -299,7 +299,7 @@ public class DefaultBlobStore implements BlobStore {
     }
 
     @Override
-    public void put(String tableName, String blobId, InputSupplier<? extends InputStream> in, Map<String,String> attributes, @Nullable Duration ttl) throws IOException {
+    public void put(String tableName, String blobId, Supplier<? extends InputStream> in, Map<String,String> attributes, @Nullable Duration ttl) throws IOException {
         checkLegalTableName(tableName);
         checkLegalBlobId(blobId);
         checkNotNull(in, "in");
@@ -310,7 +310,7 @@ public class DefaultBlobStore implements BlobStore {
         long timestamp = _storageProvider.getCurrentTimestamp(table);
         int chunkSize = _storageProvider.getDefaultChunkSize();
 
-        DigestInputStream md5In = new DigestInputStream(in.getInput(), getMessageDigest("MD5"));
+        DigestInputStream md5In = new DigestInputStream(in.get(), getMessageDigest("MD5"));
         DigestInputStream sha1In = new DigestInputStream(md5In, getMessageDigest("SHA-1"));
 
         // A more aggressive solution like the Astyanax ObjectWriter recipe would improve performance by pipelining

--- a/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/cqldriver/AdaptiveResultSet.java
+++ b/common/astyanax/src/main/java/com/bazaarvoice/emodb/common/cassandra/cqldriver/AdaptiveResultSet.java
@@ -10,8 +10,6 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.datastax.driver.core.exceptions.FrameTooLongException;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
-import com.datastax.driver.core.exceptions.OperationTimedOutException;
-import com.datastax.driver.core.exceptions.ReadTimeoutException;
 import com.datastax.driver.core.utils.MoreFutures;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
@@ -19,6 +17,7 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +66,7 @@ public class AdaptiveResultSet implements ResultSet {
             }
         });
 
-        return Futures.withFallback(adaptiveFuture, t -> {
+        return Futures.catchingAsync(adaptiveFuture, Throwable.class, t -> {
             if (isAdaptiveException(t) && remainingAdaptations > 0 && fetchSize > MIN_FETCH_SIZE) {
                 // Try again with half the fetch size
                 int reducedFetchSize = Math.max(fetchSize / 2, MIN_FETCH_SIZE);
@@ -119,7 +118,7 @@ public class AdaptiveResultSet implements ResultSet {
 
     private final Session _session;
     private ResultSet _delegate;
-    private Iterator<Row> _fetchedResults = Iterators.emptyIterator();
+    private Iterator<Row> _fetchedResults = Collections.emptyIterator();
     private volatile ResultSet _delegateWithPrefetchFailure;
     private volatile Throwable _prefetchFailure;
     private int _remainingAdaptations;

--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/leader/LeaderServiceTask.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/leader/LeaderServiceTask.java
@@ -79,7 +79,7 @@ public class LeaderServiceTask extends Task {
 
             _log.warn("Temporarily releasing leadership for process: {}", name);
             out.printf("Temporarily releasing leadership for process: %s, cluster will elect a new leader.%n", name);
-            actualService.stopAndWait();
+            actualService.stopAsync().awaitTerminated();
         }
 
         // The 'terminate' argument tells a server to give up leadership permanently (or until the server restarts).
@@ -92,7 +92,7 @@ public class LeaderServiceTask extends Task {
 
             _log.warn("Terminating leader process for: {}", name);
             out.printf("Terminating leader process for: %s. Restart the server to restart the leader process.%n", name);
-            leaderService.stopAndWait();
+            leaderService.stopAsync().awaitTerminated();
         }
 
         // Print current status.

--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/lifecycle/ManagedGuavaService.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/lifecycle/ManagedGuavaService.java
@@ -18,12 +18,12 @@ public class ManagedGuavaService implements Managed {
 
     @Override
     public void start() throws Exception {
-        _service.startAndWait();
+        _service.startAsync().awaitRunning();
     }
 
     @Override
     public void stop() throws Exception {
-        _service.stopAndWait();
+        _service.stopAsync().awaitTerminated();
     }
 
     // For debugging

--- a/common/json/src/test/java/com/bazaarvoice/emodb/common/json/JsonStreamingArrayParserTest.java
+++ b/common/json/src/test/java/com/bazaarvoice/emodb/common/json/JsonStreamingArrayParserTest.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
+import com.google.common.io.ByteSource;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.InputSupplier;
 import org.apache.http.MalformedChunkCodingException;
 import org.apache.http.TruncatedChunkException;
 import org.testng.annotations.Test;
@@ -67,19 +67,19 @@ public class JsonStreamingArrayParserTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testMalformedChunkException() throws Exception {
-        InputSupplier<InputStream> input = ByteStreams.join(
-                ByteStreams.newInputStreamSupplier("[5,6".getBytes(Charsets.UTF_8)),
+        ByteSource input = ByteSource.concat(
+                ByteSource.wrap("[5,6".getBytes(Charsets.UTF_8)),
                 exceptionStreamSupplier(new MalformedChunkCodingException("Bad chunk header")));
-        assertThrowsEOFException(input.getInput(), Integer.class);
+        assertThrowsEOFException(input.openStream(), Integer.class);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testTruncatedChunkException() throws Exception {
-        InputSupplier<InputStream> input = ByteStreams.join(
-                ByteStreams.newInputStreamSupplier("[5,6".getBytes(Charsets.UTF_8)),
+        ByteSource input = ByteSource.concat(
+                ByteSource.wrap("[5,6".getBytes(Charsets.UTF_8)),
                 exceptionStreamSupplier(new TruncatedChunkException("Truncated chunk ( expected size: 3996; actual size: 1760)")));
-        assertThrowsEOFException(input.getInput(), Integer.class);
+        assertThrowsEOFException(input.openStream(), Integer.class);
     }
 
     @Test
@@ -130,10 +130,10 @@ public class JsonStreamingArrayParserTest {
         return new ByteArrayInputStream(json.getBytes(Charsets.UTF_8));
     }
 
-    private InputSupplier<InputStream> exceptionStreamSupplier(final Throwable t) {
-        return new InputSupplier<InputStream>() {
+    private ByteSource exceptionStreamSupplier(final Throwable t) {
+        return new ByteSource() {
             @Override
-            public InputStream getInput() throws IOException {
+            public InputStream openStream() throws IOException {
                 return exceptionStream(t);
             }
         };

--- a/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashReader.java
+++ b/common/stash/src/main/java/com/bazaarvoice/emodb/common/stash/StashReader.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Range;
 import com.google.common.reflect.AbstractInvocationHandler;
 import com.google.common.reflect.Reflection;
 
+import java.util.Collections;
 import javax.annotation.Nullable;
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -156,7 +157,7 @@ abstract public class StashReader {
         final String prefix = String.format("%s/", root);
 
         return new AbstractIterator<StashTable>() {
-            Iterator<String> _commonPrefixes = Iterators.emptyIterator();
+            Iterator<String> _commonPrefixes = Collections.emptyIterator();
             String _marker = null;
             boolean _truncated = true;
 
@@ -208,7 +209,7 @@ abstract public class StashReader {
 
         return new AbstractIterator<StashTableMetadata>() {
             PeekingIterator<S3ObjectSummary> _listResponse =
-                    Iterators.peekingIterator(Iterators.<S3ObjectSummary>emptyIterator());
+                    Iterators.peekingIterator(Collections.emptyIterator());
             String _marker = null;
             boolean _truncated = true;
 

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderService.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/leader/PartitionedLeaderService.java
@@ -284,7 +284,7 @@ public class PartitionedLeaderService implements Managed {
                 Service delegateService = _leaderService.getCurrentDelegateService().orNull();
                 if (delegateService != null) {
                     _log.info("Relinquishing leadership of partition {} for {}", _partition, _serviceName);
-                    delegateService.stopAsync();
+                    delegateService.stopAsync().awaitTerminated();
                 }
                 return true;
             } else {

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/store/GuavaServiceController.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/store/GuavaServiceController.java
@@ -38,11 +38,11 @@ public class GuavaServiceController implements Managed, ValueStoreListener {
 
         if (enabled && _service == null) {
             _service = _factory.get();
-            _service.start();
+            _service.startAsync();
 
         } else if (!enabled && _service != null) {
             try {
-                _service.stop();
+                _service.stopAsync();
             } finally {
                 _service = null;
             }

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/store/GuavaServiceController.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/store/GuavaServiceController.java
@@ -38,11 +38,11 @@ public class GuavaServiceController implements Managed, ValueStoreListener {
 
         if (enabled && _service == null) {
             _service = _factory.get();
-            _service.startAsync();
+            _service.startAsync().awaitRunning();
 
         } else if (!enabled && _service != null) {
             try {
-                _service.stopAsync();
+                _service.stopAsync().awaitTerminated();
             } finally {
                 _service = null;
             }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/Canary.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/Canary.java
@@ -106,7 +106,7 @@ public class Canary extends AbstractScheduledService {
             }
         } catch (Throwable t) {
             _rateLimitedLog.error(t, "Unexpected canary exception: {}", t);
-            stop();  // Give up leadership temporarily.  Maybe another server will have more success.
+            stopAsync();  // Give up leadership temporarily.  Maybe another server will have more success.
         }
     }
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/Canary.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/Canary.java
@@ -106,7 +106,7 @@ public class Canary extends AbstractScheduledService {
             }
         } catch (Throwable t) {
             _rateLimitedLog.error(t, "Unexpected canary exception: {}", t);
-            stopAsync();  // Give up leadership temporarily.  Maybe another server will have more success.
+            stopAsync().awaitTerminated();  // Give up leadership temporarily.  Maybe another server will have more success.
         }
     }
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -542,7 +542,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
             // quit now and return an empty result.  The caller can always poll again to try to pick up any more events,
             // and if necessary an async drain will kick off a few lines down to assist in clearing the redundant update
             // wasteland.
-            events = Iterators.emptyIterator();
+            events = Collections.emptyIterator();
             approximateSize = 0;
 
             // If there are still more unresolved events claimed then unclaim them now
@@ -562,7 +562,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
             final int initialDeferredLimit = remaining;
 
             Iterator<Event> deferredEvents = new AbstractIterator<Event>() {
-                private Iterator<Event> currentBatch = Iterators.emptyIterator();
+                private Iterator<Event> currentBatch = Collections.emptyIterator();
                 private int remaining = initialDeferredLimit;
 
                 @Override

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanout.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanout.java
@@ -158,7 +158,7 @@ public class DefaultFanout extends AbstractScheduledService {
             // flooding the logs with a continuous stream of error messages.  Include the event source name in the
             // message template so we rate limit each event source independently.
             _rateLimitedLog.error(t, "Unexpected fanout exception copying from " + _name + ": {}", t);
-            stopAsync();  // Give up leadership temporarily.  Maybe another server will have more success.
+            stopAsync().awaitTerminated();  // Give up leadership temporarily.  Maybe another server will have more success.
         }
     }
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanout.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanout.java
@@ -158,7 +158,7 @@ public class DefaultFanout extends AbstractScheduledService {
             // flooding the logs with a continuous stream of error messages.  Include the event source name in the
             // message template so we rate limit each event source independently.
             _rateLimitedLog.error(t, "Unexpected fanout exception copying from " + _name + ": {}", t);
-            stopAsync().awaitTerminated();  // Give up leadership temporarily.  Maybe another server will have more success.
+            stopAsync();  // Give up leadership temporarily.  Maybe another server will have more success.
         }
     }
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanout.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultFanout.java
@@ -158,7 +158,7 @@ public class DefaultFanout extends AbstractScheduledService {
             // flooding the logs with a continuous stream of error messages.  Include the event source name in the
             // message template so we rate limit each event source independently.
             _rateLimitedLog.error(t, "Unexpected fanout exception copying from " + _name + ": {}", t);
-            stop();  // Give up leadership temporarily.  Maybe another server will have more success.
+            stopAsync();  // Give up leadership temporarily.  Maybe another server will have more success.
         }
     }
 

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
@@ -63,7 +63,7 @@ public class CanaryTest {
         verify(_databus).subscribe("__system_bus:canary-cluster", Conditions.alwaysTrue(),
                 Duration.ofDays(3650), DatabusChannelConfiguration.CANARY_TTL, false);
 
-        _canary.startAsync().awaitRunning();
+        _canary.startAsync();
 
         // Starting the canary sends a single initialization runnable to the service, so execute it now.
         ArgumentCaptor<Runnable> runnable = ArgumentCaptor.forClass(Runnable.class);

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
@@ -63,7 +63,7 @@ public class CanaryTest {
         verify(_databus).subscribe("__system_bus:canary-cluster", Conditions.alwaysTrue(),
                 Duration.ofDays(3650), DatabusChannelConfiguration.CANARY_TTL, false);
 
-        _canary.startAsync();
+        _canary.startAsync().awaitRunning();
 
         // Starting the canary sends a single initialization runnable to the service, so execute it now.
         ArgumentCaptor<Runnable> runnable = ArgumentCaptor.forClass(Runnable.class);

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/CanaryTest.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import java.util.Collections;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.testng.annotations.BeforeMethod;
@@ -88,7 +89,7 @@ public class CanaryTest {
     @Test
     public void testIterationWithNoEvents() throws Exception {
         when(_databus.poll("__system_bus:canary-cluster", Duration.ofSeconds(30), 50))
-                .thenReturn(new PollResult(Iterators.emptyIterator(), 0, false));
+                .thenReturn(new PollResult(Collections.emptyIterator(), 0, false));
 
         _iterationRunnable.run();
 
@@ -147,9 +148,9 @@ public class CanaryTest {
     @Test
     public void testIterationWithDiscardedEvents() throws Exception {
         when(_databus.poll("__system_bus:canary-cluster", Duration.ofSeconds(30), 50))
-                .thenReturn(new PollResult(Iterators.emptyIterator(), 0, true))
-                .thenReturn(new PollResult(Iterators.emptyIterator(), 0, true))
-                .thenReturn(new PollResult(Iterators.emptyIterator(), 0, false));
+                .thenReturn(new PollResult(Collections.emptyIterator(), 0, true))
+                .thenReturn(new PollResult(Collections.emptyIterator(), 0, true))
+                .thenReturn(new PollResult(Collections.emptyIterator(), 0, false));
 
         _iterationRunnable.run();
 

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Date;

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
-import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Date;

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -39,6 +39,7 @@ import com.netflix.astyanax.serializers.UUIDSerializer;
 import com.netflix.astyanax.util.RangeBuilder;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
+import java.util.Collections;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -367,7 +368,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
                 // Channel was completely empty.  Cache a TimeUUID for the current time.  This will cause future calls
                 // to read at most 1 minute of tombstones until the cache expires 10 seconds later.
                 cacheOldestSlabForChannel(channel, TimeUUIDs.newUUID());
-                return Iterators.emptyIterator();
+                return Collections.emptyIterator();
             }
         }
     }

--- a/event/src/main/java/com/bazaarvoice/emodb/event/owner/OstrichOwnerGroup.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/owner/OstrichOwnerGroup.java
@@ -225,7 +225,7 @@ public class OstrichOwnerGroup<T extends Service> implements OwnerGroup<T> {
         });
         ServiceFailureListener.listenTo(leaderService, _metricRegistry);
         _dropwizardTask.register(taskName, leaderService);
-        leaderService.startAsync();
+        leaderService.startAsync().awaitRunning();
         return Optional.of(leaderService);
     }
 

--- a/event/src/main/java/com/bazaarvoice/emodb/event/owner/OstrichOwnerGroup.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/owner/OstrichOwnerGroup.java
@@ -233,7 +233,7 @@ public class OstrichOwnerGroup<T extends Service> implements OwnerGroup<T> {
         if (ref.isPresent()) {
             Service service = ref.get();
             _log.info("Stopping owned service {}: {}", _group, name);
-            service.stopAsync();
+            service.stopAsync().awaitTerminated();
         }
     }
 

--- a/event/src/main/java/com/bazaarvoice/emodb/event/owner/OstrichOwnerGroup.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/owner/OstrichOwnerGroup.java
@@ -225,7 +225,7 @@ public class OstrichOwnerGroup<T extends Service> implements OwnerGroup<T> {
         });
         ServiceFailureListener.listenTo(leaderService, _metricRegistry);
         _dropwizardTask.register(taskName, leaderService);
-        leaderService.start();
+        leaderService.startAsync();
         return Optional.of(leaderService);
     }
 
@@ -233,7 +233,7 @@ public class OstrichOwnerGroup<T extends Service> implements OwnerGroup<T> {
         if (ref.isPresent()) {
             Service service = ref.get();
             _log.info("Stopping owned service {}: {}", _group, name);
-            service.stop();
+            service.stopAsync();
         }
     }
 
@@ -247,7 +247,7 @@ public class OstrichOwnerGroup<T extends Service> implements OwnerGroup<T> {
             return false;
         }
         try {
-            service.start().get(waitMillis, TimeUnit.MILLISECONDS);
+            service.startAsync().awaitRunning(waitMillis, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
             // Fall through
         }

--- a/event/src/test/java/com/bazaarvoice/emodb/event/core/DedupQueueTest.java
+++ b/event/src/test/java/com/bazaarvoice/emodb/event/core/DedupQueueTest.java
@@ -37,7 +37,7 @@ public class DedupQueueTest {
         DedupQueue q = new DedupQueue("test-queue", "read", "write",
                 mock(QueueDAO.class), eventStore, Suppliers.ofInstance(true), mock(ScheduledExecutorService.class), getPersistentSortedQueueFactory(),
                 mock(MetricRegistry.class));
-        q.startAndWait();
+        q.startAsync().awaitRunning();
 
         // The first poll checks the read channel, find it empty, checks the write channel.
         q.poll(Duration.ofSeconds(30), new SimpleEventSink(10));
@@ -60,7 +60,7 @@ public class DedupQueueTest {
         DedupQueue q = new DedupQueue("test-queue", "read", "write",
                 mock(QueueDAO.class), eventStore, Suppliers.ofInstance(true), mock(ScheduledExecutorService.class), getPersistentSortedQueueFactory(),
                 mock(MetricRegistry.class));
-        q.startAndWait();
+        q.startAsync().awaitRunning();
 
         // The first peek checks the read channel, find it empty, checks the write channel.
         q.peek(new SimpleEventSink(10));

--- a/event/src/test/java/com/bazaarvoice/emodb/sortedq/core/InMemoryQueueDAO.java
+++ b/event/src/test/java/com/bazaarvoice/emodb/sortedq/core/InMemoryQueueDAO.java
@@ -101,7 +101,7 @@ public class InMemoryQueueDAO implements QueueDAO {
                                             int batchSize, int limit) {
         NavigableSet<ByteBuffer> segments = _records.get(dataId);
         if (segments == null) {
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
         }
 
         if (from != null) {

--- a/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/io/EmoFileSystem.java
+++ b/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/io/EmoFileSystem.java
@@ -15,9 +15,9 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import com.google.common.io.Closeables;
 import com.google.common.io.Closer;
+import java.util.Collections;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -312,7 +312,7 @@ public class EmoFileSystem extends FileSystem implements EmoInputSplittable {
         private EmoSplitInputStream(String table, String split)
                 throws IOException {
             if (isEmptySplit(split)) {
-                _rows = Iterators.emptyIterator();
+                _rows = Collections.emptyIterator();
             } else {
                 // Get the DataStore and begin streaming the split's rows.
                 CloseableDataStore dataStore = HadoopDataStoreManager.getInstance().getDataStore(_uri, _apiKey, _metricRegistry);

--- a/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/io/FileSystemUtil.java
+++ b/mapreduce/sor-hadoop/src/main/java/com/bazaarvoice/emodb/hadoop/io/FileSystemUtil.java
@@ -2,7 +2,7 @@ package com.bazaarvoice.emodb.hadoop.io;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Iterators;
+import java.util.Collections;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
@@ -149,7 +149,7 @@ public class FileSystemUtil {
             @Override
             protected Iterator<Map<String, Object>> getRowIterator()
                     throws IOException {
-                return Iterators.emptyIterator();
+                return Collections.emptyIterator();
             }
 
             @Override

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -30,7 +30,7 @@
         <curator.version>2.4.0</curator.version>
         <curator-extensions.version>1.4.1</curator-extensions.version>
         <dropwizard.version>0.7.1</dropwizard.version>
-        <guava.version>16.0.1</guava.version>
+        <guava.version>20.0</guava.version>
         <guice.version>4.0</guice.version>
         <jackson.version>2.4.5</jackson.version>
         <metrics.version>3.0.2</metrics.version>
@@ -43,7 +43,7 @@
         <jodatime-version>2.8.2</jodatime-version>
         <jersey.version>1.18.1</jersey.version>
         <jacoco.version>0.7.2.201409121644</jacoco.version>
-        <cassandra.driver.version>3.1.1</cassandra.driver.version>
+        <cassandra.driver.version>3.2.0</cassandra.driver.version>
         <dependency-check-maven.version>1.4.2</dependency-check-maven.version>
         <skipCC>true</skipCC>
         <nexus.autoReleaseAfterClose>true</nexus.autoReleaseAfterClose>

--- a/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
@@ -41,9 +41,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.io.InputSupplier;
 import com.sun.jersey.api.client.ClientResponse;
 import io.dropwizard.testing.junit.ResourceTestRule;
+import java.util.function.Supplier;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -680,17 +680,12 @@ public class BlobStoreJerseyTest extends ResourceTest {
 
     @Test
     public void testPut() throws IOException {
-        InputSupplier<InputStream> in = new InputSupplier<InputStream>() {
-            @Override
-            public InputStream getInput() throws IOException {
-                return new ByteArrayInputStream("blob-content".getBytes());
-            }
-        };
+        Supplier<InputStream> in = () -> new ByteArrayInputStream("blob-content".getBytes());
         Map<String, String> attributes = ImmutableMap.of("key", "value");
         blobClient().put("table-name", "blob-id", in, attributes, Duration.ofDays(30));
 
         //noinspection unchecked
-        verify(_server).put(eq("table-name"), eq("blob-id"), isA(InputSupplier.class), eq(attributes), eq(Duration.ofDays(30)));
+        verify(_server).put(eq("table-name"), eq("blob-id"), isA(Supplier.class), eq(attributes), eq(Duration.ofDays(30)));
         verifyNoMoreInteractions(_server);
     }
 

--- a/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/CasBlobStoreTest.java
@@ -52,7 +52,6 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.io.InputSupplier;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -262,12 +261,7 @@ public class CasBlobStoreTest {
 
     private void verifyPutAndGet(String blobId, final byte[] blobData, Map<String, String> attributes, @Nullable Duration ttl)
             throws IOException {
-        _store.put(TABLE, blobId, new InputSupplier<InputStream>() {
-            @Override
-            public InputStream getInput() throws IOException {
-                return new ByteArrayInputStream(blobData);
-            }
-        }, attributes, ttl);
+        _store.put(TABLE, blobId, () -> new ByteArrayInputStream(blobData), attributes, ttl);
 
         // verify that we can get what we put
         Blob blob = _store.get(TABLE, blobId);

--- a/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/databus/DatabusJerseyTest.java
@@ -43,7 +43,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
 import com.sun.jersey.api.client.GenericType;
 import com.sun.jersey.spi.inject.SingletonTypeInjectableProvider;
 import io.dropwizard.testing.junit.ResourceTestRule;
@@ -177,7 +176,7 @@ public class DatabusJerseyTest extends ResourceTest {
 
     @Test
     public void testListSubscriptions1() {
-        when(_local.listSubscriptions(isSubject(), isNull(String.class), eq(Long.MAX_VALUE))).thenReturn(Iterators.<Subscription>emptyIterator());
+        when(_local.listSubscriptions(isSubject(), isNull(String.class), eq(Long.MAX_VALUE))).thenReturn(Collections.emptyIterator());
 
         Iterator<Subscription> actual = databusClient().listSubscriptions(null, Long.MAX_VALUE);
 
@@ -550,7 +549,7 @@ public class DatabusJerseyTest extends ResourceTest {
                     new Event("id-2", ImmutableMap.of("key-2", "value-2"), ImmutableList.<List<String>>of(ImmutableList.<String>of("tag-2"))));
             //noinspection unchecked
             when(databus.poll(isSubject(), eq("queue-name"), eq(Duration.ofSeconds(10)), eq(100)))
-                    .thenReturn(new PollResult(Iterators.emptyIterator(), 0, false))
+                    .thenReturn(new PollResult(Collections.emptyIterator(), 0, false))
                     .thenReturn(new PollResult(pollResults.iterator(), 2, true));
 
             List<Event> expected;
@@ -649,7 +648,7 @@ public class DatabusJerseyTest extends ResourceTest {
 
             SubjectDatabus databus = mock(SubjectDatabus.class);
             when(databus.poll(isSubject(), eq("queue-name"), eq(Duration.ofSeconds(10)), eq(100)))
-                    .thenReturn(new PollResult(Iterators.emptyIterator(), 0, false))
+                    .thenReturn(new PollResult(Collections.emptyIterator(), 0, false))
                     .thenThrow(new RuntimeException("Simulated read failure from Cassandra"));
 
             final StringWriter out = new StringWriter();

--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -894,7 +894,7 @@ public class DataStoreJerseyTest extends ResourceTest {
         UUID startUuid = TimeUUIDs.uuidForTimestamp(start);
         UUID endUuid = TimeUUIDs.getPrevious(TimeUUIDs.uuidForTimeMillis(end.getTime() + 1));
         when(_server.getTimeline("table-name", "row-key", true, false, startUuid, endUuid, false, 10, ReadConsistency.STRONG))
-                .thenReturn(Iterators.<Change>emptyIterator());
+                .thenReturn(Collections.emptyIterator());
 
         DateTimeFormatter format = DateTimeFormatter.ISO_INSTANT;
         URI uri = UriBuilder.fromUri("/sor/1")
@@ -921,7 +921,7 @@ public class DataStoreJerseyTest extends ResourceTest {
         UUID startUuid = TimeUUIDs.getPrevious(TimeUUIDs.uuidForTimeMillis(start.getTime() + 1));
         UUID endUuid = TimeUUIDs.uuidForTimestamp(end);
         when(_server.getTimeline("table-name", "row-key", true, false, startUuid, endUuid, true, 10, ReadConsistency.STRONG))
-                .thenReturn(Iterators.<Change>emptyIterator());
+                .thenReturn(Collections.emptyIterator());
 
         DateTimeFormatter format = DateTimeFormatter.ISO_INSTANT;
         URI uri = UriBuilder.fromUri("/sor/1")

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/AbstractBatchReader.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/AbstractBatchReader.java
@@ -5,6 +5,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
@@ -26,8 +27,8 @@ abstract public class AbstractBatchReader<T> extends AbstractIterator<T> {
     // Amount to increment the next batch size until the maximum is achieved
     private final int _batchIncrementSize;
     private int _currentBatchSize;
-    private final Stopwatch _timer = new Stopwatch();
-    private Iterator<T> _batch = Iterators.emptyIterator();
+    private final Stopwatch _timer = Stopwatch.createUnstarted();
+    private Iterator<T> _batch = Collections.emptyIterator();
     // In the event of a timeout record the amount of time that elapsed before the timeout
     private long _lastTimeoutTime;
 
@@ -91,7 +92,7 @@ abstract public class AbstractBatchReader<T> extends AbstractIterator<T> {
     private boolean loadNextBatch() {
         if (!hasNextBatch()) {
             // No batches remaining to load
-            _batch = Iterators.emptyIterator();
+            _batch = Collections.emptyIterator();
             return true;
         }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
@@ -342,7 +342,7 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
             @Override
             public Iterator<AnnotatedContent> execute() {
                 if (_keys.isEmpty()) {
-                    return Iterators.emptyIterator();
+                    return Collections.emptyIterator();
                 }
                 // Limit memory usage using an iterator such that only one row's change list is in memory at a time.
                 Iterator<Record> recordIterator = _dataReaderDao.readAll(_keys, consistency);

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryHistoryStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryHistoryStore.java
@@ -6,11 +6,11 @@ import com.bazaarvoice.emodb.sor.api.History;
 import com.bazaarvoice.emodb.sor.core.HistoryBatchPersister;
 import com.bazaarvoice.emodb.sor.core.HistoryStore;
 import com.google.common.base.Function;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentMap;
@@ -24,7 +24,7 @@ public class InMemoryHistoryStore implements HistoryStore {
     public Iterator<Change> getDeltaHistories(String table, String rowId) {
         String key = getKey(table, rowId);
         if (!_historyStore.containsKey(key)) {
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
         }
         return Lists.transform(_historyStore.get(key), new Function<History, Change>() {
             @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
@@ -288,7 +288,7 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
         ByteBuffer rowKey = storage.getRowKey(key.getKey());
 
         // Read Delta and Compaction objects
-        Iterator<Change> deltas = Iterators.emptyIterator();
+        Iterator<Change> deltas = Collections.emptyIterator();
         if (includeContentData) {
             ColumnFamily<ByteBuffer, DeltaKey> cf = placement.getBlockedDeltaColumnFamily();
             DeltaKey deltaStart = start != null ? new DeltaKey(start, 0) : null;
@@ -298,7 +298,7 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
         }
 
         // Read History objects
-        Iterator<Change> deltaHistory = Iterators.emptyIterator();
+        Iterator<Change> deltaHistory = Collections.emptyIterator();
         ColumnFamily<ByteBuffer, UUID> deltaHistoryCf = placement.getDeltaHistoryColumnFamily();
         deltaHistory = decodeColumns(columnScan(rowKey, placement, deltaHistoryCf, start, end, reversed, _uuidInc, limit, 0, consistency));
 
@@ -474,7 +474,7 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
         ByteBufferRange keyRange = storage.getSplitRange(splitRange, fromKeyExclusive, split);
         // The fromKeyExclusive might be equal to the end token of the split.  If so, there's nothing to return.
         if (keyRange.getStart().equals(keyRange.getEnd())) {
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
         }
 
         // In contrast to the scan() method, scan a single range prefix (the one associated with this split).
@@ -783,7 +783,7 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
                 // around which is absolutely *not* what we want since it could return data for another table.
                 if (_done || BufferUtils.compareUnsigned(_rangeStart, _rangeEnd) >= 0) {
                     _done = true;
-                    return Iterators.emptyIterator();
+                    return Collections.emptyIterator();
                 }
 
                 Timer.Context timer = _scanBatchTimer.time();
@@ -1106,7 +1106,7 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
                     }
                 }
 
-                return Iterators.peekingIterator(Iterators.<Row<ByteBuffer, DeltaKey>>emptyIterator());
+                return Iterators.peekingIterator(Collections.emptyIterator());
             }
         });
     }
@@ -1149,9 +1149,9 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
 
     private Record emptyRecord(Key key) {
         return new RecordImpl(key,
-                Iterators.<Map.Entry<UUID, Compaction>>emptyIterator(),
-                Iterators.<Map.Entry<UUID, Change>>emptyIterator(),
-                Iterators.<RecordEntryRawMetadata>emptyIterator());
+                Collections.emptyIterator(),
+                Collections.emptyIterator(),
+                Collections.emptyIterator());
     }
 
     private Iterator<Change> decodeColumns(Iterator<Column<UUID>> iter) {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
@@ -287,14 +287,14 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
         ByteBuffer rowKey = storage.getRowKey(key.getKey());
 
         // Read Delta and Compaction objects
-        Iterator<Change> deltas = Iterators.emptyIterator();
+        Iterator<Change> deltas = Collections.emptyIterator();
         if (includeContentData) {
             ColumnFamily<ByteBuffer, UUID> cf = placement.getDeltaColumnFamily();
             deltas = decodeColumns(columnScan(rowKey, placement, cf, start, end, reversed, limit, 0, consistency));
         }
 
         // Read History objects
-        Iterator<Change> deltaHistory = Iterators.emptyIterator();
+        Iterator<Change> deltaHistory = Collections.emptyIterator();
         ColumnFamily<ByteBuffer, UUID> deltaHistoryCf = placement.getDeltaHistoryColumnFamily();
         deltaHistory = decodeColumns(columnScan(rowKey, placement, deltaHistoryCf, start, end, reversed, limit, 0, consistency));
 
@@ -470,7 +470,7 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
         ByteBufferRange keyRange = storage.getSplitRange(splitRange, fromKeyExclusive, split);
         // The fromKeyExclusive might be equal to the end token of the split.  If so, there's nothing to return.
         if (keyRange.getStart().equals(keyRange.getEnd())) {
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
         }
 
         // In contrast to the scan() method, scan a single range prefix (the one associated with this split).
@@ -832,7 +832,7 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
                 // around which is absolutely *not* what we want since it could return data for another table.
                 if (_done || BufferUtils.compareUnsigned(_rangeStart, _rangeEnd) >= 0) {
                     _done = true;
-                    return Iterators.emptyIterator();
+                    return Collections.emptyIterator();
                 }
 
                 Timer.Context timer = _scanBatchTimer.time();
@@ -1122,7 +1122,7 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
                     }
                 }
 
-                return Iterators.peekingIterator(Iterators.<Row<ByteBuffer, UUID>>emptyIterator());
+                return Iterators.peekingIterator(Collections.emptyIterator());
             }
         });
     }
@@ -1160,9 +1160,9 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
 
     private Record emptyRecord(Key key) {
         return new RecordImpl(key,
-                Iterators.<Map.Entry<UUID, Compaction>>emptyIterator(),
-                Iterators.<Map.Entry<UUID, Change>>emptyIterator(),
-                Iterators.<RecordEntryRawMetadata>emptyIterator());
+                Collections.emptyIterator(),
+                Collections.emptyIterator(),
+                Collections.emptyIterator());
     }
 
     private Iterator<Change> decodeColumns(Iterator<Column<UUID>> iter) {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
@@ -500,7 +500,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
         ByteBufferRange keyRange = storage.getSplitRange(splitRange, fromKeyExclusive, split);
         // The fromKeyExclusive might be equal to the end token of the split.  If so, there's nothing to return.
         if (keyRange.getStart().equals(keyRange.getEnd())) {
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
         }
 
         return recordScan(placement, table, keyRange, consistency);
@@ -674,7 +674,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
                     }
                 }
 
-                return Iterators.peekingIterator(Iterators.<Iterable<Row>>emptyIterator());
+                return Iterators.peekingIterator(Collections.emptyIterator());
             }
         });
     }
@@ -782,7 +782,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
         ConsistencyLevel consistency = SorConsistencies.toCql(readConsistency);
 
         // Read Delta and Compaction objects
-        Iterator<Change> deltas = Iterators.emptyIterator();
+        Iterator<Change> deltas = Collections.emptyIterator();
         if (includeContentData) {
             TableDDL deltaDDL = placement.getDeltaTableDDL();
             ProtocolVersion protocolVersion = placement.getKeyspace().getCqlSession().getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
@@ -792,7 +792,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
         }
 
         // Read History objects
-        Iterator<Change> deltaHistory = Iterators.emptyIterator();
+        Iterator<Change> deltaHistory = Collections.emptyIterator();
         TableDDL deltaHistoryDDL = placement.getDeltaHistoryTableDDL();
         deltaHistory = decodeColumns(Iterators.limit(columnScan(placement, deltaHistoryDDL, rowKey, columnRange, !reversed, consistency).iterator(), scaledLimit));
 
@@ -887,9 +887,9 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
      */
     private Record emptyRecord(Key key) {
         return new RecordImpl(key,
-                Iterators.<Map.Entry<UUID, Compaction>>emptyIterator(),
-                Iterators.<Map.Entry<UUID, Change>>emptyIterator(),
-                Iterators.<RecordEntryRawMetadata>emptyIterator());
+                Collections.emptyIterator(),
+                Collections.emptyIterator(),
+                Collections.emptyIterator());
     }
 
     @VisibleForTesting

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
@@ -519,7 +519,7 @@ public class CqlDataReaderDAO implements DataReaderDAO, MigratorReaderDAO {
         ByteBufferRange keyRange = storage.getSplitRange(splitRange, fromKeyExclusive, split);
         // The fromKeyExclusive might be equal to the end token of the split.  If so, there's nothing to return.
         if (keyRange.getStart().equals(keyRange.getEnd())) {
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
         }
 
         return recordScan(placement, table, keyRange, consistency);
@@ -693,7 +693,7 @@ public class CqlDataReaderDAO implements DataReaderDAO, MigratorReaderDAO {
                     }
                 }
 
-                return Iterators.peekingIterator(Iterators.<Iterable<Row>>emptyIterator());
+                return Iterators.peekingIterator(Collections.emptyIterator());
             }
         });
     }
@@ -802,14 +802,14 @@ public class CqlDataReaderDAO implements DataReaderDAO, MigratorReaderDAO {
         ConsistencyLevel consistency = SorConsistencies.toCql(readConsistency);
 
         // Read Delta and Compaction objects
-        Iterator<Change> deltas = Iterators.emptyIterator();
+        Iterator<Change> deltas = Collections.emptyIterator();
         if (includeContentData) {
             TableDDL deltaDDL = placement.getDeltaTableDDL();
             deltas = decodeColumns(columnScan(placement, deltaDDL, rowKey, columnRange, !reversed, scaledLimit, consistency).iterator());
         }
 
         // Read History objects
-        Iterator<Change> deltaHistory = Iterators.emptyIterator();
+        Iterator<Change> deltaHistory = Collections.emptyIterator();
         TableDDL deltaHistoryDDL = placement.getDeltaHistoryTableDDL();
         deltaHistory = decodeColumns(columnScan(placement, deltaHistoryDDL, rowKey, columnRange, !reversed, scaledLimit, consistency).iterator());
 
@@ -900,9 +900,9 @@ public class CqlDataReaderDAO implements DataReaderDAO, MigratorReaderDAO {
      */
     private Record emptyRecord(Key key) {
         return new RecordImpl(key,
-                Iterators.<Map.Entry<UUID, Compaction>>emptyIterator(),
-                Iterators.<Map.Entry<UUID, Change>>emptyIterator(),
-                Iterators.<RecordEntryRawMetadata>emptyIterator());
+                Collections.emptyIterator(),
+                Collections.emptyIterator(),
+                Collections.emptyIterator());
     }
 
     @VisibleForTesting

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
@@ -145,7 +145,7 @@ public class InMemoryDataReaderDAO implements DataReaderDAO, DataWriterDAO, Migr
 
     @Override
     public Iterator<Change> getExistingHistories(Key key, UUID start, UUID end, ReadConsistency consistency) {
-        return Iterators.emptyIterator();
+        return Collections.emptyIterator();
     }
 
     @Override
@@ -176,7 +176,7 @@ public class InMemoryDataReaderDAO implements DataReaderDAO, DataWriterDAO, Migr
     public Iterator<MultiTableScanResult> multiTableScan(MultiTableScanOptions query, TableSet tables, LimitCounter limit,
                                                          ReadConsistency consistency, @Nullable Instant cutoffTime) {
         // TODO:  Create a simulation for this method
-        return Iterators.emptyIterator();
+        return Collections.emptyIterator();
     }
 
     @Override

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiDCCompactionTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiDCCompactionTest.java
@@ -159,7 +159,7 @@ public class MultiDCCompactionTest {
         Record record = mock(Record.class);
         when(record.getKey()).thenReturn(key);
         when(record.passOneIterator()).thenReturn(compactions.iterator()).thenReturn(compactions.iterator());
-        when(record.passTwoIterator()).thenReturn(Iterators.emptyIterator()).thenReturn(Iterators.emptyIterator());
+        when(record.passTwoIterator()).thenReturn(Collections.emptyIterator()).thenReturn(Collections.emptyIterator());
 
         //noinspection unchecked
         Supplier<Record> requeryFn = mock(Supplier.class);

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/CQLStashTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/CQLStashTableDAO.java
@@ -18,6 +18,7 @@ import com.google.inject.Inject;
 import com.netflix.astyanax.model.ByteBufferRange;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -156,7 +157,7 @@ public class CQLStashTableDAO {
         Row row = resultSet.one();
 
         if (row == null) {
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
         }
 
         TableJson tableJson = toTableJson(row.getString(0));

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/consistency/HintsPollerManager.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/consistency/HintsPollerManager.java
@@ -64,8 +64,7 @@ public class HintsPollerManager implements Managed {
             throws Exception {
         _leaderServiceList = getLeaderServices(_timestampCache, _curator, _self, _cqlSessionForHintsPollerMap, _clusterHintsPoller, _dropwizardTask, _metricRegistry);
         for (LeaderService leaderService : _leaderServiceList) {
-            leaderService.startAsync();
-            leaderService.awaitRunning();
+            leaderService.startAsync().awaitRunning();
         }
     }
 
@@ -73,8 +72,7 @@ public class HintsPollerManager implements Managed {
     public void stop()
             throws Exception {
         for (LeaderService leaderService : _leaderServiceList) {
-            leaderService.stopAsync();
-            leaderService.awaitTerminated();
+            leaderService.stopAsync().awaitTerminated();
         }
     }
 

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/consistency/HintsPollerService.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/consistency/HintsPollerService.java
@@ -63,7 +63,7 @@ public class HintsPollerService extends AbstractScheduledService {
             pollForHints();
         } catch (Throwable t) {
             _log.error("Unexpected HintsPoller exception for Cassandra cluster {}.", _clusterName, t);
-            stopAsync().awaitTerminated();  // Give up leadership temporarily.  Maybe another server will have more success.
+            stopAsync();  // Give up leadership temporarily.  Maybe another server will have more success.
         }
     }
 

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/consistency/HintsPollerService.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/consistency/HintsPollerService.java
@@ -63,7 +63,7 @@ public class HintsPollerService extends AbstractScheduledService {
             pollForHints();
         } catch (Throwable t) {
             _log.error("Unexpected HintsPoller exception for Cassandra cluster {}.", _clusterName, t);
-            stopAsync();  // Give up leadership temporarily.  Maybe another server will have more success.
+            stopAsync().awaitTerminated();  // Give up leadership temporarily.  Maybe another server will have more success.
         }
     }
 

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/consistency/HintsPollerService.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/consistency/HintsPollerService.java
@@ -63,7 +63,7 @@ public class HintsPollerService extends AbstractScheduledService {
             pollForHints();
         } catch (Throwable t) {
             _log.error("Unexpected HintsPoller exception for Cassandra cluster {}.", _clusterName, t);
-            stop();  // Give up leadership temporarily.  Maybe another server will have more success.
+            stopAsync();  // Give up leadership temporarily.  Maybe another server will have more success.
         }
     }
 

--- a/table/src/test/java/com/bazaarvoice/emodb/table/db/consistency/ClusterHintsPollerTest.java
+++ b/table/src/test/java/com/bazaarvoice/emodb/table/db/consistency/ClusterHintsPollerTest.java
@@ -15,8 +15,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import java.util.Collections;
 import org.hamcrest.Description;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
@@ -173,11 +173,11 @@ public class ClusterHintsPollerTest {
 
         // Mock node 1 ResultSets
         ResultSet targetIdQueryNode1 = mock(ResultSet.class);
-        when(targetIdQueryNode1.iterator()).thenReturn(Iterators.<Row>emptyIterator());
+        when(targetIdQueryNode1.iterator()).thenReturn(Collections.emptyIterator());
 
         // Mock node 2 ResultSets
         ResultSet targetIdQueryNode2 = mock(ResultSet.class);
-        when(targetIdQueryNode2.iterator()).thenReturn(Iterators.<Row>emptyIterator());
+        when(targetIdQueryNode2.iterator()).thenReturn(Collections.emptyIterator());
 
         // The following line mocks all the results we will get back from our CQL queries
         doReturn(targetIdQueryNode1).when(mockSession).execute(argThat(getHostStatementMatcher(node1,
@@ -231,7 +231,7 @@ public class ClusterHintsPollerTest {
 
         // Mock node 1 ResultSets
         ResultSet targetIdQueryNode1 = mock(ResultSet.class);
-        when(targetIdQueryNode1.iterator()).thenReturn(Iterators.<Row>emptyIterator());
+        when(targetIdQueryNode1.iterator()).thenReturn(Collections.emptyIterator());
 
         // Mock node 2 ResultSets
         ResultSet targetIdQueryNode2 = mock(ResultSet.class);

--- a/web/src/main/java/com/bazaarvoice/emodb/web/report/db/EmoTableAllTablesReportDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/report/db/EmoTableAllTablesReportDAO.java
@@ -272,7 +272,7 @@ public class EmoTableAllTablesReportDAO implements AllTablesReportDAO {
 
         return new AbstractIterator<Map<String, Object>>() {
             private String _from = query.getFromTable();
-            private Iterator<Map<String, Object>> _batch = Iterators.emptyIterator();
+            private Iterator<Map<String, Object>> _batch = Collections.emptyIterator();
             private long _limit = 0;
 
             @Override

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
@@ -24,12 +24,12 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.PeekingIterator;
-import com.google.common.io.InputSupplier;
 import com.sun.jersey.api.client.ClientResponse;
 import io.dropwizard.jersey.params.AbstractParam;
 import io.dropwizard.jersey.params.LongParam;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import java.util.function.Supplier;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
@@ -459,16 +459,13 @@ public class BlobStoreResource1 {
      * Returns an InputSupplier that throws an exception if the caller attempts to consume the input stream
      * multiple times.
      */
-    private InputSupplier<InputStream> onceOnlySupplier(final InputStream in) {
+    private Supplier<InputStream> onceOnlySupplier(final InputStream in) {
         final AtomicBoolean once = new AtomicBoolean();
-        return new InputSupplier<InputStream>() {
-            @Override
-            public InputStream getInput() throws IOException {
-                if (!once.compareAndSet(false, true)) {
-                    throw new IllegalStateException("Input stream may be consumed only once per BlobStore call.");
-                }
-                return in;
+        return () -> {
+            if (!once.compareAndSet(false, true)) {
+                throw new IllegalStateException("Input stream may be consumed only once per BlobStore call.");
             }
+            return in;
         };
     }
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResourcePoller.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusResourcePoller.java
@@ -9,8 +9,8 @@ import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
-import com.google.common.collect.Iterators;
 import com.google.inject.Inject;
+import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,7 +139,7 @@ public class DatabusResourcePoller {
                         // We're in an async context and have already returned a 200 response.  Since we can't
                         // retroactively change to 500 finish the request with an empty response and log the error.
                         _log.error("Failed to perform asynchronous poll on subscription {}", _subscription, e);
-                        result = new PollResult(Iterators.emptyIterator(), 0, false);
+                        result = new PollResult(Collections.emptyIterator(), 0, false);
                         pollFailed = true;
                     }
 


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

The next Ostrich release is upgrading its Guava to 20.0. In order to avoid having to use the shaded version and having essentially two versions of Guava in our classpath, we should upgrade Emo to 20.0.

Note: This PR also are Cassandra java driver to a version compatible with Guava 20.0.

## How to Test and Verify

This is difficult to test and verify outside of running gatekeeper for regression purposes, as Emo should behave exactly as before.

## Risk

### Level 

`Medium`

### Required Testing

`Regression`

### Risk Summary

Emo still uses several dependencies, such as Dropwizard 7, that call for older versions of Guava. It is theoretically possible that they could interact with the newer version in unpredictable ways.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
