### PR TITLE
Change default compaction settings for manifest tables

### DIFF
--- a/web/src/main/resources/ddl/databus/tables.template.cql
+++ b/web/src/main/resources/ddl/databus/tables.template.cql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS manifest (
   PRIMARY KEY (subscription, slabid)
 ) WITH COMPACT STORAGE
   AND gc_grace_seconds = 0
-  AND compaction={'sstable_size_in_mb': '160', 'class': 'LeveledCompactionStrategy'}
+  AND compaction={'sstable_size_in_mb': '40', 'tombstone_compaction_interval': '14400', 'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
   AND compression = {'sstable_compression': ''};
 
 -- One row per slabId.  Each "slab" contains a list of events, one event per column.  The application imposes a maximum

--- a/web/src/main/resources/ddl/queue/tables.template.cql
+++ b/web/src/main/resources/ddl/queue/tables.template.cql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS manifest (
   PRIMARY KEY (queue, slabid)
 ) WITH COMPACT STORAGE
   AND gc_grace_seconds = 0
-  AND compaction={'sstable_size_in_mb': '160', 'class': 'LeveledCompactionStrategy'}
+  AND compaction={'sstable_size_in_mb': '40', 'tombstone_compaction_interval': '14400', 'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'}
   AND compression = {'sstable_compression': ''};
 
 -- One row per slabId.  Each "slab" contains a list of messages, one message per column.  The application imposes a


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

We have noticed that Emo's manifest tables perform much better with smaller SSTable sizes and a faster tomstone compaction interval. This PR is modifies Emo's CQL templates to reflect more efficient compaction settings.

## How to Test and Verify

1. Start up Emo locally
2. Use cqlsh to confirm that the manifest tables were created with the new compaction settings

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

There is extremely little risk here. In fact, this change won't even be capable of affecting existing clusters, as the tables already exist.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
