### PR TITLE
Changed manifest read guarantees

### DIFF
--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventWriterDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventWriterDAO.java
@@ -153,7 +153,7 @@ public class AstyanaxEventWriterDAO implements EventWriterDAO {
 
             void run() {
                 _manifestRow = update.updateRow(ColumnFamilies.MANIFEST, channel);
-                _eventReaderDAO.readAll(channel, this, this);
+                _eventReaderDAO.readAll(channel, this, this, false);
             }
 
             // SlabFilter interface, called before scanning events in a slab.


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

The EmoDB team recently checked in an update to read the databus manifest table with CL local_quorum instead of 1.  While this provides stronger guarantees in practice it generated more load than expected on the Cassandra databus servers.

This PR attempts to find a balance between the two methods.  It uses the original fast CL1 reads for most peeks and polls but after at most 10 seconds will always to a local_quorum read to ensure all manifest slabs are eventually returned.

## How to Test and Verify

Regression test to ensure peek and poll behave as expected.

## Risk

Low.  At worst this PR changes EmoDB back to a configuration it had been using for a long time prior to the recent change.

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
