### PR TITLE
Make delta migrator pause when the cluster is not fully healthy

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultMigratorTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultMigratorTools.java
@@ -4,6 +4,9 @@ import com.bazaarvoice.emodb.sor.db.MigrationScanResult;
 import com.bazaarvoice.emodb.sor.db.MigratorReaderDAO;
 import com.bazaarvoice.emodb.sor.db.MigratorWriterDAO;
 import com.bazaarvoice.emodb.sor.db.ScanRange;
+import com.bazaarvoice.emodb.table.db.astyanax.FullConsistencyTimeProvider;
+import com.bazaarvoice.emodb.table.db.astyanax.PlacementCache;
+import com.bazaarvoice.emodb.table.db.consistency.HintsConsistencyTimeProvider;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
 
@@ -15,11 +18,16 @@ public class DefaultMigratorTools implements MigratorTools {
 
     private final MigratorReaderDAO _migratorReaderDao;
     private final MigratorWriterDAO _migratorWriterDao;
+    private final FullConsistencyTimeProvider _fullConsistencyTimeProvider;
+    private final PlacementCache _placementCache;
 
     @Inject
-    public DefaultMigratorTools(MigratorReaderDAO migratorReaderDAO, MigratorWriterDAO migratorWriterDAO) {
+    public DefaultMigratorTools(MigratorReaderDAO migratorReaderDAO, MigratorWriterDAO migratorWriterDAO,
+                                HintsConsistencyTimeProvider fullConsistencyTimeProvider, PlacementCache placementCache) {
         _migratorReaderDao = checkNotNull(migratorReaderDAO, "migratorReaderDao");
         _migratorWriterDao = checkNotNull(migratorWriterDAO, "migratorWriterDao");
+        _fullConsistencyTimeProvider = checkNotNull(fullConsistencyTimeProvider, "fullConsistencyTimeProvider");
+        _placementCache = checkNotNull(placementCache, "placementCache");
     }
 
     @Override
@@ -36,4 +44,8 @@ public class DefaultMigratorTools implements MigratorTools {
         return _migratorReaderDao.readRows(placement, scanRange);
     }
 
+    @Override
+    public long getFullConsistencyTimestamp(String placement) {
+        return _fullConsistencyTimeProvider.getMaxTimeStamp(_placementCache.get(placement).getKeyspace().getClusterName());
+    }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MigratorTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MigratorTools.java
@@ -7,10 +7,12 @@ import com.google.common.util.concurrent.RateLimiter;
 
 import java.util.Iterator;
 
-// interface to migrate deltas from old tables to new tables with blocking
+// Interface to migrate deltas from old tables to new tables with blocking
 public interface MigratorTools {
 
     void writeRows(String placement, Iterator<MigrationScanResult> results, RateLimiter rateLimiter);
 
     Iterator<MigrationScanResult> readRows(String placement, ScanRange scanRange);
+
+    long getFullConsistencyTimestamp(String placement);
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DistributedMigratorRangeMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/DistributedMigratorRangeMonitor.java
@@ -288,6 +288,11 @@ public class DistributedMigratorRangeMonitor implements Managed {
                 return true;
             }
 
+            while (!_rangeMigrator.isCapableOfMigrating(placement)) {
+                _log.warn("FCL is too high. Delta migration will block until it comes down.");
+                Thread.sleep(60 * 1000);
+            }
+
             _log.info("Started migration range task: {}", task);
 
             _statusDAO.setMigratorRangeTaskActive(migrationId, taskId, new Date());


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Running the delta migrator can be unsafe to rest to Emo if Cassandra is not fully healthy. For example, if a single node is down, then the migrator can lead to millions and millions of hints building up the rest of the healthy nodes, which can make them unhealthy. Additionally, this hint buildup can cause FCL to take a prohibitively long to come back down after the cluster becomes healthy again.

This PR modifies the migrator stop migrating whenever FCL becomes greater than 10 minutes, and resume once the cluster becomes healthy again.

## How to Test and Verify

1. Check out this PR
2. Run the migrator using `start-migrator-role.sh`
3. Set full consistency far into the past using `curl -s -XPOST 'http://localhost:8081/tasks/sor-compaction-timestamp?all=2013-10-24T13:08:41.882Z'`
3. Start a migration using `curl -XPOST localhost:8082/migrator/1/migrate/ugc_global:ugc`
4. Confirm that the migration is not completing do to increased full consistency lag.
5. Within 5 minutes, the hints poller will run again and set FCL back to 5 minutes.
6. Observe that migration then resumes and competes sucessfully.

## Risk

### Level 

`Low`

### Required Testing

The only risk here is that does not pause when it is supposed to for some reason, which is: 
1. Highly unlikely to the the small complexity of the modification
2. Not a worse outcome than how the migrator currently behaves.

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
