### PR TITLE
Modify migrator to only scan live token ranges

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -184,6 +184,10 @@ public class DataStoreModule extends PrivateModule {
             bind(CQLStashTableDAO.class).asEagerSingleton();
             bind(StashTableDAO.class).to(AstyanaxTableDAO.class).asEagerSingleton();
             expose(StashTableDAO.class);
+        } else if (_serviceMode.specifies(EmoServiceMode.Aspect.delta_migrator)) {
+            bind(CQLStashTableDAO.class).to(CqlMigratorTableDAO.class).asEagerSingleton();
+            bind(StashTableDAO.class).to(AstyanaxTableDAO.class).asEagerSingleton();
+            expose(StashTableDAO.class);
         }
 
         // The system of record requires two bootstrap tables in which it stores its metadata about tables.
@@ -246,8 +250,10 @@ public class DataStoreModule extends PrivateModule {
         bind(GracefulShutdownManager.class).asEagerSingleton();
 
         // Tools for migration to blocked deltas
-        bind(MigratorTools.class).to(DefaultMigratorTools.class);
-        expose(MigratorTools.class);
+        if (_serviceMode.specifies(EmoServiceMode.Aspect.delta_migrator)) {
+            bind(MigratorTools.class).to(DefaultMigratorTools.class);
+            expose(MigratorTools.class);
+        }
     }
 
     @Provides @Singleton
@@ -427,6 +433,10 @@ public class DataStoreModule extends PrivateModule {
 
     @Provides @Singleton @StashBlackListTableCondition
     protected Condition provideStashBlackListTableCondition(DataStoreConfiguration configuration) {
+        if (_serviceMode.specifies(EmoServiceMode.Aspect.delta_migrator)) {
+            return Conditions.alwaysFalse();
+        }
+
         return configuration.getStashBlackListTableCondition()
                 .transform(Conditions::fromString)
                 .or(Conditions.alwaysFalse());

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultMigratorTools.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultMigratorTools.java
@@ -1,16 +1,22 @@
 package com.bazaarvoice.emodb.sor.core;
 
+import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.db.MigrationScanResult;
 import com.bazaarvoice.emodb.sor.db.MigratorReaderDAO;
 import com.bazaarvoice.emodb.sor.db.MigratorWriterDAO;
 import com.bazaarvoice.emodb.sor.db.ScanRange;
+import com.bazaarvoice.emodb.table.db.StashTableDAO;
 import com.bazaarvoice.emodb.table.db.astyanax.FullConsistencyTimeProvider;
 import com.bazaarvoice.emodb.table.db.astyanax.PlacementCache;
 import com.bazaarvoice.emodb.table.db.consistency.HintsConsistencyTimeProvider;
+import com.bazaarvoice.emodb.table.db.stash.StashTokenRange;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.inject.Inject;
 
 import java.util.Iterator;
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -20,14 +26,17 @@ public class DefaultMigratorTools implements MigratorTools {
     private final MigratorWriterDAO _migratorWriterDao;
     private final FullConsistencyTimeProvider _fullConsistencyTimeProvider;
     private final PlacementCache _placementCache;
+    private final StashTableDAO _stashTableDao;
 
     @Inject
     public DefaultMigratorTools(MigratorReaderDAO migratorReaderDAO, MigratorWriterDAO migratorWriterDAO,
-                                HintsConsistencyTimeProvider fullConsistencyTimeProvider, PlacementCache placementCache) {
+                                HintsConsistencyTimeProvider fullConsistencyTimeProvider, PlacementCache placementCache,
+                                StashTableDAO stashTableDAO) {
         _migratorReaderDao = checkNotNull(migratorReaderDAO, "migratorReaderDao");
         _migratorWriterDao = checkNotNull(migratorWriterDAO, "migratorWriterDao");
         _fullConsistencyTimeProvider = checkNotNull(fullConsistencyTimeProvider, "fullConsistencyTimeProvider");
         _placementCache = checkNotNull(placementCache, "placementCache");
+        _stashTableDao = checkNotNull(stashTableDAO, "stashTableDao");
     }
 
     @Override
@@ -40,8 +49,21 @@ public class DefaultMigratorTools implements MigratorTools {
     @Override
     public Iterator<MigrationScanResult> readRows(String placement, ScanRange scanRange) {
         checkNotNull(placement, "placement");
-        checkNotNull(scanRange, scanRange);
-        return _migratorReaderDao.readRows(placement, scanRange);
+        checkNotNull(scanRange, "scanRange");
+
+        // Since the range may wrap from high to low end of the token range we need to unwrap it
+        List<ScanRange> unwrappedRanges = scanRange.unwrapped();
+
+        Iterator<StashTokenRange> tokenRanges = Iterators.concat(
+                Iterators.transform(
+                        unwrappedRanges.iterator(),
+                        unwrappedRange -> _stashTableDao.getStashTokenRangesFromSnapshot(placement, placement, unwrappedRange.getFrom(), unwrappedRange.getTo())));
+
+        return Iterators.concat(
+                Iterators.transform(tokenRanges, tokenRange ->
+                        _migratorReaderDao.readRows(placement, ScanRange.create(tokenRange.getFrom(), tokenRange.getTo()))
+                )
+        );
     }
 
     @Override

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/CQLStashTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/CQLStashTableDAO.java
@@ -40,10 +40,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class CQLStashTableDAO {
     
-    private final static String STASH_TOKEN_RANGE_TABLE = "stash_token_range";
+    protected String STASH_TOKEN_RANGE_TABLE = "stash_token_range";
     // Clean up stash tables if they aren't explicitly cleaned after 3 days.  No Stash should take over 1 day
     // so this should provide ample buffer.
-    private final static int TTL = (int) TimeUnit.DAYS.toSeconds(3);
+    protected int TTL = (int) TimeUnit.DAYS.toSeconds(3);
 
     private final static String STASH_ID_COLUMN = "stash_id";
     private final static String DATA_CENTER_COLUMN = "data_center";

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/CqlMigratorTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/CqlMigratorTableDAO.java
@@ -1,0 +1,20 @@
+package com.bazaarvoice.emodb.table.db.astyanax;
+
+import com.bazaarvoice.emodb.common.dropwizard.guice.SystemTablePlacement;
+import com.bazaarvoice.emodb.datacenter.api.DataCenters;
+import com.google.inject.Inject;
+
+/**
+ * A near identical implementation of {@link CQLStashTableDAO} used by the migrator. The only difference between the two
+ * is that this version uses a different Cassandra table and disables TTL.
+ */
+public class CqlMigratorTableDAO extends CQLStashTableDAO {
+
+    @Inject
+    public CqlMigratorTableDAO(@SystemTablePlacement String systemTablePlacement,
+                            PlacementCache placementCache, DataCenters dataCenters) {
+        super(systemTablePlacement, placementCache, dataCenters);
+        STASH_TOKEN_RANGE_TABLE = "migrator_token_range";
+        TTL = 0;
+    }
+}

--- a/web-local/pom.xml
+++ b/web-local/pom.xml
@@ -402,6 +402,8 @@
                                         <argument>${project.basedir}/config-migrator.yaml</argument>
                                         <argument>${project.basedir}/config-ddl-local.yaml</argument>
                                         <argument>-z</argument>
+                                        <argument>-p</argument>
+                                        <argument>${permissions.file}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatus.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/migrator/migratorstatus/MigratorStatus.java
@@ -15,23 +15,24 @@ public class MigratorStatus extends ScanStatus {
     private int _maxWritesPerSecond;
 
     public MigratorStatus(ScanStatus scanStatus, int maxWritesPerSecond) {
-        this(scanStatus.getScanId(), scanStatus.getOptions(), scanStatus.isCanceled(),
-                scanStatus.getStartTime(), scanStatus.getPendingScanRanges(),
+        this(scanStatus.getScanId(), scanStatus.getOptions(), scanStatus.isTableSnapshotCreated(),
+                scanStatus.isCanceled(), scanStatus.getStartTime(), scanStatus.getPendingScanRanges(),
                 scanStatus.getActiveScanRanges(), scanStatus.getCompleteScanRanges(),
                 scanStatus.getCompleteTime(), maxWritesPerSecond);
     }
 
     @JsonCreator
     public MigratorStatus(@JsonProperty ("scanId") String scanId,
-                      @JsonProperty ("options") ScanOptions options,
-                      @JsonProperty ("canceled") boolean canceled,
-                      @JsonProperty ("startTime") Date startTime,
-                      @JsonProperty ("pendingScanRanges") List<ScanRangeStatus> pendingMigrationRanges,
-                      @JsonProperty ("activeScanRanges") List<ScanRangeStatus> activeMigrationRanges,
-                      @JsonProperty ("completeScanRanges") List<ScanRangeStatus> completeMigrationRanges,
-                      @JsonProperty ("completeTime") @Nullable Date completeTime,
-                      @JsonProperty ("maxWritesPerSecond") int maxWritesPerSecond) {
-        super(scanId, options, false, canceled, startTime, pendingMigrationRanges, activeMigrationRanges, completeMigrationRanges, completeTime);
+                          @JsonProperty ("options") ScanOptions options,
+                          @JsonProperty ("tableSnapshotCreated") boolean tableSnapshotCreated,
+                          @JsonProperty ("canceled") boolean canceled,
+                          @JsonProperty ("startTime") Date startTime,
+                          @JsonProperty ("pendingScanRanges") List<ScanRangeStatus> pendingMigrationRanges,
+                          @JsonProperty ("activeScanRanges") List<ScanRangeStatus> activeMigrationRanges,
+                          @JsonProperty ("completeScanRanges") List<ScanRangeStatus> completeMigrationRanges,
+                          @JsonProperty ("completeTime") @Nullable Date completeTime,
+                          @JsonProperty ("maxWritesPerSecond") int maxWritesPerSecond) {
+        super(scanId, options, tableSnapshotCreated, canceled, startTime, pendingMigrationRanges, activeMigrationRanges, completeMigrationRanges, completeTime);
         _maxWritesPerSecond = maxWritesPerSecond;
     }
 


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

During testing of the delta migration, it was observed that the migrator can get stuck on token ranges with too many tombstones. This is presumably do to purged tables. 

This PR modifies the migrator to only scan live toke ranges.

## How to Test and Verify

1. Check out this PR
2. Load some data into Emp
2. Run `./start-migrator-role.sh`
3. Start a migration through the migrator resource
4. Confirm that all data was migrated using count queries in cqlsh

## Risk

### Level 

`Medium`

### Required Testing

`Manual`

### Risk Summary

If this is implemented incorrectly, the migrator could potentially miss data.

We will mitigate this risk by running stashes on both delta tables after migration and ensuring that data isn't missing.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
