### PR TITLE
EMO-6788: Added document partitioning condition

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -341,7 +341,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
         checkNotNull(tableFilter, "tableFilter");
         checkArgument(subscriptionTtl.compareTo(Duration.ZERO) > 0, "SubscriptionTtl must be >0");
         checkArgument(eventTtl.compareTo(Duration.ZERO) > 0, "EventTtl must be >0");
-        TableFilterValidator.checkAllowed(tableFilter);
+        SubscriptionConditionValidator.checkAllowed(tableFilter);
 
         if (includeDefaultJoinFilter) {
             // If the default join filter condition is set (that is, isn't "alwaysTrue()") then add it to the filter

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionConditionValidator.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionConditionValidator.java
@@ -7,6 +7,7 @@ import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 import com.bazaarvoice.emodb.sor.condition.ConstantCondition;
 import com.bazaarvoice.emodb.sor.condition.ContainsCondition;
+import com.bazaarvoice.emodb.sor.condition.PartitionCondition;
 import com.bazaarvoice.emodb.sor.condition.EqualCondition;
 import com.bazaarvoice.emodb.sor.condition.InCondition;
 import com.bazaarvoice.emodb.sor.condition.IntrinsicCondition;
@@ -19,16 +20,16 @@ import com.bazaarvoice.emodb.sor.condition.OrCondition;
 import javax.annotation.Nullable;
 import java.util.Collection;
 
-class TableFilterValidator implements ConditionVisitor<Void, Void> {
+class SubscriptionConditionValidator implements ConditionVisitor<Void, Void> {
 
     /**
      * @throws IllegalArgumentException if the condition performs checks that are not allowed against table metadata.
      */
     static void checkAllowed(Condition condition) {
-        condition.visit(new TableFilterValidator(), null);
+        condition.visit(new SubscriptionConditionValidator(), null);
     }
 
-    private TableFilterValidator() {}
+    private SubscriptionConditionValidator() {}
 
     public Void visit(ConstantCondition condition, Void context) {
         return null;
@@ -51,9 +52,11 @@ class TableFilterValidator implements ConditionVisitor<Void, Void> {
     }
 
     public Void visit(IntrinsicCondition condition, Void context) {
-        // The only supported intrinsic is "~table" and "~placement".  None of the others can be evaluated from just table metadata.
-        // This check should match the implementation of TableFilterIntrinsics.java.
-        if (!Intrinsic.TABLE.equals(condition.getName()) && !Intrinsic.PLACEMENT.equals(condition.getName())) {
+        // The only supported intrinsics are "~table", "~placement" and "~id".  None of the others can be evaluated from
+        // metadata available during fanout.  This check should match the implementation of SubscriptionIntrinsics.java.
+        if (!Intrinsic.TABLE.equals(condition.getName()) &&
+                !Intrinsic.PLACEMENT.equals(condition.getName()) &&
+                !Intrinsic.ID.equals(condition.getName())) {
             throw new IllegalArgumentException("Intrinsic '" + condition.getName() + "' is not supported within table filters.");
         }
         condition.getCondition().visit(this, null);
@@ -83,7 +86,11 @@ class TableFilterValidator implements ConditionVisitor<Void, Void> {
     public Void visit(MapCondition condition, Void context) {
         return visitAll(condition.getEntries().values());
     }
-    
+
+    public Void visit(PartitionCondition condition, @Nullable Void context) {
+        return condition.getCondition().visit(this, null);
+    }
+
     private Void visitAll(Collection<Condition> conditions) {
         for (Condition condition : conditions) {
             condition.visit(this, null);

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
@@ -68,7 +68,7 @@ public class SubscriptionEvaluator {
                 json = Maps.newHashMap(table.getAttributes());
                 json.put(UpdateRef.TAGS_NAME, eventData.getTags());
             }
-            return ConditionEvaluator.eval(subscription.getTableFilter(), json, new TableFilterIntrinsics(table)) &&
+            return ConditionEvaluator.eval(subscription.getTableFilter(), json, new SubscriptionIntrinsics(table, eventData.getKey())) &&
                     subscriberHasPermission(subscription, table);
         } catch (Exception e) {
             _rateLimitedLog.error(e, "Unable to evaluate condition for subscription " + subscription.getName() +

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionIntrinsics.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionIntrinsics.java
@@ -1,0 +1,23 @@
+package com.bazaarvoice.emodb.databus.core;
+
+import com.bazaarvoice.emodb.table.db.Table;
+import com.bazaarvoice.emodb.table.db.TableFilterIntrinsics;
+
+/**
+ * Intrinsics for evaluation during fanout to subscribers.  Only intrinsics available during fanout -- table, placement,
+ * and id -- are supported.
+ */
+public class SubscriptionIntrinsics extends TableFilterIntrinsics {
+
+    private final String _key;
+
+    public SubscriptionIntrinsics(Table table, String key) {
+        super(table);
+        _key = key;
+    }
+
+    @Override
+    public String getId() {
+        return _key;
+    }
+}

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/ConditionVisitor.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/ConditionVisitor.java
@@ -39,4 +39,7 @@ public interface ConditionVisitor<T, V> {
 
     @Nullable
     V visit(MapCondition condition, @Nullable T context);
+
+    @Nullable
+    V visit(PartitionCondition condition, @Nullable T context);
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/Conditions.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/Conditions.java
@@ -11,6 +11,7 @@ import com.bazaarvoice.emodb.sor.condition.impl.LikeConditionImpl;
 import com.bazaarvoice.emodb.sor.condition.impl.MapConditionBuilderImpl;
 import com.bazaarvoice.emodb.sor.condition.impl.NotConditionImpl;
 import com.bazaarvoice.emodb.sor.condition.impl.OrConditionBuilderImpl;
+import com.bazaarvoice.emodb.sor.condition.impl.PartitionConditionImpl;
 import com.bazaarvoice.emodb.sor.delta.deser.DeltaParser;
 import com.bazaarvoice.emodb.sor.delta.impl.ContainsConditionImpl;
 import com.google.common.collect.Sets;
@@ -201,5 +202,17 @@ public abstract class Conditions {
 
     public static MapConditionBuilder mapBuilder() {
         return new MapConditionBuilderImpl();
+    }
+
+    public static Condition partition(int numPartitions, int partition) {
+        return partition(numPartitions, equal(partition));
+    }
+
+    public static Condition partition(int numPartitions, int... partitions) {
+        return partition(numPartitions, in(Arrays.asList(partitions)));
+    }
+
+    public static Condition partition(int numPartitions, Condition condition) {
+        return new PartitionConditionImpl(numPartitions, condition);
     }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/PartitionCondition.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/PartitionCondition.java
@@ -1,0 +1,40 @@
+package com.bazaarvoice.emodb.sor.condition;
+
+/**
+ * Condition to explicitly partition the events based on a hash of the document ID.  The condition takes two parameters:
+ *
+ * <ol>
+ *     <li>The total number of partitions</li>
+ *     <li>A condition which tests whether the partition for the current document is a match</li>
+ * </ol>
+ *
+ * For example, the following two conditions should roughly split all matching documents between them:
+ *
+ * <code>
+ *     and({..,"type":"review"},partition(2:1))
+ *     and({..,"type":"review"},partition(2:2))
+ * </code>
+ *
+ * Note that partitions are 1-based and so for a number of partitions <code>p</code> the possible matching conditions
+ * are the integers in <code>[1..p]</code>.  There are some checks preventing the client from providing invalid
+ * conditions but these are non-exhaustive and do not cover meaningless conditions.  For example, the following
+ * conditions will result no matches:
+ *
+ * <code>
+ *     partition(4: ge(5))
+ *     partition(4: and(1,2))
+ * </code>
+ */
+public interface PartitionCondition extends Condition {
+
+    /**
+     * Total number of partitions.  Must be a positive integer.
+     */
+    int getNumPartitions();
+
+    /**
+     * Condition to evaluate whether the partition for the current document matches.  Most commonly this will be
+     * a simple equality condition such as <code>eq(1)</code> which can be shortened to just <code>1</code>.
+     */
+    Condition getCondition();
+}

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/eval/InverseEvaluator.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/eval/InverseEvaluator.java
@@ -7,6 +7,7 @@ import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.condition.ConstantCondition;
 import com.bazaarvoice.emodb.sor.condition.ContainsCondition;
+import com.bazaarvoice.emodb.sor.condition.PartitionCondition;
 import com.bazaarvoice.emodb.sor.condition.EqualCondition;
 import com.bazaarvoice.emodb.sor.condition.InCondition;
 import com.bazaarvoice.emodb.sor.condition.IntrinsicCondition;
@@ -16,7 +17,6 @@ import com.bazaarvoice.emodb.sor.condition.MapCondition;
 import com.bazaarvoice.emodb.sor.condition.NotCondition;
 import com.bazaarvoice.emodb.sor.condition.OrCondition;
 import com.bazaarvoice.emodb.sor.condition.State;
-import com.bazaarvoice.emodb.sor.delta.eval.Intrinsics;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
 
@@ -178,6 +178,16 @@ class InverseEvaluator implements ConditionVisitor<Void, Condition> {
         return Conditions.or(conditions);
     }
 
+    @Nullable
+    @Override
+    public Condition visit(PartitionCondition condition, Void context) {
+        Condition inverse = condition.getCondition().visit(this, null);
+        if (inverse == null) {
+            return null;
+        }
+        return Conditions.partition(condition.getNumPartitions(), inverse);
+    }
+    
     // The remaining conditions have no well-defined inverse expressible as a Condition other than not(condition).
 
     @Nullable

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AbstractCondition.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AbstractCondition.java
@@ -1,9 +1,15 @@
 package com.bazaarvoice.emodb.sor.condition.impl;
 
+import com.bazaarvoice.emodb.common.json.OrderedJson;
 import com.bazaarvoice.emodb.sor.condition.Condition;
+import com.bazaarvoice.emodb.sor.condition.InCondition;
+import com.bazaarvoice.emodb.sor.condition.OrCondition;
+import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
 
 public abstract class AbstractCondition implements Condition {
 
@@ -17,6 +23,7 @@ public abstract class AbstractCondition implements Condition {
         }
         return buf.toString();
     }
+
     /**
      * Default weight for all conditions is 1.  Conditions which are more complex than a trivial check should return
      * a higher value.
@@ -24,5 +31,25 @@ public abstract class AbstractCondition implements Condition {
     @Override
     public int weight() {
         return 1;
+    }
+
+    protected static void appendSubCondition(Appendable buf, Condition condition) throws IOException {
+        // The syntax allows a comma-separated list of conditions that are implicitly wrapped in an OrCondition.
+        // If _condition is an InCondition or OrCondition we can print them without the "in(...)" and "or(...)"
+        // wrappers to result in a cleaner string format that the parser can parse back into InCondition/OrCondition.
+        if (condition instanceof InCondition) {
+            Set<Object> values = ((InCondition) condition).getValues();
+            Joiner.on(',').appendTo(buf, OrderedJson.orderedStrings(values));
+        } else if (condition instanceof OrCondition) {
+            Collection<Condition> conditions = ((OrCondition) condition).getConditions();
+            String sep = "";
+            for (Condition orCondition : conditions) {
+                buf.append(sep);
+                orCondition.appendTo(buf);
+                sep = ",";
+            }
+        } else {
+            condition.appendTo(buf);
+        }
     }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/IntrinsicConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/IntrinsicConditionImpl.java
@@ -53,23 +53,7 @@ public class IntrinsicConditionImpl extends AbstractCondition implements Intrins
         Writer out = CharStreams.asWriter(buf);
         DeltaJson.write(out, _name);
         buf.append(':');
-        // The syntax allows a comma-separated list of conditions that are implicitly wrapped in an OrCondition.
-        // If _condition is an InCondition or OrCondition we can print them without the "in(...)" and "or(...)"
-        // wrappers to result in a cleaner string format that the parser can parse back into InCondition/OrCondition.
-        if (_condition instanceof InCondition) {
-            Set<Object> values = ((InCondition) _condition).getValues();
-            Joiner.on(',').appendTo(buf, OrderedJson.orderedStrings(values));
-        } else if (_condition instanceof OrCondition) {
-            Collection<Condition> conditions = ((OrCondition) _condition).getConditions();
-            String sep = "";
-            for (Condition condition : conditions) {
-                buf.append(sep);
-                condition.appendTo(buf);
-                sep = ",";
-            }
-        } else {
-            _condition.appendTo(buf);
-        }
+        appendSubCondition(buf, _condition);
         buf.append(')');
     }
 

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/PartitionConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/PartitionConditionImpl.java
@@ -1,0 +1,180 @@
+package com.bazaarvoice.emodb.sor.condition.impl;
+
+import com.bazaarvoice.emodb.sor.condition.AndCondition;
+import com.bazaarvoice.emodb.sor.condition.ComparisonCondition;
+import com.bazaarvoice.emodb.sor.condition.Condition;
+import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
+import com.bazaarvoice.emodb.sor.condition.Conditions;
+import com.bazaarvoice.emodb.sor.condition.ConstantCondition;
+import com.bazaarvoice.emodb.sor.condition.ContainsCondition;
+import com.bazaarvoice.emodb.sor.condition.EqualCondition;
+import com.bazaarvoice.emodb.sor.condition.InCondition;
+import com.bazaarvoice.emodb.sor.condition.IntrinsicCondition;
+import com.bazaarvoice.emodb.sor.condition.IsCondition;
+import com.bazaarvoice.emodb.sor.condition.LikeCondition;
+import com.bazaarvoice.emodb.sor.condition.MapCondition;
+import com.bazaarvoice.emodb.sor.condition.NotCondition;
+import com.bazaarvoice.emodb.sor.condition.OrCondition;
+import com.bazaarvoice.emodb.sor.condition.PartitionCondition;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class PartitionConditionImpl extends AbstractCondition implements PartitionCondition {
+
+    private final int _numPartitions;
+    private final Condition _condition;
+
+    public PartitionConditionImpl(int numPartitions, Condition condition) {
+        _numPartitions = numPartitions;
+        _condition = checkNotNull(condition, "condition");
+        checkArgument(numPartitions > 0, "Number of partitions must be at least 1");
+        // Validate the condition
+        condition.visit(new PartitionConditionValidationVisitor(), null);
+    }
+
+    /**
+     * Validator for the condition, mostly checks that values are numbers within the partition range.  Some nonsensical
+     * values are still permitted since the purpose is to exclude patently invalid conditions but not necessarily
+     * meaningless ones.
+     */
+    private class PartitionConditionValidationVisitor implements ConditionVisitor<Void, Void> {
+        @Nullable
+        @Override
+        public Void visit(ConstantCondition condition, @Nullable Void context) {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Void visit(EqualCondition condition, @Nullable Void context) {
+            if (!(condition.getValue() instanceof Number)) {
+                throw new IllegalArgumentException("Partition value must be an integer");
+            }
+            Number partitionNum = (Number) condition.getValue();
+            int partition = partitionNum.intValue();
+            if (partitionNum.doubleValue() != partition) {
+                throw new IllegalArgumentException("Partition value must be an integer");
+            }
+            if (partition < 1 || partition > _numPartitions) {
+                throw new IllegalArgumentException("Partition must be between 1 and " + _numPartitions);
+            }
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Void visit(ComparisonCondition condition, @Nullable Void context) {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Void visit(InCondition condition, @Nullable Void context) {
+            condition.getValues().forEach(v -> Conditions.equal(v).visit(this, null));
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Void visit(IsCondition condition, @Nullable Void context) {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Void visit(NotCondition condition, @Nullable Void context) {
+            return condition.getCondition().visit(this, null);
+        }
+
+        @Nullable
+        @Override
+        public Void visit(AndCondition condition, @Nullable Void context) {
+            condition.getConditions().forEach(c -> c.visit(this, null));
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Void visit(OrCondition condition, @Nullable Void context) {
+            condition.getConditions().forEach(c -> c.visit(this, null));
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Void visit(IntrinsicCondition condition, @Nullable Void context) {
+            throw new IllegalArgumentException("Invalid comparison of partition to intrinsic");
+        }
+
+        @Nullable
+        @Override
+        public Void visit(LikeCondition condition, @Nullable Void context) {
+            throw new IllegalArgumentException("Invalid comparison of partition to string");
+        }
+
+        @Nullable
+        @Override
+        public Void visit(ContainsCondition condition, @Nullable Void context) {
+            throw new IllegalArgumentException("Invalid comparison of partition to array");
+        }
+
+        @Nullable
+        @Override
+        public Void visit(MapCondition condition, @Nullable Void context) {
+            throw new IllegalArgumentException("Invalid comparison of partition to object");
+        }
+
+        @Nullable
+        @Override
+        public Void visit(PartitionCondition condition, @Nullable Void context) {
+            throw new IllegalArgumentException("Invalid nested use of partitions");
+        }
+    }
+
+    @Override
+    public <T, V> V visit(ConditionVisitor<T, V> visitor, @Nullable T context) {
+        return visitor.visit(this, context);
+    }
+
+    @Override
+    public void appendTo(Appendable buf) throws IOException {
+        buf.append("partition(");
+        buf.append(Integer.toString(_numPartitions));
+        buf.append(":");
+        appendSubCondition(buf, _condition);
+        buf.append(")");
+    }
+
+    @Override
+    public int getNumPartitions() {
+        return _numPartitions;
+    }
+
+    @Override
+    public Condition getCondition() {
+        return _condition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PartitionConditionImpl)) {
+            return false;
+        }
+        PartitionConditionImpl that = (PartitionConditionImpl) o;
+        return _numPartitions == that._numPartitions &&
+                Objects.equals(_condition, that._condition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_numPartitions, _condition);
+    }
+}

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/DeltaParser.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/deser/DeltaParser.java
@@ -276,6 +276,9 @@ public class DeltaParser {
 
             } else if ("containsOnly".equals(token)) {
                 return parseContainsCondition(ContainsCondition.Containment.ONLY);
+
+            } else if ("partition".equals(token)) {
+                return parsePartitionCondition();
             }
         }
 
@@ -388,6 +391,17 @@ public class DeltaParser {
         String pattern = _t.nextString();
         _t.nextClean(')');
         return Conditions.like(pattern);
+    }
+
+    private Condition parsePartitionCondition() {
+        _t.nextClean('(');
+        int numPartitions = ((Number)_t.nextValue()).intValue();
+        _t.nextClean(':');
+        List<Condition> conditions = Lists.newArrayList();
+        do {
+            conditions.add(parseCondition());
+        } while (_t.nextArg(',', ')'));
+        return Conditions.partition(numPartitions, Conditions.or(conditions));
     }
 
     private <T extends Collection<?>> T checkArgCount(String function, int numArgs, T arguments) {

--- a/sor-api/src/test/java/com/bazaarvoice/emodb/sor/condition/ConditionParserTest.java
+++ b/sor-api/src/test/java/com/bazaarvoice/emodb/sor/condition/ConditionParserTest.java
@@ -154,6 +154,23 @@ public class ConditionParserTest {
         doTest("like(\"const\")", "\"const\"", Conditions.equal("const"));
     }
 
+    @Test
+    public void testPartition() {
+        doTest("partition(8 : 1)", "partition(8:1)", Conditions.partition(8, Conditions.equal(1)));
+        doTest("partition(8 : 2,4,6)", "partition(8:2,4,6)", Conditions.partition(8, Conditions.or(
+                Conditions.equal(2), Conditions.equal(4), Conditions.equal(6)
+        )));
+        doTest("partition(4 : ge(2))", "partition(4:ge(2))", Conditions.partition(4, Conditions.ge(2)));
+        doTestException("partition(4:0)", "Partition must be between 1 and 4");
+        doTestException("partition(4:5)", "Partition must be between 1 and 4");
+        doTestException("partition(4:not(6))", "Partition must be between 1 and 4");
+        doTestException("partition(4:or(1,2,6))", "Partition must be between 1 and 4");
+        doTestException("partition(4:\"1\")", "Partition value must be an integer");
+        doTestException("partition(4:1.5)", "Partition value must be an integer");
+        doTestException("partition(4:contains(1))", "Invalid comparison of partition to array");
+        doTestException("partition(4:{..,\"partition\":1})", "Invalid comparison of partition to object");
+    }
+
     private void doTest(String input, String expectedString, Condition expected) {
         Condition actual = Conditions.fromString(input);
         assertEquals(actual, expected, "ConditionParser returned unexpected results:\nGiven   : " + input);

--- a/sor-api/src/test/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluatorTest.java
+++ b/sor-api/src/test/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluatorTest.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -344,6 +345,25 @@ public class ConditionEvaluatorTest {
     }
 
     @Test
+    public void testPartition() {
+        // The following list of expected values was pre-computed using the given input.  Should the hashing algorithm
+        // used by partition change then these would likely also need updating.
+        List<Integer> expected = ImmutableList.of(22, 44, 55, 43, 44, 26, 13, 25, 1, 42, 32, 36, 15, 30, 28, 62);
+        for (int i=0; i < expected.size(); i++) {
+            Intrinsics intrinsics = mock(Intrinsics.class);
+            when(intrinsics.getTable()).thenReturn("mytable");
+            when(intrinsics.getId()).thenReturn("doc" + i);
+            for (int t=1; t <= 64; t++) {
+                if (t == expected.get(i)) {
+                    assertTrue(eval(Conditions.partition(64, Conditions.equal(t)), null, intrinsics));
+                } else {
+                    assertFalse(eval(Conditions.partition(64, Conditions.equal(t)), null, intrinsics));
+                }
+            }
+        }
+    }
+
+    @Test
     public void testAndConditionOrdering() {
         // Create an "and" condition with weights out of order
         Condition cheapest = Conditions.mapBuilder()
@@ -438,7 +458,7 @@ public class ConditionEvaluatorTest {
         // Verify condition serializes in natural order by key
         assertEquals(mapCondition.toString(), "{..,\"k0\":{..,\"a\":1,\"b\":2,\"c\":3},\"k1\":{..,\"echo\":\"echo\"},\"k2\":{..,\"brown\":\"cow\",\"how\":\"now\"}}");
         // Verify conditions are returned in increasing weight
-        Iterator<Map.Entry<String, Condition>> conditions = ((MapCondition)mapCondition).getEntries().entrySet().iterator();
+        Iterator<Map.Entry<String, Condition>> conditions = ((MapCondition) mapCondition).getEntries().entrySet().iterator();
         assertEquals(conditions.next(), Maps.immutableEntry("k1", cheapest));
         assertEquals(conditions.next(), Maps.immutableEntry("k2", middle));
         assertEquals(conditions.next(), Maps.immutableEntry("k0", priciest));

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/matching/ConditionPart.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/matching/ConditionPart.java
@@ -10,6 +10,7 @@ import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.condition.ConstantCondition;
 import com.bazaarvoice.emodb.sor.condition.ContainsCondition;
+import com.bazaarvoice.emodb.sor.condition.PartitionCondition;
 import com.bazaarvoice.emodb.sor.condition.EqualCondition;
 import com.bazaarvoice.emodb.sor.condition.InCondition;
 import com.bazaarvoice.emodb.sor.condition.IntrinsicCondition;
@@ -124,6 +125,12 @@ public class ConditionPart extends EmoMatchingPart {
         @Override
         public T visit(MapCondition condition, @Nullable String context) {
             throw new IllegalArgumentException("Value cannot be evaluated as an map");
+        }
+
+        @Nullable
+        @Override
+        public T visit(PartitionCondition condition, @Nullable String context) {
+            throw new IllegalArgumentException("Value cannot be evaluated as a partition");
         }
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/matching/TableConditionPart.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/matching/TableConditionPart.java
@@ -11,6 +11,7 @@ import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.condition.ConstantCondition;
 import com.bazaarvoice.emodb.sor.condition.ContainsCondition;
+import com.bazaarvoice.emodb.sor.condition.PartitionCondition;
 import com.bazaarvoice.emodb.sor.condition.EqualCondition;
 import com.bazaarvoice.emodb.sor.condition.InCondition;
 import com.bazaarvoice.emodb.sor.condition.IntrinsicCondition;
@@ -170,7 +171,8 @@ abstract public class TableConditionPart extends EmoMatchingPart {
 
             switch (condition.getName()) {
                 case Intrinsic.TABLE:
-                    // Table name doesn't require metadata; check the contained condition
+                case Intrinsic.ID:
+                    // Table name and document ID don't require metadata; check the contained condition
                     requiresMetadata = condition.getCondition().visit(this, null);
                     break;
 
@@ -225,6 +227,12 @@ abstract public class TableConditionPart extends EmoMatchingPart {
                 }
             }
             return requiresMetadata;
+        }
+
+        @Nullable
+        @Override
+        public Boolean visit(PartitionCondition condition, @Nullable Void context) {
+            return condition.getCondition().visit(this, null);
         }
 
         // All remaining conditions are verifiable from the immediate context and do not require table metadata.

--- a/web/src/test/java/com/bazaarvoice/emodb/web/auth/EmoPermissionTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/auth/EmoPermissionTest.java
@@ -411,7 +411,7 @@ public class EmoPermissionTest {
 
     @Test (expectedExceptions = InvalidPermissionStringException.class)
     public void testInvalidTableCondition() {
-        _resolver.resolvePermission("sor|*|if(intrinsic(\"~id\":~))");
+        _resolver.resolvePermission("sor|*|if(intrinsic(\"~version\":~))");
     }
 
     @Test


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?
This PR allows for rudimentary partitioning of a databus subscription by creating _n_ subscriptions, each with an identical subscription condition and a distinct partition.  For example, given a subscription with the following condition:

```
{..,"type":"review"}
```

Two subscriptions each with one of the following conditions would receive the same events with the documents split roughly evenly by ID between the two subscriptions:

```
and({..,"type":"review"},partition(2:1))
and({..,"type":"review"},partition(2:2))
```

## How to Test and Verify

1. Check out this PR
2. Create two subscriptions such as those above.
3. Create at least one table and create multiple matching documents.  Then perform at least one update to each document.
4. Verify that each document was only present in one of the two subscriptions and that the second event for each document was in the same subscription as the initial event.

## Risk

This update is fairly low risk.  Even though it introduces a new subscription condition until there are any clients who use it the new code paths introduced by it won't be exercised.

### Level 

`Medium`

### Required Testing

`Manual`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
