### PR TITLE
Resiliency to Split Timeouts

### DIFF
--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/store/MapStore.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/store/MapStore.java
@@ -12,8 +12,6 @@ public interface MapStore<T> {
 
     Set<String> keySet();
 
-    String getZkPath();
-
     @Nullable
     T get(String key);
 

--- a/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/store/ZkMapStore.java
+++ b/common/zookeeper/src/main/java/com/bazaarvoice/emodb/common/zookeeper/store/ZkMapStore.java
@@ -172,11 +172,6 @@ public class ZkMapStore<T> implements MapStore<T>, Managed {
         return builder.build();
     }
 
-    @Override
-    public String getZkPath() {
-        return _zkPath;
-    }
-
     @Nullable
     @Override
     public T get(String key) {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -423,6 +423,12 @@ public class DataStoreModule extends PrivateModule {
         return new RateLimiterCache(rateLimits, 1000);
     }
 
+    @Provides @Singleton @MinSplitSizeMap
+    MapStore<DataStoreMinSplitSize> provideMinSplitSizeMap(@DataStoreZooKeeper CuratorFramework curator,
+                                                LifeCycleRegistry lifeCycle) {
+        return lifeCycle.manage(new ZkMapStore<>(curator, "min-split-size", new ZKDataStoreMinSplitSizeSerializer()));
+    }
+
     @Provides @Singleton @StashRoot
     Optional<URI> provideStashRootDirectory(DataStoreConfiguration configuration) {
         if (configuration.getStashRoot().isPresent()) {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -166,6 +166,10 @@ public class DataStoreModule extends PrivateModule {
             bind(ClusterHintsPoller.class).asEagerSingleton();
         }
 
+        if (_serviceMode.specifies(EmoServiceMode.Aspect.dataStore_web)) {
+            bind(MinSplitSizeCleanupMonitor.class).asEagerSingleton();
+        }
+
         // The web servers are responsible for performing background table background_table_maintenance.
         // Enable background table background_table_maintenance if specified.
         if (_serviceMode.specifies(EmoServiceMode.Aspect.background_table_maintenance)) {
@@ -248,8 +252,6 @@ public class DataStoreModule extends PrivateModule {
 
         bind(DataWriteCloser.class).to(WriteCloseableDataStore.class);
         bind(GracefulShutdownManager.class).asEagerSingleton();
-
-        bind(MinSplitSizeCleanupMonitor.class).asEagerSingleton();
 
         // Tools for migration to blocked deltas
         if (_serviceMode.specifies(EmoServiceMode.Aspect.delta_migrator)) {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -249,6 +249,8 @@ public class DataStoreModule extends PrivateModule {
         bind(DataWriteCloser.class).to(WriteCloseableDataStore.class);
         bind(GracefulShutdownManager.class).asEagerSingleton();
 
+        bind(MinSplitSizeCleanupMonitor.class).asEagerSingleton();
+
         // Tools for migration to blocked deltas
         if (_serviceMode.specifies(EmoServiceMode.Aspect.delta_migrator)) {
             bind(MigratorTools.class).to(DefaultMigratorTools.class);

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreMinSplitSize.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreMinSplitSize.java
@@ -1,0 +1,21 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import java.time.Instant;
+
+public class DataStoreMinSplitSize {
+    private final int _minSplitSize;
+    private final Instant _expirationTime;
+
+    public DataStoreMinSplitSize(int minSplitSize, Instant expirationTime) {
+        _minSplitSize = minSplitSize;
+        _expirationTime = expirationTime;
+    }
+
+    public int getMinSplitSize() {
+        return _minSplitSize;
+    }
+
+    public Instant getExpirationTime() {
+        return _expirationTime;
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
@@ -4,6 +4,7 @@ import com.bazaarvoice.emodb.common.api.impl.LimitCounter;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.json.deferred.LazyJsonMap;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
 import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.AuditBuilder;
 import com.bazaarvoice.emodb.sor.api.Change;
@@ -58,6 +59,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
@@ -68,6 +70,8 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
@@ -87,6 +91,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -97,6 +103,9 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
 
     private static final int NUM_COMPACTION_THREADS = 2;
     private static final int MAX_COMPACTION_QUEUE_LENGTH = 100;
+
+    private final Logger _log = LoggerFactory.getLogger(DefaultDataStore.class);
+
 
     private final DatabusEventWriterRegistry _eventWriterRegistry;
     private final TableDAO _tableDao;
@@ -114,6 +123,7 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
     private final Meter _discardedCompactions;
     private final Compactor _compactor;
     private final CompactionControlSource _compactionControlSource;
+    private final MapStore<DataStoreMinSplitSize> _minSplitSizeMap;
 
     private StashTableDAO _stashTableDao;
 
@@ -121,9 +131,11 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
     public DefaultDataStore(LifeCycleRegistry lifeCycle, MetricRegistry metricRegistry, DatabusEventWriterRegistry eventWriterRegistry, TableDAO tableDao,
                             DataReaderDAO dataReaderDao, DataWriterDAO dataWriterDao, SlowQueryLog slowQueryLog, HistoryStore historyStore,
                             @StashRoot Optional<URI> stashRootDirectory, @LocalCompactionControl CompactionControlSource compactionControlSource,
-                            @StashBlackListTableCondition Condition stashBlackListTableCondition, AuditWriter auditWriter) {
+                            @StashBlackListTableCondition Condition stashBlackListTableCondition, AuditWriter auditWriter,
+                            @MinSplitSizeMap MapStore<DataStoreMinSplitSize> minSplitSizeMap) {
         this(eventWriterRegistry, tableDao, dataReaderDao, dataWriterDao, slowQueryLog, defaultCompactionExecutor(lifeCycle),
-                historyStore, stashRootDirectory, compactionControlSource, stashBlackListTableCondition, auditWriter, metricRegistry);
+                historyStore, stashRootDirectory, compactionControlSource, stashBlackListTableCondition, auditWriter,
+                minSplitSizeMap, metricRegistry);
     }
 
     @VisibleForTesting
@@ -131,7 +143,8 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
                             DataReaderDAO dataReaderDao, DataWriterDAO dataWriterDao,
                             SlowQueryLog slowQueryLog, ExecutorService compactionExecutor, HistoryStore historyStore,
                             Optional<URI> stashRootDirectory, CompactionControlSource compactionControlSource,
-                            Condition stashBlackListTableCondition, AuditWriter auditWriter, MetricRegistry metricRegistry) {
+                            Condition stashBlackListTableCondition, AuditWriter auditWriter,
+                            MapStore<DataStoreMinSplitSize> minSplitSizeMap, MetricRegistry metricRegistry) {
         _eventWriterRegistry = checkNotNull(eventWriterRegistry, "eventWriterRegistry");
         _tableDao = checkNotNull(tableDao, "tableDao");
         _dataReaderDao = checkNotNull(dataReaderDao, "dataReaderDao");
@@ -149,6 +162,7 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
         _compactor = new DistributedCompactor(_archiveDeltaSize, _historyStore.isDeltaHistoryEnabled(), metricRegistry);
 
         _compactionControlSource = checkNotNull(compactionControlSource, "compactionControlSource");
+        _minSplitSizeMap = checkNotNull(minSplitSizeMap, "minSplitSizeMap");
     }
 
     /**
@@ -545,8 +559,30 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
         checkLegalTableName(tableName);
         checkArgument(desiredRecordsPerSplit > 0, "DesiredRecordsPerSplit must be >0");
 
+        DataStoreMinSplitSize minSplitSize = _minSplitSizeMap.get(tableName);
+
+        int actualSplitSize;
+
+        if (minSplitSize != null && minSplitSize.getExpirationTime().isAfter(Instant.now())) {
+            actualSplitSize = Math.max(desiredRecordsPerSplit, minSplitSize.getMinSplitSize());
+        } else {
+            actualSplitSize = desiredRecordsPerSplit;
+        }
+
         Table table = _tableDao.get(tableName);
-        return _dataReaderDao.getSplits(table, desiredRecordsPerSplit);
+
+        try {
+            return _dataReaderDao.getSplits(table, desiredRecordsPerSplit, actualSplitSize);
+        } catch (TimeoutException timeoutException) {
+            try {
+                _minSplitSizeMap.set(tableName,
+                        new DataStoreMinSplitSize(actualSplitSize * 10, Instant.now().plus(1, ChronoUnit.DAYS)));
+            } catch (Exception e) {
+                _log.warn("Unable to store min split size for table {}", tableName);
+            }
+
+            throw Throwables.propagate(timeoutException);
+        }
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultDataStore.java
@@ -559,6 +559,9 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
         checkLegalTableName(tableName);
         checkArgument(desiredRecordsPerSplit > 0, "DesiredRecordsPerSplit must be >0");
 
+        // Check if Emo is allowed to request splits from Cassandra of this size. If a previous user has recently timed
+        // out trying to splits close to this size, query for larger splits according the splitSizeMap's directive.
+
         DataStoreMinSplitSize minSplitSize = _minSplitSizeMap.get(tableName);
 
         int actualSplitSize;
@@ -576,7 +579,7 @@ public class DefaultDataStore implements DataStore, DataProvider, DataTools, Tab
         } catch (TimeoutException timeoutException) {
             try {
                 _minSplitSizeMap.set(tableName,
-                        new DataStoreMinSplitSize(actualSplitSize * 10, Instant.now().plus(1, ChronoUnit.DAYS)));
+                        new DataStoreMinSplitSize(actualSplitSize * 8, Instant.now().plus(1, ChronoUnit.DAYS)));
             } catch (Exception e) {
                 _log.warn("Unable to store min split size for table {}", tableName);
             }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeCleanupMonitor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeCleanupMonitor.java
@@ -1,0 +1,70 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.curator.recipes.leader.LeaderService;
+import com.bazaarvoice.emodb.common.dropwizard.guice.SelfHostAndPort;
+import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ManagedGuavaService;
+import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
+import com.bazaarvoice.emodb.sor.DataStoreZooKeeper;
+import com.google.common.net.HostAndPort;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.inject.Inject;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.curator.framework.CuratorFramework;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class MinSplitSizeCleanupMonitor extends LeaderService {
+
+    private static final String SERVICE_NAME = "min-split-size-cleanup-montor";
+    private static final String LEADER_DIR = "/leader/min-split-size";
+
+    @Inject
+    public MinSplitSizeCleanupMonitor(@DataStoreZooKeeper CuratorFramework curator, @SelfHostAndPort HostAndPort selfHostAndPort,
+                                      LeaderServiceTask leaderServiceTask, LifeCycleRegistry lifecycle,
+                                      @MinSplitSizeMap MapStore<DataStoreMinSplitSize> minSplitSizeMap) {
+        super(curator, LEADER_DIR, selfHostAndPort.toString(), SERVICE_NAME, 1, TimeUnit.MINUTES,
+                () -> new MigratorCleanupService(minSplitSizeMap));
+        leaderServiceTask.register(SERVICE_NAME, this);
+        lifecycle.manage(new ManagedGuavaService(this));
+    }
+
+    private static class MigratorCleanupService extends AbstractScheduledService {
+
+        private final MapStore<DataStoreMinSplitSize> _minSplitSizeMap;
+
+        public MigratorCleanupService(MapStore<DataStoreMinSplitSize> minSplitSizeMap) {
+            _minSplitSizeMap = checkNotNull(minSplitSizeMap);
+        }
+
+        @Override
+        protected void runOneIteration() throws Exception {
+            Map<String, DataStoreMinSplitSize> minSplitSizes = _minSplitSizeMap.getAll();
+            for (Map.Entry<String, DataStoreMinSplitSize> entry : minSplitSizes.entrySet()) {
+                if (entry.getValue().getExpirationTime().isBefore(Instant.now())) {
+                    _minSplitSizeMap.remove(entry.getKey());
+                }
+            }
+        }
+
+        /**
+         *
+         * @return a schedule that causes this service to be executed once per day at midnight
+         */
+        @Override
+        protected Scheduler scheduler() {
+
+            OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+
+            return Scheduler.newFixedRateSchedule(
+                    Duration.between(now, OffsetDateTime.of(now.toLocalDate().plusDays(1).atStartOfDay(), ZoneOffset.UTC)).getSeconds(),
+                    Duration.ofDays(1).getSeconds(), TimeUnit.SECONDS);
+        }
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeMap.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeMap.java
@@ -1,0 +1,17 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.google.inject.BindingAnnotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for identifying the cluster to minimum lag duration map.
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface MinSplitSizeMap {
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/ZKDataStoreMinSplitSizeSerializer.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/ZKDataStoreMinSplitSizeSerializer.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 public class ZKDataStoreMinSplitSizeSerializer implements ZkValueSerializer<DataStoreMinSplitSize> {
     @Override
     public String toString(DataStoreMinSplitSize value) {
-        return String.format("%.8f,%s", value.getMinSplitSize(), value.getExpirationTime());
+        return String.format("%d,%s", value.getMinSplitSize(), value.getExpirationTime());
 
     }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/ZKDataStoreMinSplitSizeSerializer.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/ZKDataStoreMinSplitSizeSerializer.java
@@ -1,0 +1,26 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.emodb.common.zookeeper.store.ZkValueSerializer;
+import java.time.Instant;
+
+public class ZKDataStoreMinSplitSizeSerializer implements ZkValueSerializer<DataStoreMinSplitSize> {
+    @Override
+    public String toString(DataStoreMinSplitSize value) {
+        return String.format("%.8f,%s", value.getMinSplitSize(), value.getExpirationTime());
+
+    }
+
+    @Override
+    public DataStoreMinSplitSize fromString(String string) {
+        if (string == null) {
+            return null;
+        }
+
+        int comma = string.indexOf(',');
+        if (comma <= 0) {
+            throw new IllegalArgumentException("Min split size value cannot be parsed: " + string);
+        }
+        int minSplitSize = Integer.parseInt(string.substring(0, comma));
+        Instant expirationTime = Instant.parse(string.substring(comma+1));
+        return new DataStoreMinSplitSize(minSplitSize, expirationTime);    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryDataStore.java
@@ -31,6 +31,6 @@ public class InMemoryDataStore extends DefaultDataStore {
         super(eventWriterRegistry, new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), MoreExecutors.sameThreadExecutor(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), metricRegistry);
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), metricRegistry);
     }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryDataStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryDataStore.java
@@ -13,6 +13,7 @@ import com.google.common.base.Optional;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import java.net.URI;
+import java.time.Clock;
 
 /**
  * In-memory implementation of {@link com.bazaarvoice.emodb.sor.api.DataStore}, for testing. Doesn't generate events.
@@ -31,6 +32,6 @@ public class InMemoryDataStore extends DefaultDataStore {
         super(eventWriterRegistry, new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), MoreExecutors.sameThreadExecutor(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new InMemoryMapStore<>(), metricRegistry);
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), metricRegistry, Clock.systemUTC());
     }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryMapStore.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/test/InMemoryMapStore.java
@@ -1,0 +1,78 @@
+package com.bazaarvoice.emodb.sor.core.test;
+
+import com.bazaarvoice.emodb.common.zookeeper.store.ChangeType;
+import com.bazaarvoice.emodb.common.zookeeper.store.MapStore;
+import com.bazaarvoice.emodb.common.zookeeper.store.MapStoreListener;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InMemoryMapStore<T> implements MapStore<T> {
+
+    private final Logger _log = LoggerFactory.getLogger(InMemoryMapStore.class);
+
+    private final Map<String, T> _store;
+    private final List<MapStoreListener> _listeners;
+
+
+    public InMemoryMapStore() {
+        _store = new HashMap<>();
+        _listeners = new ArrayList<>();
+    }
+
+    @Override
+    public Map<String, T> getAll() {
+        return _store;
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return _store.keySet();
+    }
+
+    @Nullable
+    @Override
+    public T get(String key) {
+        return _store.get(key);
+    }
+
+    @Override
+    public void set(String key, T value) throws Exception {
+        boolean updating = _store.containsKey(key);
+        _store.put(key, value);
+        fireChanged(key, updating ? ChangeType.CHANGE : ChangeType.ADD);
+    }
+
+    @Override
+    public void remove(String key) throws Exception {
+        if (_store.remove(key) != null) {
+            fireChanged(key, ChangeType.REMOVE);
+        }
+    }
+
+    @Override
+    public void addListener(MapStoreListener listener) {
+        _listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(MapStoreListener listener) {
+        _listeners.remove(listener);
+    }
+
+    private void fireChanged(String key, ChangeType changeType) {
+        for (MapStoreListener listener : _listeners) {
+            try {
+                listener.entryChanged(key, changeType);
+            } catch (Throwable t) {
+                _log.error("Listener threw an unexpected exception.", t);
+            }
+        }
+
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DataReaderDAO.java
@@ -40,7 +40,7 @@ public interface DataReaderDAO {
      * Returns a list of split identifiers that, when queried, will return all data in the table.  This method will
      * make a best effort to return splits smaller than or equal to the specified desired number of records per split.
      */
-    List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException;
+    List<String> getSplits(Table table, int recordsPerSplit, int localResplits) throws TimeoutException;
 
     /** Retrieves up to {@code limit} records from the specified split in the specified table. */
     Iterator<Record> getSplit(Table table, String split, @Nullable String fromKeyExclusive, LimitCounter limit, ReadConsistency consistency);

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DataReaderDAO.java
@@ -7,6 +7,7 @@ import com.bazaarvoice.emodb.table.db.Table;
 import com.bazaarvoice.emodb.table.db.TableSet;
 import com.google.common.base.Optional;
 
+import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.Collection;
@@ -39,13 +40,13 @@ public interface DataReaderDAO {
      * Returns a list of split identifiers that, when queried, will return all data in the table.  This method will
      * make a best effort to return splits smaller than or equal to the specified desired number of records per split.
      */
-    List<String> getSplits(Table table, int desiredRecordsPerSplit);
+    List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException;
 
     /** Retrieves up to {@code limit} records from the specified split in the specified table. */
     Iterator<Record> getSplit(Table table, String split, @Nullable String fromKeyExclusive, LimitCounter limit, ReadConsistency consistency);
 
     /**
-     * Like {@link #getSplits(com.bazaarvoice.emodb.table.db.Table, int)} for an entire placement.  Useful in conjunction
+     * Like {@link #getSplits(com.bazaarvoice.emodb.table.db.Table, int, int)} for an entire placement.  Useful in conjunction
      * with a multi-table scan for scanning subranges of a token range.  Returns a ScanRangeSplits which provides
      * splits by groups of hosts.  Querying each group's hosts sequentially should evenly distribute the load.
      * The optional "subrange" parameter limits the splits only to the matching token range.

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
@@ -41,6 +41,7 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -74,6 +75,10 @@ import com.netflix.astyanax.shallows.EmptyKeyspaceTracerFactory;
 import com.netflix.astyanax.thrift.AbstractKeyspaceOperationImpl;
 import com.netflix.astyanax.util.ByteBufferRangeImpl;
 import com.netflix.astyanax.util.RangeBuilder;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.concurrent.TimeoutException;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.thrift.Cassandra;
@@ -90,6 +95,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -98,6 +105,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Cassandra implementation of {@link DataReaderDAO} that uses the Netflix Astyanax client library.
  */
 public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO, AstyanaxKeyScanner {
+
+    private final Logger _log = LoggerFactory.getLogger(AstyanaxDataReaderDAO.class);
+
     private static final int MAX_RANDOM_ROWS_BATCH = 50;
     private static final int MAX_SCAN_ROWS_BATCH = 250;
     private static final int SCAN_ROW_BATCH_INCREMENT = 50;
@@ -371,19 +381,43 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
 
     @Timed (name = "bv.emodb.sor.AstyanaxDataReaderDAO.getSplits", absolute = true)
     @Override
-    public List<String> getSplits(Table tbl, int desiredRecordsPerSplit) {
+    public List<String> getSplits(Table tbl, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
         checkNotNull(tbl, "table");
-        List<String> splits = Lists.newArrayList();
-        List<CfSplit> cfSplits = getCfSplits(tbl, desiredRecordsPerSplit);
-        for (CfSplit split : cfSplits) {
-            ByteBuffer begin = parseTokenString(split.getStartToken());
-            ByteBuffer finish = parseTokenString(split.getEndToken());
+        checkArgument(splitQuerySize % desiredRecordsPerSplit == 0);
+        checkArgument(Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2) % 2.0 == 0);
 
-            splits.add(SplitFormat.encode(new ByteBufferRangeImpl(begin, finish, -1, false)));
+        try {
+            List<String> splits = new ArrayList<>();
+            List<CfSplit> cfSplits = getCfSplits(tbl, desiredRecordsPerSplit);
+            for (CfSplit split : cfSplits) {
+
+                List<Token> splitTokens = ImmutableList.of(_tokenFactory.fromString(split.getStartToken()), _tokenFactory.fromString(split.getEndToken()));
+                for (int i = 0; i < Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2); i++) {
+                    List<Token> newTokens = new ArrayList<>(splitTokens.size() * 2 -1);
+                    for (int j = 0; j < splitTokens.size() - 1; j++) {
+                        newTokens.add(splitTokens.get(j));
+                        newTokens.add(ByteOrderedPartitioner.instance.midpoint(splitTokens.get(j), splitTokens.get(j+1)));
+                    }
+                    newTokens.add(splitTokens.get(splitTokens.size() - 1));
+                    splitTokens = newTokens;
+                }
+
+                for (int i = 0; i < splitTokens.size() -1; i++) {
+                    splits.add(SplitFormat.encode(new ByteBufferRangeImpl(_tokenFactory.toByteArray(splitTokens.get(i)),
+                            _tokenFactory.toByteArray(splitTokens.get(i + 1)), -1, false)));
+                }
+
+            }
+            // Randomize the splits so, if processed somewhat in parallel, requests distribute around the ring.
+            Collections.shuffle(splits);
+            return splits;
+        } catch (Exception e) {
+            if (isTimeoutException(e)) {
+                throw new TimeoutException();
+            } else {
+                throw Throwables.propagate(e);
+            }
         }
-        // Randomize the splits so, if processed somewhat in parallel, requests distribute around the ring.
-        Collections.shuffle(splits);
-        return splits;
     }
 
     private List<CfSplit> getCfSplits(Table tbl, int desiredRecordsPerSplit) {
@@ -578,15 +612,68 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
         // Split the token range into sub-ranges with approximately the desired number of records per split
         String rangeStart = tokenRange.getStartToken();
 
-        List<CfSplit> splits = getCfSplits(
-                keyspace.getAstyanaxKeyspace(), cf, tokenRange.getStartToken(), tokenRange.getEndToken(),
-                desiredRecordsPerSplit, allTokenRanges);
+        Deque<AstyanaxBlockedDataReaderDAO.ScanRangeSplitWorkItem> splitWorkQueue = new LinkedList<>();
+        splitWorkQueue.push(new AstyanaxBlockedDataReaderDAO.ScanRangeSplitWorkItem(tokenRange, desiredRecordsPerSplit, true));
 
-        for (CfSplit split : splits) {
-            ByteBuffer begin = parseTokenString(split.getStartToken());
-            ByteBuffer finish = parseTokenString(split.getEndToken());
+        AstyanaxBlockedDataReaderDAO.ScanRangeSplitWorkItem splitWork;
+        while ((splitWork = splitWorkQueue.poll()) != null) {
+            try {
+                List<CfSplit> splits = getCfSplits(
+                        keyspace.getAstyanaxKeyspace(), cf, splitWork.range.getStartToken(), splitWork.range.getEndToken(),
+                        splitWork.desiredRecordsPerSplit, allTokenRanges);
 
-            builder.addScanRange(rack, rangeStart, ScanRange.create(begin, finish));
+                for (CfSplit split : splits) {
+                    if (splitWork.desiredRecordsPerSplit <= desiredRecordsPerSplit) {
+                        ByteBuffer begin = parseTokenString(split.getStartToken());
+                        ByteBuffer finish = parseTokenString(split.getEndToken());
+                        builder.addScanRange(rack, rangeStart, ScanRange.create(begin, finish));
+                    } else {
+                        // This work item was for a larger-than-desired split created due to a previous timeout.
+                        // Add the split back to the work queue to be split again at a smaller size.  Note that
+                        // retryOnTimeout is set to false since we've already established that growing and subdividing
+                        // it won't help.
+                        TokenRange newWorkTokenRange = new TokenRangeImpl(split.getStartToken(), split.getEndToken(), splitWork.range.getEndpoints());
+                        int newWorkDesiredSize = splitWork.desiredRecordsPerSplit / 10;
+                        splitWorkQueue.push(
+                                new AstyanaxBlockedDataReaderDAO.ScanRangeSplitWorkItem(newWorkTokenRange, newWorkDesiredSize, false));
+                        _log.debug("Decreasing scan range split to {} for keyspace {} and range {}", newWorkDesiredSize, keyspace.getName(), newWorkTokenRange);
+                    }
+                }
+            } catch (Exception e) {
+                if (isTimeoutException(e)) {
+                    if (splitWork.retryOnTimeout) {
+                        // Try again with 10 times the desired number of records per split, up to a reasonable maximum
+                        int retryDesiredRecordsPerSplit = (int) Math.min(splitWork.desiredRecordsPerSplit * 10L, Integer.MAX_VALUE);
+                        boolean retryOnTimeout = retryDesiredRecordsPerSplit < desiredRecordsPerSplit * 1000 && retryDesiredRecordsPerSplit != Integer.MAX_VALUE;
+                        splitWorkQueue.push(new AstyanaxBlockedDataReaderDAO.ScanRangeSplitWorkItem(splitWork.range, retryDesiredRecordsPerSplit, retryOnTimeout));
+                        _log.debug("Increasing scan range split to {} for keyspace {} and range {}", retryDesiredRecordsPerSplit, keyspace.getName(), splitWork.range);
+                    } else {
+                        // Either we've already grown the token range to the maximum size we're willing to try
+                        // or we've already succeeded at the larger split size but are still timing out at the smaller one.
+                        // Either way our best choice at this point is to return the over-sized range.  The caller will
+                        // have to adjust around this later.
+                        ByteBuffer begin = parseTokenString(splitWork.range.getStartToken());
+                        ByteBuffer finish = parseTokenString(splitWork.range.getEndToken());
+                        builder.addScanRange(rack, rangeStart, ScanRange.create(begin, finish));
+                        _log.warn("Unable to generate scan range split below {} for keyspace {} and range {}",
+                                splitWork.desiredRecordsPerSplit, keyspace.getName(), splitWork.range);
+                    }
+                } else {
+                    throw Throwables.propagate(e);
+                }
+            }
+        }
+    }
+
+    private class ScanRangeSplitWorkItem {
+        final TokenRange range;
+        final int desiredRecordsPerSplit;
+        final boolean retryOnTimeout;
+
+        public ScanRangeSplitWorkItem(TokenRange range, int desiredRecordsPerSplit, boolean retryOnTimeout) {
+            this.range = range;
+            this.desiredRecordsPerSplit = desiredRecordsPerSplit;
+            this.retryOnTimeout = retryOnTimeout;
         }
     }
 
@@ -837,7 +924,7 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
 
             @Override
             protected boolean isTimeoutException(Exception e) {
-                return Iterables.tryFind(Throwables.getCausalChain(e), Predicates.instanceOf(IsTimeoutException.class)).isPresent();
+                return AstyanaxBlockedDataReaderDAO.this.isTimeoutException(e);
             }
 
             @Override
@@ -861,6 +948,10 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
                 return false;
             }
         };
+    }
+
+    private boolean isTimeoutException(Exception e) {
+        return Iterables.tryFind(Throwables.getCausalChain(e), Predicates.instanceOf(IsTimeoutException.class)).isPresent();
     }
 
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
@@ -400,7 +400,7 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
     public List<String> getSplits(Table tbl, int recordsPerSplit, int localResplits) throws TimeoutException {
         checkNotNull(tbl, "table");
         checkArgument(recordsPerSplit > 0);
-        checkArgument(localResplits > 0);
+        checkArgument(localResplits >= 0);
 
         try {
             List<String> splits = new ArrayList<>();

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
@@ -379,28 +379,35 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
         }));
     }
 
+    // Manually split the token ranges using ByteOrderedPartitioner's midpoint method
+    @VisibleForTesting
+    public List<Token> resplitLocally(String startToken, String endToken, int numResplits) {
+        List<Token> splitTokens = ImmutableList.of(_tokenFactory.fromString(startToken), _tokenFactory.fromString(endToken));
+        for (int i = 0; i < numResplits; i++) {
+            List<Token> newTokens = new ArrayList<>(splitTokens.size() * 2 - 1);
+            for (int j = 0; j < splitTokens.size() - 1; j++) {
+                newTokens.add(splitTokens.get(j));
+                newTokens.add(ByteOrderedPartitioner.instance.midpoint(splitTokens.get(j), splitTokens.get(j + 1)));
+            }
+            newTokens.add(splitTokens.get(splitTokens.size() - 1));
+            splitTokens = newTokens;
+        }
+        return splitTokens;
+    }
+
     @Timed (name = "bv.emodb.sor.AstyanaxDataReaderDAO.getSplits", absolute = true)
     @Override
-    public List<String> getSplits(Table tbl, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
+    public List<String> getSplits(Table tbl, int recordsPerSplit, int localResplits) throws TimeoutException {
         checkNotNull(tbl, "table");
-        checkArgument(splitQuerySize % desiredRecordsPerSplit == 0);
-        checkArgument(Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2) % 2.0 == 0);
+        checkArgument(recordsPerSplit > 0);
+        checkArgument(localResplits > 0);
 
         try {
             List<String> splits = new ArrayList<>();
-            List<CfSplit> cfSplits = getCfSplits(tbl, desiredRecordsPerSplit);
+            List<CfSplit> cfSplits = getCfSplits(tbl, recordsPerSplit);
             for (CfSplit split : cfSplits) {
 
-                List<Token> splitTokens = ImmutableList.of(_tokenFactory.fromString(split.getStartToken()), _tokenFactory.fromString(split.getEndToken()));
-                for (int i = 0; i < Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2); i++) {
-                    List<Token> newTokens = new ArrayList<>(splitTokens.size() * 2 -1);
-                    for (int j = 0; j < splitTokens.size() - 1; j++) {
-                        newTokens.add(splitTokens.get(j));
-                        newTokens.add(ByteOrderedPartitioner.instance.midpoint(splitTokens.get(j), splitTokens.get(j+1)));
-                    }
-                    newTokens.add(splitTokens.get(splitTokens.size() - 1));
-                    splitTokens = newTokens;
-                }
+                List<Token> splitTokens = resplitLocally(split.getStartToken(), split.getEndToken(), localResplits);
 
                 for (int i = 0; i < splitTokens.size() -1; i++) {
                     splits.add(SplitFormat.encode(new ByteBufferRangeImpl(_tokenFactory.toByteArray(splitTokens.get(i)),

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
@@ -40,6 +40,7 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -73,6 +74,9 @@ import com.netflix.astyanax.shallows.EmptyKeyspaceTracerFactory;
 import com.netflix.astyanax.thrift.AbstractKeyspaceOperationImpl;
 import com.netflix.astyanax.util.ByteBufferRangeImpl;
 import com.netflix.astyanax.util.RangeBuilder;
+import io.netty.util.Timeout;
+import java.util.ArrayList;
+import java.util.concurrent.TimeoutException;
 import org.apache.cassandra.dht.ByteOrderedPartitioner;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.thrift.Cassandra;
@@ -367,19 +371,43 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
 
     @Timed (name = "bv.emodb.sor.AstyanaxDataReaderDAO.getSplits", absolute = true)
     @Override
-    public List<String> getSplits(Table tbl, int desiredRecordsPerSplit) {
+    public List<String> getSplits(Table tbl, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
         checkNotNull(tbl, "table");
-        List<String> splits = Lists.newArrayList();
-        List<CfSplit> cfSplits = getCfSplits(tbl, desiredRecordsPerSplit);
-        for (CfSplit split : cfSplits) {
-            ByteBuffer begin = parseTokenString(split.getStartToken());
-            ByteBuffer finish = parseTokenString(split.getEndToken());
+        checkArgument(splitQuerySize % desiredRecordsPerSplit == 0);
+        checkArgument(Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2) % 2.0 == 0);
 
-            splits.add(SplitFormat.encode(new ByteBufferRangeImpl(begin, finish, -1, false)));
+        try {
+            List<String> splits = new ArrayList<>();
+            List<CfSplit> cfSplits = getCfSplits(tbl, desiredRecordsPerSplit);
+            for (CfSplit split : cfSplits) {
+
+                List<Token> splitTokens = ImmutableList.of(_tokenFactory.fromString(split.getStartToken()), _tokenFactory.fromString(split.getEndToken()));
+                for (int i = 0; i < Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2); i++) {
+                    List<Token> newTokens = new ArrayList<>(splitTokens.size() * 2 -1);
+                    for (int j = 0; j < splitTokens.size() - 1; j++) {
+                        newTokens.add(splitTokens.get(j));
+                        newTokens.add(ByteOrderedPartitioner.instance.midpoint(splitTokens.get(j), splitTokens.get(j+1)));
+                    }
+                    newTokens.add(splitTokens.get(splitTokens.size() - 1));
+                    splitTokens = newTokens;
+                }
+
+                for (int i = 0; i < splitTokens.size() -1; i++) {
+                    splits.add(SplitFormat.encode(new ByteBufferRangeImpl(_tokenFactory.toByteArray(splitTokens.get(i)),
+                            _tokenFactory.toByteArray(splitTokens.get(i + 1)), -1, false)));
+                }
+
+            }
+            // Randomize the splits so, if processed somewhat in parallel, requests distribute around the ring.
+            Collections.shuffle(splits);
+            return splits;
+        } catch (Exception e) {
+            if (isTimeoutException(e)) {
+                throw new TimeoutException();
+            } else {
+                throw Throwables.propagate(e);
+            }
         }
-        // Randomize the splits so, if processed somewhat in parallel, requests distribute around the ring.
-        Collections.shuffle(splits);
-        return splits;
     }
 
     private List<CfSplit> getCfSplits(Table tbl, int desiredRecordsPerSplit) {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
@@ -374,7 +374,7 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
     public List<String> getSplits(Table tbl, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
         checkNotNull(tbl, "table");
         checkArgument(splitQuerySize % desiredRecordsPerSplit == 0);
-        checkArgument(Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2) % 2.0 == 0);
+        checkArgument(Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2) % 1.0 == 0);
 
         try {
             List<String> splits = new ArrayList<>();

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
@@ -390,7 +390,7 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
     public List<String> getSplits(Table tbl, int recordsPerSplit, int localResplits) throws TimeoutException {
         checkNotNull(tbl, "table");
         checkArgument(recordsPerSplit > 0);
-        checkArgument(localResplits > 0);
+        checkArgument(localResplits >= 0);
 
         try {
             List<String> splits = new ArrayList<>();

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
@@ -381,6 +381,8 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
             List<CfSplit> cfSplits = getCfSplits(tbl, desiredRecordsPerSplit);
             for (CfSplit split : cfSplits) {
 
+                // In the case in while the splitQuerySize is larger than desiredRecordsPerSplit, manually split the token ranges
+                // using ByteOrderedPartitioner's midpoint method
                 List<Token> splitTokens = ImmutableList.of(_tokenFactory.fromString(split.getStartToken()), _tokenFactory.fromString(split.getEndToken()));
                 for (int i = 0; i < Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2); i++) {
                     List<Token> newTokens = new ArrayList<>(splitTokens.size() * 2 -1);

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
@@ -37,6 +37,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import com.netflix.astyanax.model.ByteBufferRange;
 import com.netflix.astyanax.util.ByteBufferRangeImpl;
+import java.util.concurrent.TimeoutException;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -905,8 +906,8 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
     // support for this call using CQL.  Therefore they must always defer to the Asytanax implementation.
 
     @Override
-    public List<String> getSplits(Table table, int desiredRecordsPerSplit) {
-        return _astyanaxReaderDAO.getSplits(table, desiredRecordsPerSplit);
+    public List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
+        return _astyanaxReaderDAO.getSplits(table, desiredRecordsPerSplit, splitQuerySize);
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
@@ -906,8 +906,8 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
     // support for this call using CQL.  Therefore they must always defer to the Asytanax implementation.
 
     @Override
-    public List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
-        return _astyanaxReaderDAO.getSplits(table, desiredRecordsPerSplit, splitQuerySize);
+    public List<String> getSplits(Table table, int recordsPerSplit, int localResplits) throws TimeoutException {
+        return _astyanaxReaderDAO.getSplits(table, recordsPerSplit, localResplits);
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
@@ -63,6 +63,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 import com.netflix.astyanax.model.ByteBufferRange;
 import com.netflix.astyanax.util.ByteBufferRangeImpl;
+import java.util.concurrent.TimeoutException;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -918,8 +919,8 @@ public class CqlDataReaderDAO implements DataReaderDAO, MigratorReaderDAO {
     // support for this call using CQL.  Therefore they must always defer to the Asytanax implementation.
 
     @Override
-    public List<String> getSplits(Table table, int desiredRecordsPerSplit) {
-        return _astyanaxReaderDAO.getSplits(table, desiredRecordsPerSplit);
+    public List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
+        return _astyanaxReaderDAO.getSplits(table, desiredRecordsPerSplit, splitQuerySize);
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataReaderDAO.java
@@ -919,8 +919,8 @@ public class CqlDataReaderDAO implements DataReaderDAO, MigratorReaderDAO {
     // support for this call using CQL.  Therefore they must always defer to the Asytanax implementation.
 
     @Override
-    public List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
-        return _astyanaxReaderDAO.getSplits(table, desiredRecordsPerSplit, splitQuerySize);
+    public List<String> getSplits(Table table, int recordsPerSplit, int localResplits) throws TimeoutException {
+        return _astyanaxReaderDAO.getSplits(table, recordsPerSplit, localResplits);
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
@@ -27,6 +27,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.RateLimiter;
+import java.util.concurrent.TimeoutException;
+import org.apache.cassandra.dht.ByteOrderedPartitioner;
+import org.apache.cassandra.dht.Token;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 
@@ -180,7 +183,8 @@ public class InMemoryDataReaderDAO implements DataReaderDAO, DataWriterDAO, Migr
     }
 
     @Override
-    public List<String> getSplits(Table table, int desiredRecordsPerSplit) {
+    public List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
+
         List<String> splits = Lists.newArrayList();
         String start = "";
         int count = 0;
@@ -188,9 +192,14 @@ public class InMemoryDataReaderDAO implements DataReaderDAO, DataWriterDAO, Migr
             if (++count == desiredRecordsPerSplit) {
                 splits.add(encodeSplit(start, key));
                 start = key;
+                count = 0;
             }
         }
-        splits.add(encodeSplit(start, ""));
+
+        if (count > 0) {
+            splits.add(encodeSplit(start, ""));
+        }
+
         return splits;
     }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
@@ -183,13 +183,14 @@ public class InMemoryDataReaderDAO implements DataReaderDAO, DataWriterDAO, Migr
     }
 
     @Override
-    public List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
+    public List<String> getSplits(Table table, int recordsPerSplit, int localResplits) throws TimeoutException {
 
         List<String> splits = Lists.newArrayList();
         String start = "";
         int count = 0;
+        int splitSize = recordsPerSplit / ((int) Math.pow(2, localResplits));
         for (String key : safeGet(_contentChanges, table.getName()).keySet()) {
-            if (++count == desiredRecordsPerSplit) {
+            if (++count == splitSize) {
                 splits.add(encodeSplit(start, key));
                 start = key;
                 count = 0;

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeTest.java
@@ -1,6 +1,5 @@
 package com.bazaarvoice.emodb.sor.core;
 
-import com.bazaarvoice.emodb.sor.api.Audit;
 import com.bazaarvoice.emodb.sor.api.AuditBuilder;
 import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
@@ -17,6 +16,7 @@ import java.util.concurrent.TimeoutException;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class MinSplitSizeTest {
@@ -26,6 +26,12 @@ public class MinSplitSizeTest {
         InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO() {
             @Override
             public List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
+
+                // confirm that splitQuerySize / desiredRecordsPerSplit is always a power of 2
+                System.out.println(splitQuerySize);
+                assertEquals(Math.log(splitQuerySize / desiredRecordsPerSplit) / Math.log(2) % 1.0, 0.0);
+
+
                 if (splitQuerySize <= 10) {
                     throw new TimeoutException();
                 }
@@ -51,7 +57,7 @@ public class MinSplitSizeTest {
             fail();
         } catch (Exception e) {}
 
-        // data store should have cached that 10 is too small from previous request and return splits of 100 instead.
+        // Splits should come back normally
         assertEquals(dataStore.getSplits("table", 10).size(), 20);
 
     }

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeTest.java
@@ -94,7 +94,12 @@ public class MinSplitSizeTest {
         // Number of tokens should be 2^5 + 1 = 33, as 33 consecutive tokens can form 32 ranges.
         assertEquals(astyanaxDataReaderDAO.resplitLocally(BOP20Partitioner.MINIMUM, BOP20Partitioner.MAXIMUM, 5).size(), 33);
 
+        List<Token> unsplitTokens = astyanaxDataReaderDAO.resplitLocally(BOP20Partitioner.MINIMUM, BOP20Partitioner.MAXIMUM, 0);
+
         // Number of tokens should be 2^0 + 1 = 2, as 2 consecutive tokens can form 1 range.
-        assertEquals(astyanaxDataReaderDAO.resplitLocally(BOP20Partitioner.MINIMUM, BOP20Partitioner.MAXIMUM, 0).size(), 2);
+        assertEquals(unsplitTokens.size(), 2);
+        assertEquals(unsplitTokens.get(0).toString(), BOP20Partitioner.MINIMUM);
+        assertEquals(unsplitTokens.get(1).toString(), BOP20Partitioner.MAXIMUM);
+
     }
 }

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeTest.java
@@ -1,0 +1,58 @@
+package com.bazaarvoice.emodb.sor.core;
+
+import com.bazaarvoice.emodb.sor.api.Audit;
+import com.bazaarvoice.emodb.sor.api.AuditBuilder;
+import com.bazaarvoice.emodb.sor.api.DataStore;
+import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
+import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
+import com.bazaarvoice.emodb.sor.db.test.InMemoryDataReaderDAO;
+import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.bazaarvoice.emodb.sor.uuid.TimeUUIDs;
+import com.bazaarvoice.emodb.table.db.Table;
+import com.codahale.metrics.MetricRegistry;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class MinSplitSizeTest {
+
+    @Test
+    public void testMinSplitAfterTimeout() {
+        InMemoryDataReaderDAO dataDao = new InMemoryDataReaderDAO() {
+            @Override
+            public List<String> getSplits(Table table, int desiredRecordsPerSplit, int splitQuerySize) throws TimeoutException {
+                if (splitQuerySize <= 10) {
+                    throw new TimeoutException();
+                }
+
+                return super.getSplits(table, desiredRecordsPerSplit, splitQuerySize);
+            }
+        };
+
+        DataStore dataStore = new InMemoryDataStore(dataDao, new MetricRegistry());
+
+        dataStore.createTable("table", new TableOptionsBuilder().setPlacement("default").build(),
+                Collections.emptyMap(), new AuditBuilder().build());
+
+        for (int i = 0; i < 200; i++) {
+            dataStore.update("table", Integer.toString(i), TimeUUIDs.newUUID(), Deltas.fromString("{\"name\":\"Bob\"}"),
+                    new AuditBuilder().build(), WriteConsistency.STRONG);
+        }
+
+        assertEquals(dataStore.getSplits("table", 50).size(), 4);
+
+        try {
+            dataStore.getSplits("table", 10);
+            fail();
+        } catch (Exception e) {}
+
+        // data store should have cached that 10 is too small from previous request and return splits of 100 instead.
+        assertEquals(dataStore.getSplits("table", 10).size(), 20);
+
+    }
+}

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/RedundantDeltaTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/RedundantDeltaTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
+import java.time.Clock;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -64,7 +65,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry(), Clock.systemUTC());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -121,7 +122,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry(), Clock.systemUTC());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -202,7 +203,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry(), Clock.systemUTC());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -222,7 +223,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry(), Clock.systemUTC());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -299,7 +300,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), tableDao, dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(),  new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry(), Clock.systemUTC());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -371,7 +372,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), tableDao, dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(),  new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry(), Clock.systemUTC());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/RedundantDeltaTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/RedundantDeltaTest.java
@@ -18,6 +18,7 @@ import com.bazaarvoice.emodb.sor.compactioncontrol.InMemoryCompactionControlSour
 import com.bazaarvoice.emodb.sor.condition.Conditions;
 import com.bazaarvoice.emodb.sor.core.test.DiscardingExecutorService;
 import com.bazaarvoice.emodb.sor.core.test.InMemoryHistoryStore;
+import com.bazaarvoice.emodb.sor.core.test.InMemoryMapStore;
 import com.bazaarvoice.emodb.sor.db.Key;
 import com.bazaarvoice.emodb.sor.db.Record;
 import com.bazaarvoice.emodb.sor.db.test.InMemoryDataReaderDAO;
@@ -63,7 +64,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -120,7 +121,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -201,7 +202,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -221,7 +222,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), new InMemoryTableDAO(), dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -298,7 +299,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), tableDao, dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(),  new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));
@@ -370,7 +371,7 @@ public class RedundantDeltaTest {
         DefaultDataStore store = new DefaultDataStore(new DatabusEventWriterRegistry(), tableDao, dataDao, dataDao,
                 new NullSlowQueryLog(), new DiscardingExecutorService(), new InMemoryHistoryStore(),
                 Optional.<URI>absent(),  new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                new DiscardingAuditWriter(), new MetricRegistry());
+                new DiscardingAuditWriter(), new InMemoryMapStore<>(), new MetricRegistry());
 
         TableOptions options = new TableOptionsBuilder().setPlacement("default").build();
         store.createTable(TABLE, options, Collections.<String, Object>emptyMap(), newAudit("create table"));

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
@@ -19,6 +19,7 @@ import com.google.common.base.Optional;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import java.net.URI;
+import java.time.Clock;
 
 /**
  * Wrapper around a set of {@link DataStore} instances that replicate to each other,
@@ -63,12 +64,12 @@ public class MultiDCDataStores {
             if (asyncCompacter) {
                 _stores[i] = new DefaultDataStore(new SimpleLifeCycleRegistry(), metricRegistry, new DatabusEventWriterRegistry(), _tableDao,
                         _inMemoryDaos[i].setHistoryStore(_historyStores[i]), _replDaos[i], new NullSlowQueryLog(), _historyStores[i],
-                        Optional.<URI>absent(),  new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new DiscardingAuditWriter(), new InMemoryMapStore<>());
+                        Optional.<URI>absent(),  new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new DiscardingAuditWriter(), new InMemoryMapStore<>(), Clock.systemUTC());
             } else {
                 _stores[i] = new DefaultDataStore(new DatabusEventWriterRegistry(), _tableDao, _inMemoryDaos[i].setHistoryStore(_historyStores[i]),
                         _replDaos[i], new NullSlowQueryLog(), MoreExecutors.sameThreadExecutor(), _historyStores[i],
                         Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                        new DiscardingAuditWriter(), new InMemoryMapStore<>(), metricRegistry);
+                        new DiscardingAuditWriter(), new InMemoryMapStore<>(), metricRegistry, Clock.systemUTC());
             }
         }
     }

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/test/MultiDCDataStores.java
@@ -9,6 +9,7 @@ import com.bazaarvoice.emodb.sor.core.DatabusEventWriterRegistry;
 import com.bazaarvoice.emodb.sor.core.HistoryStore;
 import com.bazaarvoice.emodb.sor.core.DefaultDataStore;
 import com.bazaarvoice.emodb.sor.core.test.InMemoryHistoryStore;
+import com.bazaarvoice.emodb.sor.core.test.InMemoryMapStore;
 import com.bazaarvoice.emodb.sor.db.test.InMemoryDataReaderDAO;
 import com.bazaarvoice.emodb.sor.log.NullSlowQueryLog;
 import com.bazaarvoice.emodb.table.db.TableDAO;
@@ -62,12 +63,12 @@ public class MultiDCDataStores {
             if (asyncCompacter) {
                 _stores[i] = new DefaultDataStore(new SimpleLifeCycleRegistry(), metricRegistry, new DatabusEventWriterRegistry(), _tableDao,
                         _inMemoryDaos[i].setHistoryStore(_historyStores[i]), _replDaos[i], new NullSlowQueryLog(), _historyStores[i],
-                        Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new DiscardingAuditWriter());
+                        Optional.<URI>absent(),  new InMemoryCompactionControlSource(), Conditions.alwaysFalse(), new DiscardingAuditWriter(), new InMemoryMapStore<>());
             } else {
                 _stores[i] = new DefaultDataStore(new DatabusEventWriterRegistry(), _tableDao, _inMemoryDaos[i].setHistoryStore(_historyStores[i]),
                         _replDaos[i], new NullSlowQueryLog(), MoreExecutors.sameThreadExecutor(), _historyStores[i],
                         Optional.<URI>absent(), new InMemoryCompactionControlSource(), Conditions.alwaysFalse(),
-                        new DiscardingAuditWriter(), metricRegistry);
+                        new DiscardingAuditWriter(), new InMemoryMapStore<>(), metricRegistry);
             }
         }
     }


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

When calls to `getSplits` are made with split sizes that Cassandra is unable to provide, Emo returns a 500 do to Cassandra timeout. If the client retries, it will likely continue to repetitively timeout and never return successfully. 

This PR attempts to create a 24-hour Zookeeper cache of all timeouts from `getSplits` from each table. Before fulfilling a call to `getSplits` Emo will check the cache and only perform a split call to Cassandra with a size it thinks has a reasonable chance of returning.

If Emo is forced to use a larger Cassandra split size, then it will manually resplit the splits it received lexicographically to emulate splits of desired size.

## How to Test and Verify

This is somewhat hard to test locally for two reasons:
1. It is extremely hard to get Cassandra to timeout a call to `getSplits` locally
2. Local Cassandra seems to give inaccurate splits

Outside of the above, I have done my best to test this locally by faking these situation by modifying Emo to emulate these circumstances.

## Risk

### Level 

`Medium`

### Required Testing

`Regression`

### Risk Summary

The main risk here is that the new system somehow returns inaccurate splits that lead to missing data.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
