### PR TITLE
Added weighting of conditions to assist in evaluating them efficiently

### DIFF
--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/Condition.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/Condition.java
@@ -22,6 +22,14 @@ public interface Condition {
 
     void appendTo(Appendable buf) throws IOException;
 
+    /**
+     * A rough estimate of the computational complexity for this condition.  In many cases this varies based on the
+     * context and cannot be reliably provided in the abstract.  This method is not intended to provide a definitive
+     * weight but should be a best estimate only for the purpose of ordering condition evaluation in the context of
+     * an "and", "or", or "map" condition in increasing order of complexity.
+     */
+    int weight();
+
     boolean equals(@Nullable Object o);
 
     int hashCode();

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AbstractCondition.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AbstractCondition.java
@@ -17,4 +17,12 @@ public abstract class AbstractCondition implements Condition {
         }
         return buf.toString();
     }
+    /**
+     * Default weight for all conditions is 1.  Conditions which are more complex than a trivial check should return
+     * a higher value.
+     */
+    @Override
+    public int weight() {
+        return 1;
+    }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AndConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/AndConditionImpl.java
@@ -6,21 +6,36 @@ import com.bazaarvoice.emodb.sor.condition.ConditionVisitor;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * Standard implementation for {@link AndCondition}.  Note that this implementation preserves the original condition
+ * order internally for serialization purposes in {@link #appendTo(Appendable)} but the return value from
+ * {@link #getConditions()} is sorted by increasing weight.
+ */
 public class AndConditionImpl extends AbstractCondition implements AndCondition {
 
     private final Collection<Condition> _conditions;
+    private final List<Condition> _weightSortedConditions;
 
     public AndConditionImpl(Collection<Condition> conditions) {
         _conditions = checkNotNull(conditions, "conditions");
+        _weightSortedConditions = Collections.unmodifiableList(
+                conditions.stream()
+                        .sorted(Comparator.comparingInt(Condition::weight))
+                        .collect(Collectors.toList()));
     }
 
     @Override
     public Collection<Condition> getConditions() {
-        return _conditions;
+        return _weightSortedConditions;
     }
 
     @Override
@@ -40,13 +55,39 @@ public class AndConditionImpl extends AbstractCondition implements AndCondition 
         buf.append(")");
     }
 
+    /**
+     * The worst case total weight of an "and" is the sum of the weights of all contained conditions.
+     */
+    @Override
+    public int weight() {
+        return _conditions.stream().mapToInt(Condition::weight).sum();
+    }
+
     @Override
     public boolean equals(Object o) {
-        return this == o || (o instanceof AndCondition) && _conditions.equals(((AndCondition) o).getConditions());
+        return this == o || (o instanceof AndCondition) && conditionsEqual(((AndCondition) o).getConditions());
+    }
+
+    /**
+     * The order of the conditions is irrelevant, just check the set is the same.
+     */
+    private boolean conditionsEqual(Collection<Condition> conditions) {
+        if (conditions.size() != _conditions.size()) {
+            return false;
+        }
+        List<Condition> unvalidatedConditions = new ArrayList<>(conditions);
+        for (Condition condition : _conditions) {
+            if (!unvalidatedConditions.remove(condition)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
     public int hashCode() {
-        return 11213 ^ _conditions.hashCode();
+        // Order of the underlying collection of values is irrelevant, so sum the individual object hashes
+        // so that order does not affect the computed hash.
+        return 11213 ^ _conditions.stream().mapToInt(Object::hashCode).sum();
     }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/ConstantConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/ConstantConditionImpl.java
@@ -32,6 +32,14 @@ public class ConstantConditionImpl extends AbstractCondition implements Constant
         buf.append(_value ? "alwaysTrue()" : "alwaysFalse()");
     }
 
+    /**
+     * Constant conditions are effectively free since the result is simply "true" or "false" with no computation necessary.
+     */
+    @Override
+    public int weight() {
+        return 0;
+    }
+
     @Override
     public boolean equals(Object o) {
         return this == o || (o instanceof ConstantCondition) && _value == ((ConstantCondition) o).getValue();

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/LikeConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/LikeConditionImpl.java
@@ -464,5 +464,13 @@ abstract public class LikeConditionImpl extends AbstractCondition implements Lik
                     Joiner.on(substitute).join(_innerSubstrings) +
                     substitute + _suffix;
         }
+
+        /**
+         * Of all of the "like" condition variants the complex implementation is slightly more expensive to compute.
+         */
+        @Override
+        public int weight() {
+            return 2;
+        }
     }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/NotConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/NotConditionImpl.java
@@ -34,6 +34,15 @@ public class NotConditionImpl extends AbstractCondition implements NotCondition 
         buf.append(")");
     }
 
+    /**
+     * Inverting the contained condition is effectively free, so the weight of a "not" is the same as the weight of
+     * the contained condition.
+     */
+    @Override
+    public int weight() {
+        return _condition.weight();
+    }
+
     @Override
     public boolean equals(Object o) {
         return (this == o) || (o instanceof NotCondition) && _condition.equals(((NotCondition) o).getCondition());

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/OrConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/impl/OrConditionImpl.java
@@ -6,21 +6,37 @@ import com.bazaarvoice.emodb.sor.condition.OrCondition;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+/**
+ * Standard implementation for {@link OrCondition}.  Note that this implementation preserves the original condition
+ * order internally for serialization purposes in {@link #appendTo(Appendable)} but the return value from
+ * {@link #getConditions()} is sorted by increasing weight.
+ */
 public class OrConditionImpl extends AbstractCondition implements OrCondition {
 
     private final Collection<Condition> _conditions;
+    private final List<Condition> _weightSortedConditions;
 
     public OrConditionImpl(Collection<Condition> conditions) {
         _conditions = checkNotNull(conditions, "conditions");
+        _weightSortedConditions = Collections.unmodifiableList(
+                conditions.stream()
+                        .sorted(Comparator.comparingInt(Condition::weight))
+                        .collect(Collectors.toList()));
+
     }
 
     @Override
     public Collection<Condition> getConditions() {
-        return _conditions;
+        return _weightSortedConditions;
     }
 
     @Override
@@ -40,13 +56,39 @@ public class OrConditionImpl extends AbstractCondition implements OrCondition {
         buf.append(")");
     }
 
+    /**
+     * The worst case total weight of an "or" is the sum of the weights of all contained conditions.
+     */
+    @Override
+    public int weight() {
+        return _conditions.stream().mapToInt(Condition::weight).sum();
+    }
+
     @Override
     public boolean equals(Object o) {
-        return this == o || (o instanceof OrCondition) && _conditions.equals(((OrCondition) o).getConditions());
+        return this == o || (o instanceof OrCondition) && conditionsEqual(((OrCondition) o).getConditions());
+    }
+
+    /**
+     * The order of the conditions is irrelevant, just check the set is the same.
+     */
+    private boolean conditionsEqual(Collection<Condition> conditions) {
+        if (conditions.size() != _conditions.size()) {
+            return false;
+        }
+        List<Condition> unvalidatedConditions = new ArrayList<>(conditions);
+        for (Condition condition : _conditions) {
+            if (!unvalidatedConditions.remove(condition)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
     public int hashCode() {
-        return 10601 ^ _conditions.hashCode();
+        // Order of the underlying collection of values is irrelevant, so sum the individual object hashes
+        // so that order does not affect the computed hash.
+        return 10601 ^ _conditions.stream().mapToInt(Object::hashCode).sum();
     }
 }

--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/ContainsConditionImpl.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/delta/impl/ContainsConditionImpl.java
@@ -111,6 +111,16 @@ public class ContainsConditionImpl implements ContainsCondition {
         buf.append(")");
     }
 
+    /**
+     * "Contains" more-so than other conditions is difficult to determine the weight for a-priori since its evaluation
+     * time in the worst case scales linearly based on the input size.  For this reason the weight is skewed higher
+     * than normal.
+     */
+    @Override
+    public int weight() {
+        return 3 * _values.size();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

Currently when conditions are evaluated for a subscription for an "and", "or", or "map" condition they conditions are evaluated in an arbitrary order which usually aligns with the original order provided by the user.  Computation time could be improved if these conditions processed their internal conditions in increasing order of complexity.  For example, "and(_expensiveCondition_, _cheapCondition_)" can evaluate the internal conditions in any order but if _cheapCondition_ turns out to be false then the entire operation would be faster if it were evaluated before _expensiveCondition_.

This PR adds an approximate weight to every condition type.  It then uses these weights to evaluate internal conditions in order from least to greatest weight for "and", "or", and "map" conditions.

## How to Test and Verify

Functionally there are no changes with the PR, the benefits are purely in runtime.  Therefore the only testing required is regression testing.

1. Check out this PR
2. Run integration tests and verify nothing is broken.

## Risk

### Level 

`Low`

### Required Testing

`Regression`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
