### PR TITLE
Prevent tables from being purged during delta migration

### DIFF
--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -53,6 +53,7 @@ import com.bazaarvoice.emodb.table.db.astyanax.MoveTableTask;
 import com.bazaarvoice.emodb.table.db.astyanax.PlacementCache;
 import com.bazaarvoice.emodb.table.db.astyanax.PlacementFactory;
 import com.bazaarvoice.emodb.table.db.astyanax.PlacementsUnderMove;
+import com.bazaarvoice.emodb.table.db.astyanax.PurgesBlocked;
 import com.bazaarvoice.emodb.table.db.astyanax.RateLimiterCache;
 import com.bazaarvoice.emodb.table.db.astyanax.SystemTableNamespace;
 import com.bazaarvoice.emodb.table.db.astyanax.TableChangesEnabledTask;
@@ -137,6 +138,9 @@ public class BlobStoreModule extends PrivateModule {
 
     @Override
     protected void configure() {
+
+        bind(Boolean.class).annotatedWith(PurgesBlocked.class).toInstance(false);
+
         // Note: we only use ZooKeeper if this is the data center that is allowed to edit table metadata (create/drop table)
         // Chain TableDAO -> MutexTableDAO -> CachingTableDAO -> AstyanaxTableDAO.
         bind(TableDAO.class).to(MutexTableDAO.class).asEagerSingleton();

--- a/quality/integration/src/test/java/test/integration/sor/CasStashTableTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/CasStashTableTest.java
@@ -92,7 +92,7 @@ public class CasStashTableTest  {
         _astyanaxTableDAO = new AstyanaxTableDAO(_lifeCycleRegistry, "__system_sor", "app_global:sys",
                 8, ImmutableMap.of(), placementFactory, placementCache, "datacenter1",
                 mock(RateLimiterCache.class), mock(DataCopyDAO.class), mock(DataPurgeDAO.class), mock(FullConsistencyTimeProvider.class),
-                mock(ValueStore.class), mock(CacheRegistry.class), ImmutableMap.of(), mock(Clock.class));
+                mock(ValueStore.class), mock(CacheRegistry.class), ImmutableMap.of(), false, mock(Clock.class));
         _astyanaxTableDAO.setCQLStashTableDAO(cqlStashTableDAO);
         // Don't store table definitions in the actual backing store so as not to interrupt other tests.  Use a
         // private in-memory implementation.

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreModule.java
@@ -442,6 +442,11 @@ public class DataStoreModule extends PrivateModule {
                 .or(Conditions.alwaysFalse());
     }
 
+    @Provides @Singleton @PurgesBlocked
+    boolean providePurgesBlocked(DataStoreConfiguration configuration) {
+        return configuration.getMigrationPhase() == DeltaMigrationPhase.DOUBLE_WRITE_LEGACY_READ;
+    }
+
     private Collection<ClusterInfo> getClusterInfos(DataStoreConfiguration configuration) {
         Map<String, ClusterInfo> clusterInfoMap = Maps.newLinkedHashMap();
         for (CassandraConfiguration config : configuration.getCassandraClusters().values()) {

--- a/sor/src/test/java/com/bazaarvoice/emodb/table/db/astyanax/TableLifeCycleTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/table/db/astyanax/TableLifeCycleTest.java
@@ -2169,7 +2169,7 @@ public class TableLifeCycleTest {
                 placementFactory, new PlacementCache(placementFactory),
                 dataCenter, mock(RateLimiterCache.class), dataCopyDAO, dataPurgeDAO,
                 fullConsistencyTimeProvider, tableChangesEnabled, cacheRegistry,
-                ImmutableMap.of(PL_ZZ_MOVING, PL_ZZ), clock);
+                ImmutableMap.of(PL_ZZ_MOVING, PL_ZZ), false, clock);
         tableDAO.setBackingStore(backingStore);
         return tableDAO;
     }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
@@ -473,7 +473,7 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
                     public void run(Runnable progress) {
 
                         if (_purgesBlocked) {
-                            throw new FullConsistencyException("It is unsafe to purge a table during delta migration.");
+                            throw new IllegalStateException("It is unsafe to purge a table during delta migration.");
                         }
 
                         // Delay the final purge until we're confident we'll catch everything.

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
@@ -178,6 +178,7 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
     private final CacheHandle _tableCacheHandle;
     private final Map<String, String> _placementsUnderMove;
     private CQLStashTableDAO _stashTableDao;
+    private final boolean _purgesBlocked;
     private Clock _clock;
 
     @Inject
@@ -196,6 +197,7 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
                             @TableChangesEnabled ValueStore<Boolean> tableChangesEnabled,
                             @CachingTableDAORegistry CacheRegistry cacheRegistry,
                             @PlacementsUnderMove Map<String, String> placementsUnderMove,
+                            @PurgesBlocked boolean purgesBlocked,
                             @Nullable Clock clock) {
         _systemTablePlacement = checkNotNull(systemTablePlacement, "systemTablePlacement");
         _bootstrapTables = HashBiMap.create(checkNotNull(bootstrapTables, "bootstrapTables"));
@@ -211,6 +213,7 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
         _tableChangesEnabled = checkNotNull(tableChangesEnabled, "tableChangesEnabled");
         _tableCacheHandle = cacheRegistry.lookup("tables", true);
         _placementsUnderMove = checkNotNull(placementsUnderMove, "placementsUnderMove");
+        _purgesBlocked = purgesBlocked;
         _clock = clock != null ? clock : Clock.systemUTC();
 
         // There are two tables used to store metadata about all the other tables.
@@ -468,6 +471,11 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
                 return MaintenanceOp.forData("Drop:purge-" + iteration, iteration == 1 ? when1 : when2, dataCenter, new MaintenanceTask() {
                     @Override
                     public void run(Runnable progress) {
+
+                        if (_purgesBlocked) {
+                            throw new FullConsistencyException("It is unsafe to purge a table during delta migration.");
+                        }
+
                         // Delay the final purge until we're confident we'll catch everything.
                         if (iteration == 2) {
                             checkPlacementConsistent(storage.getPlacement(), droppedAt);

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/PurgesBlocked.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/PurgesBlocked.java
@@ -1,0 +1,19 @@
+package com.bazaarvoice.emodb.table.db.astyanax;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for determining whether to block Emo from purging tables.
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface PurgesBlocked {
+}

--- a/table/src/test/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAOTest.java
+++ b/table/src/test/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAOTest.java
@@ -116,7 +116,7 @@ public class AstyanaxTableDAOTest {
                 newPlacementFactory(dataCenter), mock(PlacementCache.class), dataCenter,
                 mock(RateLimiterCache.class), mock(DataCopyDAO.class), mock(DataPurgeDAO.class),
                 mock(FullConsistencyTimeProvider.class), mock(ValueStore.class), mock(CacheRegistry.class),
-                ImmutableMap.<String, String>of(), mock(Clock.class));
+                ImmutableMap.<String, String>of(), false, mock(Clock.class));
 
         TableBackingStore tableBackingStore = mock(TableBackingStore.class);
         Map<String, Object> tableMap = JsonHelper.fromJson(_tableMetaData, new TypeReference<Map<String, Object>>() {});


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

After a table is dropped, Emo asynchronously purges all it is data in the background. During delta migration, this is undesirable because Emo could attempt to delete a delta after it has been read in my the migrator, but before it has been written to the new table. If this were to happen, dead data could end up on the Cassandra ring that Emo has no knowledge of. This would therefore lead it being eternally dead data that could not be cleaned up. This situation is no dangerous to Emo's operation of data consistency, but rather just wasteful and undesirable.

The best solution to this problem is to modify Emo to not perform any table purges during delta migration. This would not prevent tables from being dropped, but rather just defer the purge stage until after the delta migration is complete.

## How to Test and Verify

Testing this is difficult because table's do not begin the purge process until 1 day after they have been dropped. 

The best way to test this is to manually modify `DROP_TO_PURGE_1` in `AstyanaxTableDAO.java` to be 1 second rather than 1 day. Doing this will cause Emo to immediately attempt a purge.
1. Set the migration phase in the config to `BLOCKED_WRITE_LEGACY_READ`
2. Create a table in Emo
3. Add some data to it
4.. Drop the table
5. Verify in the logs that Emo threw a `FullConsistencyException` and prevented the purge
6. Use `cqlsh` to verify none of the data was deleted

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The only risk I see here is that a critical mass of purges build up during the delta migration, which could cause chaos when Emo attempts to purge them all after. I think this is highly unlikely, however.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
