### PR TITLE
Fixed error in convenience call to create partition condition.

### DIFF
--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/Conditions.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/condition/Conditions.java
@@ -208,7 +208,7 @@ public abstract class Conditions {
         return partition(numPartitions, equal(partition));
     }
 
-    public static Condition partition(int numPartitions, int... partitions) {
+    public static Condition partition(int numPartitions, Integer... partitions) {
         return partition(numPartitions, in(Arrays.asList(partitions)));
     }
 

--- a/sor-api/src/test/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluatorTest.java
+++ b/sor-api/src/test/java/com/bazaarvoice/emodb/sor/condition/eval/ConditionEvaluatorTest.java
@@ -354,11 +354,11 @@ public class ConditionEvaluatorTest {
             when(intrinsics.getTable()).thenReturn("mytable");
             when(intrinsics.getId()).thenReturn("doc" + i);
             for (int t=1; t <= 64; t++) {
-                if (t == expected.get(i)) {
-                    assertTrue(eval(Conditions.partition(64, Conditions.equal(t)), null, intrinsics));
-                } else {
-                    assertFalse(eval(Conditions.partition(64, Conditions.equal(t)), null, intrinsics));
-                }
+                boolean matches = t == expected.get(i);
+                assertEquals(eval(Conditions.partition(64, t), null, intrinsics), matches);
+                // When testing "in" convenience method just need to chose a partition which is not in the "expected" set
+                assertEquals(eval(Conditions.partition(64, t, 2), null, intrinsics), matches);
+                assertEquals(eval(Conditions.partition(64, Conditions.equal(t)), null, intrinsics), matches);
             }
         }
     }


### PR DESCRIPTION
## Github Issue #

None

## What Are We Doing Here?

This fixes a bug in the call to `Conditions.partition(int numPartitions, int... partitions)`.  This code is not in use anywhere so there is no current risk, but were a client to use this convenience method it would raise an exception due to an improper array-to-list conversion.

## How to Test and Verify

1. Check out this PR
2. Programmatically create a condition using the above method call.
3. Verify no exception was thrown.

## Risk

Low

### Level 

`Low`

### Required Testing

`Smoke`

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
