### PR TITLE
 EMO-6762 create/remove compaction metric in service lifecycle

### DIFF
--- a/web-local/start-zookeeper.sh
+++ b/web-local/start-zookeeper.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# Docker Installation on Mac OS X: https://docs.docker.com/engine/installation/mac/
-#
-# Starts the following services locally (see configuration reference https://docs.docker.com/samples/library/zookeeper/):
-# - ZooKeeper (port 2181)
-
-docker run -p 2181:2181  -v $(pwd)/target/zookeeper:/data zookeeper:3.4.13

--- a/web-local/start-zookeeper.sh
+++ b/web-local/start-zookeeper.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Docker Installation on Mac OS X: https://docs.docker.com/engine/installation/mac/
+#
+# Starts the following services locally (see configuration reference https://docs.docker.com/samples/library/zookeeper/):
+# - ZooKeeper (port 2181)
+
+docker run -p 2181:2181  -v $(pwd)/target/zookeeper:/data zookeeper:3.4.13

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitorManager.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitorManager.java
@@ -6,14 +6,11 @@ import com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ManagedGuavaService;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.ServiceFailureListener;
-import com.bazaarvoice.emodb.datacenter.api.DataCenters;
 import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.compactioncontrol.LocalCompactionControl;
 import com.bazaarvoice.emodb.table.db.consistency.GlobalFullConsistencyZooKeeper;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.base.Supplier;
 import com.google.common.net.HostAndPort;
-import com.google.common.util.concurrent.Service;
 import com.google.inject.Inject;
 import org.apache.curator.framework.CuratorFramework;
 
@@ -27,20 +24,20 @@ public class CompactionControlMonitorManager {
     @Inject
     CompactionControlMonitorManager(LifeCycleRegistry lifeCycle,
                                     @LocalCompactionControl CompactionControlSource compactionControlSource,
-                                    DataCenters dataCenters,
                                     @GlobalFullConsistencyZooKeeper CuratorFramework curator,
                                     @SelfHostAndPort HostAndPort self,
                                     Clock clock,
                                     LeaderServiceTask dropwizardTask,
                                     final MetricRegistry metricRegistry) {
         LeaderService leaderService = new LeaderService(
-                curator, "/leader/compaction-control-monitor", self.toString(), "Leader-CompactionControlMonitor", 30, TimeUnit.MINUTES,
-                new Supplier<Service>() {
-                    @Override
-                    public Service get() {
-                        return new CompactionControlMonitor(compactionControlSource, clock, metricRegistry);
-                    }
-                });
+                curator,
+                "/leader/compaction-control-monitor",
+                self.toString(),
+                "Leader-CompactionControlMonitor",
+                30, TimeUnit.MINUTES,
+                () -> new CompactionControlMonitor(compactionControlSource, clock, metricRegistry)
+        );
+
         ServiceFailureListener.listenTo(leaderService, metricRegistry);
         dropwizardTask.register("stash-runtime-monitor", leaderService);
         lifeCycle.manage(new ManagedGuavaService(leaderService));

--- a/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitorTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlMonitorTest.java
@@ -36,16 +36,15 @@ public class CompactionControlMonitorTest {
         compactionControlMonitor.deleteExpiredStashTimes(timestamp1 + Duration.ofMinutes(10).toMillis());
         Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 3);
         StashTimeKey stashTimeKey = StashTimeKey.of("id-1", "us-east-1");
-        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey(stashTimeKey), true);
+        Assert.assertTrue(compactionControlSource.getAllStashTimes().containsKey(stashTimeKey));
 
         compactionControlMonitor.deleteExpiredStashTimes(expiredTimestamp1 + Duration.ofMinutes(1).toMillis());
         Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 2);
-        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey(stashTimeKey), false);
+        Assert.assertFalse(compactionControlSource.getAllStashTimes().containsKey(stashTimeKey));
 
         compactionControlMonitor.deleteExpiredStashTimes(expiredTimestamp3 + Duration.ofMinutes(1).toMillis());
         Assert.assertEquals(compactionControlSource.getAllStashTimes().size(), 0);
-        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey(stashTimeKey), false);
-        Assert.assertEquals(compactionControlSource.getAllStashTimes().containsKey(stashTimeKey), false);
+        Assert.assertFalse(compactionControlSource.getAllStashTimes().containsKey(stashTimeKey));
+        Assert.assertFalse(compactionControlSource.getAllStashTimes().containsKey(stashTimeKey));
     }
-
 }


### PR DESCRIPTION
## What Are We Doing Here?

- Create/remove `bv.emodb.scan.ScanUploader.compaction-control-time-lag` metric based on lifecycle of ScheduledService
- Add script that starts zookeeper locally
- Update tests

## How to Test and Verify

- add  `"com.bazaarvoice.emodb.web.compactioncontrol": DEBUG` to logging section in  web-local/config-local.yaml

- update reacquireDelay from `30, TimeUnit.MINUTES` to `10, TimeUnit.SECONDS` in LeaderService constructor in `com.bazaarvoice.emodb.web.compactioncontrol.CompactionControlMonitorManager` class 

- `cd web-local && ./start-clean.sh`

- in another terminal tab run `curl localhost:8081/tasks/leader?release=stash-runtime-monitor -XPOST
`
- wait for 10 seconds
- verify following output without exceptions:
```
WARN  [2018-12-21 13:28:09,482] [dw-admin-255] com.bazaarvoice.emodb.common.dropwizard.leader.LeaderServiceTask: Temporarily releasing leadership for process: stash-runtime-monitor
DEBUG [2018-12-21 13:28:09,483] [CompactionControlMonitor STOPPING] com.bazaarvoice.emodb.web.compactioncontrol.CompactionControlMonitor: CompactionControlMonitor has been shut down
0:0:0:0:0:0:0:1 -  -  [21/Dec/2018:13:28:09 +0000] "POST /tasks/leader?release=stash-runtime-monitor HTTP/1.1" 200 - "-" "curl/7.54.0" 31
DEBUG [2018-12-21 13:28:19,498] [CompactionControlMonitor STARTING] com.bazaarvoice.emodb.web.compactioncontrol.CompactionControlMonitor: CompactionControlMonitor has been started
DEBUG [2018-12-21 13:28:19,498] [CompactionControlMonitor RUNNING] com.bazaarvoice.emodb.web.compactioncontrol.CompactionControlMonitor: Checking for expired stash times at 1545398899498
```
## Risk

### Level 

Low

### Required Testing

Manual

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
