### PR TITLE
Fix bugs in DeltaIterator and CQL Reader DAO

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
@@ -56,6 +56,8 @@ abstract public class DeltaIterator<R, T> extends AbstractIterator<T> {
 
         // delta is fragmented if the first block is not zero. In this case, we skip it.
         if (getBlock(_list.get(0)) != 0) {
+            // We must also clear the list of the fragmented delta blocks to avoid them being stitched in with
+            // the next delta, which will cause a buffer overflow
             _list.clear();
             return null;
         }
@@ -91,6 +93,9 @@ abstract public class DeltaIterator<R, T> extends AbstractIterator<T> {
                     contentSize += getValue(_next).remaining();
                 } else {
                     // fragmented delta encountered, we must skip over it
+
+                    // We must also clear the list of the fragmented delta blocks to avoid them being stitched in with
+                    // the next delta, which will cause a buffer overflow
                     _list.clear();
                     return null;
                 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
@@ -56,6 +56,7 @@ abstract public class DeltaIterator<R, T> extends AbstractIterator<T> {
 
         // delta is fragmented if the first block is not zero. In this case, we skip it.
         if (getBlock(_list.get(0)) != 0) {
+            _list.clear();
             return null;
         }
 
@@ -90,6 +91,7 @@ abstract public class DeltaIterator<R, T> extends AbstractIterator<T> {
                     contentSize += getValue(_next).remaining();
                 } else {
                     // fragmented delta encountered, we must skip over it
+                    _list.clear();
                     return null;
                 }
             } else {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
@@ -189,7 +189,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
 
     /**
      * Synchronously executes the provided statement.  The statement must query the delta table as returned from
-     * {@link com.bazaarvoice.emodb.sor.db.astyanax.DeltaPlacement#getDeltaTableDDL()}
+     * {@link com.bazaarvoice.emodb.sor.db.astyanax.DeltaPlacement#getBlockedDeltaTableDDL()}
      */
     private Iterator<Iterable<Row>> deltaQuery(DeltaPlacement placement, Statement statement, boolean singleRow,
                                                String errorContext, Object... errorContextArgs) {
@@ -199,7 +199,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
     /**
      * Asynchronously executes the provided statement.  Although the iterator is returned immediately the actual results
      * may still be loading in the background.  The statement must query the delta table as returned from
-     * {@link com.bazaarvoice.emodb.sor.db.astyanax.DeltaPlacement#getDeltaTableDDL()}
+     * {@link com.bazaarvoice.emodb.sor.db.astyanax.DeltaPlacement#getBlockedDeltaTableDDL()}
      */
     private Iterator<Iterable<Row>> deltaQueryAsync(DeltaPlacement placement, Statement statement, boolean singleRow,
                                                     String errorContext, Object... errorContextArgs) {
@@ -723,7 +723,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
         @Override
         protected ResultSet queryRowGroupRowsAfter(Row row) {
             Range<RangeTimeUUID> columnRange = Range.greaterThan(new RangeTimeUUID(getChangeId(row)));
-            return columnScan(_placement, _placement.getDeltaTableDDL(), getKey(row),
+            return columnScan(_placement, _placement.getBlockedDeltaTableDDL(), getKey(row),
                     columnRange, true, _consistency);
         }
     }
@@ -735,7 +735,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
     private ResultSet columnScan(DeltaPlacement placement, TableDDL tableDDL, ByteBuffer rowKey, Range<RangeTimeUUID> columnRange,
                                  boolean ascending, ConsistencyLevel consistency) {
 
-        Select.Where where = (tableDDL == placement.getDeltaTableDDL() ? selectDeltaFrom(placement.getBlockedDeltaTableDDL()) : selectFrom(tableDDL))
+        Select.Where where = (tableDDL == placement.getBlockedDeltaTableDDL() ? selectDeltaFrom(placement.getBlockedDeltaTableDDL()) : selectFrom(tableDDL))
                 .where(eq(tableDDL.getRowKeyColumnName(), rowKey));
 
         if (columnRange.hasLowerBound()) {
@@ -785,7 +785,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
         // Read Delta and Compaction objects
         Iterator<Change> deltas = Iterators.emptyIterator();
         if (includeContentData) {
-            TableDDL deltaDDL = placement.getDeltaTableDDL();
+            TableDDL deltaDDL = placement.getBlockedDeltaTableDDL();
             ProtocolVersion protocolVersion = placement.getKeyspace().getCqlSession().getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
             CodecRegistry codecRegistry = placement.getKeyspace().getCqlSession().getCluster().getConfiguration().getCodecRegistry();
 

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -57,7 +57,7 @@ dataCenter:
 
 systemOfRecord:
   migrationPhase: PRE_MIGRATION
-  deltaBlockSizeInKb: 8
+  deltaBlockSizeInKb: 16
   stashRoot: s3://emodb-us-east-1/stash/ci
 
   # Optional property - to exclude the tables satisfying the condition from the daily Stash run.


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

In the process of testing blocked deltas, I encountered two bugs that can cause a read to fail. Neither bug can cause data corruption or inconsistency of any kind, as they cause read's to fail, rather than providing an inaccurate read.

1. `CQLBlockedDataReaderDAO`: There were several calls to `deltaTableDDL` that should be calls to `blockedDeltaTableDDL`. These DDL's are not equivalent, and therefore reads can fail when there are calls to deltaTableDDL.

2. `DeltaIterator`: In the rare instance where a delta is deleted by compaction while it is in the process of being stitched together, the delta should be ignored. This was already the case, though the `DeltaIterator` did not properly clean up after itself when this occurred, as it does not clear the blocks that it had already accumulated from the list. This can cause a read to fail, as those uncleaned up blocks can cause a buffer overflow when stitching the next delta.

## How to Test and Verify

This is difficult to test, as these failures occur at non-deterministic times. The best we can do is test these fixes extensively in our QA environments and ensure that they do not occur anymore.

## Risk

### Level 

`Medium`

### Required Testing

`Regression`

### Risk Summary

This is medium risk just because it is a modification of the underlying datastore implementation. That being said, these changes are pretty small and contained. 

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
