### PR TITLE
EMO-6802: Add maximum size in bytes for a slab to prevent problems due to very large documents

### DIFF
--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/ChannelAllocationState.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/ChannelAllocationState.java
@@ -81,19 +81,18 @@ public class ChannelAllocationState {
             detach().release();
             return null;
 
+        }
+
+        if (countAndBytesConsumed.getLeft() < remaining) {
+
+            // All events fit in current slab, leave it attached
+            return new DefaultSlabAllocation(_slab.addRef(), offsetForNewAllocation, countAndBytesConsumed.getLeft());
+
         } else {
 
-            if (countAndBytesConsumed.getLeft() < remaining) {
+            // Whatever is left of this slab is consumed. Return the rest of the slab. Detach from it so we'll allocate a new one next time.
+            return new DefaultSlabAllocation(detach(), offsetForNewAllocation, countAndBytesConsumed.getLeft());
 
-                // All events fit in current slab, leave it attached
-                return new DefaultSlabAllocation(_slab.addRef(), offsetForNewAllocation, countAndBytesConsumed.getLeft());
-
-            } else {
-
-                // Whatever is left of this slab is consumed. Return the rest of the slab. Detach from it so we'll allocate a new one next time.
-                return new DefaultSlabAllocation(detach(), offsetForNewAllocation, countAndBytesConsumed.getLeft());
-
-            }
         }
     }
 }

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/ChannelAllocationState.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/ChannelAllocationState.java
@@ -1,5 +1,8 @@
 package com.bazaarvoice.emodb.event.db.astyanax;
 
+import com.google.common.collect.PeekingIterator;
+import org.apache.commons.lang3.tuple.Pair;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
@@ -8,6 +11,7 @@ public class ChannelAllocationState {
     private SlabRef _slab;
     private int _slabConsumed;
     private long _slabExpiresAt;
+    private int _slabBytesConsumed;
 
     /** Per-channel lock on creating new shared slabs. */
     public Object getSlabCreationLock() {
@@ -25,9 +29,9 @@ public class ChannelAllocationState {
     }
 
     /** Attaches a slab and allocates from it in a single atomic operation. */
-    public synchronized SlabAllocation attachAndAllocate(SlabRef slab, int desired) {
+    public synchronized SlabAllocation attachAndAllocate(SlabRef slab, PeekingIterator<Integer> eventSizes) {
         attach(slab);
-        return allocate(desired);
+        return allocate(eventSizes);
     }
 
     /** Attaches a new slab to the channel with the specified capacity. */
@@ -37,6 +41,7 @@ public class ChannelAllocationState {
 
         _slab = slab;
         _slabConsumed = 0;
+        _slabBytesConsumed = 0;
         _slabExpiresAt = System.currentTimeMillis() + Constants.SLAB_ROTATE_TTL.toMillis();
     }
 
@@ -53,22 +58,32 @@ public class ChannelAllocationState {
         return slab;
     }
 
-    public synchronized SlabAllocation allocate(int desired) {
-        checkArgument(desired > 0);
+    public synchronized SlabAllocation allocate(PeekingIterator<Integer> eventSizes) {
+        checkArgument(eventSizes.hasNext());
 
         if (!isAttached()) {
             return null;
         }
 
         int remaining = Constants.MAX_SLAB_SIZE - _slabConsumed;
-        if (desired < remaining) {
-            // Return a portion of the slab.
-            DefaultSlabAllocation allocation = new DefaultSlabAllocation(_slab.addRef(), _slabConsumed, desired);
-            _slabConsumed += desired;
-            return allocation;
+
+        Pair<Integer, Integer> countAndBytesConsumed = DefaultSlabAllocator.defaultAllocationCount(_slabConsumed, _slabBytesConsumed, eventSizes);
+
+        int offsetForNewAllocation = _slabConsumed;
+
+        _slabConsumed += countAndBytesConsumed.getLeft();
+        _slabBytesConsumed += countAndBytesConsumed.getRight();
+
+        if (countAndBytesConsumed.getLeft() < remaining) {
+
+            // All events fit in current slab, leave it attached
+            return new DefaultSlabAllocation(_slab.addRef(), offsetForNewAllocation, countAndBytesConsumed.getLeft());
+
         } else {
-            // Return the rest of the slab.  Detach from it so we'll allocate a new one next time.
-            return new DefaultSlabAllocation(detach(), _slabConsumed, remaining);
+
+            // Whatever is left of this slab is consumed. Return the rest of the slab. Detach from it so we'll allocate a new one next time.
+            return new DefaultSlabAllocation(detach(), offsetForNewAllocation, countAndBytesConsumed.getLeft());
+
         }
     }
 }

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/Constants.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/Constants.java
@@ -7,6 +7,12 @@ interface Constants {
     /** Maximum number of events that should be stored in a single slab.  Must be <= 65536. */
     static final int MAX_SLAB_SIZE = 1000;
 
+    /** Maximum number of bytes that should be in a slab */
+    static final int BYTES_PER_MEGABYTE = 1024 * 1024;
+    static final int MAX_SLAB_SIZE_IN_MEGABYTES = 10;
+    static final int MAX_SLAB_SIZE_IN_BYTES = MAX_SLAB_SIZE_IN_MEGABYTES * BYTES_PER_MEGABYTE;
+    static final int MAX_EVENT_SIZE_IN_BYTES = 256 * 1024;
+
     /** Slab column value that indicates a slab is still open. */
     static final int OPEN_SLAB_MARKER = Integer.MAX_VALUE;
 

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/DefaultSlabAllocator.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/DefaultSlabAllocator.java
@@ -10,11 +10,14 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
+import com.google.common.collect.PeekingIterator;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.netflix.astyanax.serializers.TimeUUIDSerializer;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.Executors;
@@ -71,8 +74,37 @@ public class DefaultSlabAllocator implements SlabAllocator {
         return executor;
     }
 
+    /** Compute how many slots in a slab will be used to do a default (new slab) allocation, and how many bytes it will consume
+     *
+     * @param slabSlotsUsed - number of available slots in a slab that have been used prior to this allocation
+     * @param slabBytesUsed - number of bytes in a slab that have been used prior to this allocation
+     * @param eventSizes - list of the size in bytes of all events that we want to insert into the slab
+     *
+     * @return a pair of integers, the left value is the number of slots that will be used by this allocation and the
+     *         right value is the numb er of bytes that will be used by this allocation
+     */
+    static Pair<Integer, Integer> defaultAllocationCount(int slabSlotsUsed, int slabBytesUsed, PeekingIterator<Integer> eventSizes) {
+        int slabTotalSlotCount = slabSlotsUsed;
+        int allocationSlotCount = 0;
+        int slabTotalBytesUsed = slabBytesUsed;
+        int allocationBytes = 0;
+        while (eventSizes.hasNext()) {
+            checkArgument(eventSizes.peek() <= Constants.MAX_EVENT_SIZE_IN_BYTES, "Event size (" + eventSizes.peek() + ") is greater than the maximum allowed (" + Constants.MAX_EVENT_SIZE_IN_BYTES + ") event size");
+            if (slabTotalSlotCount + 1 <= Constants.MAX_SLAB_SIZE && slabTotalBytesUsed + eventSizes.peek() <= Constants.MAX_SLAB_SIZE_IN_BYTES) {
+                slabTotalSlotCount++;
+                allocationSlotCount++;
+                int eventSize = eventSizes.next();
+                slabTotalBytesUsed += eventSize;
+                allocationBytes += eventSize;
+            } else {
+                break;
+            }
+        }
+        return new ImmutablePair<>(allocationSlotCount, allocationBytes);
+    }
+
     @Override
-    public SlabAllocation allocate(String channelName, int desiredCount) {
+    public SlabAllocation allocate(String channelName, int desiredCount, PeekingIterator<Integer> eventSizes) {
         checkNotNull(channelName, "channelName");
         checkArgument(desiredCount > 0, "desiredCount must be >0");
 
@@ -94,14 +126,14 @@ public class DefaultSlabAllocator implements SlabAllocator {
             // SlabPersister I/O operation around creating slabs.
 
             // Is there is an existing open slab we can allocate from?
-            SlabAllocation allocation = channelState.allocate(desiredCount);
+            SlabAllocation allocation = channelState.allocate(eventSizes);
             if (allocation != null) {
                 return allocation;
             }
 
             // No existing slab.  Create a new slab just for the caller and not shared with anyone else.
             SlabRef slab = createSlab(channelName);
-            return new DefaultSlabAllocation(slab, 0, Constants.MAX_SLAB_SIZE);
+            return new DefaultSlabAllocation(slab, 0, defaultAllocationCount(0, 0, eventSizes).getLeft());
 
         } else {
             // Regular case for callers writing a few events.  Allocate from an existing open slab if possible, and if
@@ -109,7 +141,7 @@ public class DefaultSlabAllocator implements SlabAllocator {
             // per channel at a time.
             synchronized (channelState.getSlabCreationLock()) {
                 // Can we satisfy the allocation without creating a new slab?
-                SlabAllocation allocation = channelState.allocate(desiredCount);
+                SlabAllocation allocation = channelState.allocate(eventSizes);
                 if (allocation != null) {
                     return allocation;
                 }
@@ -119,7 +151,7 @@ public class DefaultSlabAllocator implements SlabAllocator {
 
                 // We're still guaranteed that the channel is closed (!channel.isAttached()) because all calls to the
                 // channel.attach() method are protected by the SlabCreationLock which we held when checking isAttached.
-                return channelState.attachAndAllocate(slab, desiredCount);
+                return channelState.attachAndAllocate(slab, eventSizes);
             }
         }
     }

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/SlabAllocator.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/SlabAllocator.java
@@ -1,6 +1,8 @@
 package com.bazaarvoice.emodb.event.db.astyanax;
 
+import com.google.common.collect.PeekingIterator;
+
 public interface SlabAllocator {
 
-    SlabAllocation allocate(String channel, int desiredCount);
+    SlabAllocation allocate(String channel, int desiredCount, PeekingIterator<Integer> eventSizes);
 }

--- a/event/src/test/java/com/bazaarvoice/emodb/event/db/astyanax/ChannelAllocationStateTest.java
+++ b/event/src/test/java/com/bazaarvoice/emodb/event/db/astyanax/ChannelAllocationStateTest.java
@@ -1,0 +1,145 @@
+package com.bazaarvoice.emodb.event.db.astyanax;
+
+import com.google.common.collect.Iterators;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+public class ChannelAllocationStateTest {
+
+    private static final Logger _log = LoggerFactory.getLogger(ChannelAllocationStateTest.class);
+
+    @Test
+    public void allocateOversizeEvent() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<100; i++) {
+            sizes.add(64);
+        }
+        sizes.add(Constants.MAX_EVENT_SIZE_IN_BYTES + 1);
+        ChannelAllocationState channelAllocationState = new ChannelAllocationState();
+        try {
+            channelAllocationState.attachAndAllocate(mock(SlabRef.class), Iterators.peekingIterator(sizes.iterator()));
+            assertTrue(false, "ERROR: No exception thrown when oversize event allocated");
+        } catch (IllegalArgumentException e) {
+            _log.info("SUCCESS: IllegalArgumentException thrown when oversize event allocated");
+        } catch (Exception e) {
+            assertTrue(false, "ERROR: " + e.getClass().getName() + " thrown when oversize event allocated");
+        }
+    }
+
+    @Test
+    public void allocateWholeSlabMaxNumberSmallEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE; i++) {
+            sizes.add(64);
+        }
+        ChannelAllocationState channelAllocationState = new ChannelAllocationState();
+        SlabRef slabRef = mock(SlabRef.class);
+        when(slabRef.addRef()).thenReturn(slabRef);
+        try {
+            channelAllocationState.attachAndAllocate(slabRef, Iterators.peekingIterator(sizes.iterator()));
+            _log.info("SUCCESS:  allocated " + Constants.MAX_SLAB_SIZE + " 64-byte events");
+        } catch (Exception e) {
+            assertTrue(false, "ERROR: " + e.getClass().getName() + " thrown when max # (" + Constants.MAX_SLAB_SIZE + ") 64-byte events allocated");
+        }
+    }
+
+    @Test
+    public void allocateWholeSlabExactBytesMaxEvents() {
+        int allocSize = Constants.MAX_SLAB_SIZE_IN_BYTES/Constants.MAX_SLAB_SIZE;
+        int lastAllocExtraBytes = 0;
+        if (Constants.MAX_SLAB_SIZE_IN_BYTES % Constants.MAX_SLAB_SIZE != 0) {
+            lastAllocExtraBytes = Constants.MAX_SLAB_SIZE_IN_BYTES % Constants.MAX_SLAB_SIZE;
+        }
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE; i++) {
+            if (i == Constants.MAX_SLAB_SIZE-1) {
+                sizes.add(allocSize+lastAllocExtraBytes);
+            } else {
+                sizes.add(allocSize);
+            }
+        }
+        ChannelAllocationState channelAllocationState = new ChannelAllocationState();
+        SlabRef slabRef = mock(SlabRef.class);
+        when(slabRef.addRef()).thenReturn(slabRef);
+        try {
+            channelAllocationState.attachAndAllocate(slabRef,  Iterators.peekingIterator(sizes.iterator()));
+            _log.info("SUCCESS:  allocated " + Constants.MAX_SLAB_SIZE + " events that exactly filled the slab (" + Constants.MAX_SLAB_SIZE_IN_MEGABYTES + " MB)");
+        } catch (Exception e) {
+            assertTrue(false, "ERROR: " + e.getClass().getName() + " thrown when max # (" + Constants.MAX_SLAB_SIZE + ") events that exactly filled slab allocated");
+        }
+    }
+
+    @Test
+    public void allocateWholeSlabExactBytesLessThanMaxEvents() {
+        int allocSize = Constants.MAX_SLAB_SIZE_IN_BYTES/(Constants.MAX_SLAB_SIZE/2);
+        int lastAllocExtraBytes = 0;
+        if (Constants.MAX_SLAB_SIZE_IN_BYTES % (Constants.MAX_SLAB_SIZE/2) != 0) {
+            lastAllocExtraBytes = Constants.MAX_SLAB_SIZE_IN_BYTES % (Constants.MAX_SLAB_SIZE/2);
+        }
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE/2; i++) {
+            if (i == Constants.MAX_SLAB_SIZE/2-1) {
+                sizes.add(allocSize+lastAllocExtraBytes);
+            } else {
+                sizes.add(allocSize);
+            }
+        }
+        ChannelAllocationState channelAllocationState = new ChannelAllocationState();
+        SlabRef slabRef = mock(SlabRef.class);
+        when(slabRef.addRef()).thenReturn(slabRef);
+        try {
+            channelAllocationState.attachAndAllocate(slabRef, Iterators.peekingIterator(sizes.iterator()));
+            _log.info("SUCCESS:  allocated " + Constants.MAX_SLAB_SIZE/2 + " events that exactly filled the slab (" + Constants.MAX_SLAB_SIZE_IN_MEGABYTES + " MB)");
+        } catch (Exception e) {
+            assertTrue(false, "ERROR: " + e.getClass().getName() + " thrown when 1/2 max # (" + Constants.MAX_SLAB_SIZE/2 + ") events that exactly filled slab allocated");
+        }
+    }
+
+    @Test
+    public void allocateLessThanMaxBytesLessThanMaxEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE-1; i++) {
+            sizes.add(64);
+        }
+        ChannelAllocationState channelAllocationState = new ChannelAllocationState();
+        SlabRef slabRef = mock(SlabRef.class);
+        when(slabRef.addRef()).thenReturn(slabRef);
+        try {
+            channelAllocationState.attachAndAllocate(slabRef, Iterators.peekingIterator(sizes.iterator()));
+            _log.info("SUCCESS:  allocated " + (Constants.MAX_SLAB_SIZE-1) + " 64-byte events");
+        } catch (Exception e) {
+            assertTrue(false, "ERROR: " + e.getClass().getName() + " thrown when max # -1 (" + (Constants.MAX_SLAB_SIZE-1) + ") 64-byte events allocated");
+        }
+    }
+
+    @Test
+    public void allocateSlabInMultipleCalls() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE/2; i++) {
+            sizes.add(64);
+        }
+        ChannelAllocationState channelAllocationState = new ChannelAllocationState();
+        SlabRef slabRef = mock(SlabRef.class);
+        when(slabRef.addRef()).thenReturn(slabRef);
+        try {
+            channelAllocationState.attachAndAllocate(slabRef,  Iterators.peekingIterator(sizes.iterator()));
+            _log.info("SUCCESS:  allocated " + Constants.MAX_SLAB_SIZE/2 + " 64-byte events");
+        } catch (Exception e) {
+            assertTrue(false, "ERROR: " + e.getClass().getName() + " thrown when first max/2 # (" + Constants.MAX_SLAB_SIZE/2 + ") 64-byte events allocated");
+        }
+        try {
+            channelAllocationState.allocate(Iterators.peekingIterator(sizes.iterator()));
+            _log.info("SUCCESS:  allocated " + Constants.MAX_SLAB_SIZE/2 + " 64-byte events");
+        } catch (Exception e) {
+            assertTrue(false, "ERROR: " + e.getClass().getName() + " thrown when second max/2 # (" + Constants.MAX_SLAB_SIZE/2 + ") 64-byte events allocated");
+        }
+    }
+}

--- a/event/src/test/java/com/bazaarvoice/emodb/event/db/astyanax/DefaultSlabAllocatorTest.java
+++ b/event/src/test/java/com/bazaarvoice/emodb/event/db/astyanax/DefaultSlabAllocatorTest.java
@@ -1,0 +1,165 @@
+package com.bazaarvoice.emodb.event.db.astyanax;
+
+import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Iterators;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertTrue;
+
+public class DefaultSlabAllocatorTest {
+
+    private static final Logger _log = LoggerFactory.getLogger(DefaultSlabAllocatorTest.class);
+
+    @Test
+    public void allocateGreaterThanMaxEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE*3/2; i++) {
+            sizes.add(64);
+        }
+        DefaultSlabAllocator slabAllocator = new DefaultSlabAllocator(mock(LifeCycleRegistry.class), mock(ManifestPersister.class), "metrics", mock(MetricRegistry.class));
+        try {
+            slabAllocator.allocate("mychannel", Constants.MAX_SLAB_SIZE*3/2, Iterators.peekingIterator(sizes.iterator()));
+            _log.info("SUCCESS: No exception thrown when " + (Constants.MAX_SLAB_SIZE*3/2) + " events allocated");
+        } catch (Exception e) {
+            _log.error("ERROR: " + e.getClass().getName() + " thrown when " + (Constants.MAX_SLAB_SIZE*3/2) + " events allocated");
+            assert(false);
+        }
+    }
+
+    @Test
+    public void allocateMaxEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE; i++) {
+            sizes.add(64);
+        }
+        DefaultSlabAllocator slabAllocator = new DefaultSlabAllocator(mock(LifeCycleRegistry.class), mock(ManifestPersister.class), "metrics", mock(MetricRegistry.class));
+        try {
+            slabAllocator.allocate("mychannel", Constants.MAX_SLAB_SIZE, Iterators.peekingIterator(sizes.iterator()));
+            _log.info("SUCCESS: No exception thrown when " + Constants.MAX_SLAB_SIZE + " events allocated");
+        } catch (Exception e) {
+            _log.error("ERROR: " + e.getClass().getName() + " thrown when " + Constants.MAX_SLAB_SIZE + " events allocated");
+            assert(false);
+        }
+    }
+
+    @Test
+    public void allocateFewerThanMaxEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE/2; i++) {
+            sizes.add(64);
+        }
+        DefaultSlabAllocator slabAllocator = new DefaultSlabAllocator(mock(LifeCycleRegistry.class), mock(ManifestPersister.class), "metrics", mock(MetricRegistry.class));
+        try {
+            slabAllocator.allocate("mychannel", Constants.MAX_SLAB_SIZE/2, Iterators.peekingIterator(sizes.iterator()));
+            _log.info("SUCCESS: No exception thrown when " + (Constants.MAX_SLAB_SIZE/2) + " events allocated");
+        } catch (Exception e) {
+            _log.error("ERROR: " + e.getClass().getName() + " thrown when " + (Constants.MAX_SLAB_SIZE/2) + " events allocated");
+            assert(false);
+        }
+    }
+
+
+    @Test
+    public void computeAllocationGreaterThanMaxEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE*3/2; i++) {
+            sizes.add(64);
+        }
+        try {
+            Pair<Integer, Integer> allocation = DefaultSlabAllocator.defaultAllocationCount(0,0, Iterators.peekingIterator(sizes.iterator()));
+            assertTrue(allocation.getLeft() == Constants.MAX_SLAB_SIZE, "ERROR: allocation has " + allocation.getLeft() + " slots, " + Constants.MAX_SLAB_SIZE + " expected");
+            _log.info("SUCCESS: allocation has " + allocation.getLeft() + " slots, " + Constants.MAX_SLAB_SIZE + " expected when " + 0 + " slots already used and " + (Constants.MAX_SLAB_SIZE*3/2) + " requested");
+        } catch (Exception e) {
+            _log.error("ERROR: " + e.getClass().getName() + " thrown when " + (Constants.MAX_SLAB_SIZE*3/2) + " events allocated");
+            assert(false);
+        }
+    }
+
+    @Test
+    public void computeAllocationMaxEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE; i++) {
+            sizes.add(64);
+        }
+        try {
+            Pair<Integer, Integer> allocation = DefaultSlabAllocator.defaultAllocationCount(0,0, Iterators.peekingIterator(sizes.iterator()));
+            assertTrue(allocation.getLeft() == Constants.MAX_SLAB_SIZE, "ERROR: allocation has " + allocation.getLeft() + " slots, " + Constants.MAX_SLAB_SIZE + " expected");
+            _log.info("SUCCESS: allocation has " + allocation.getLeft() + " slots, " + Constants.MAX_SLAB_SIZE + " expected when " + 0 + " slots already used and " + Constants.MAX_SLAB_SIZE + " requested");
+        } catch (Exception e) {
+            _log.error("ERROR: " + e.getClass().getName() + " thrown when " + Constants.MAX_SLAB_SIZE + " events allocated");
+            assert(false);
+        }
+    }
+
+    @Test
+    public void computeAllocationFewerThanMaxEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE/2; i++) {
+            sizes.add(64);
+        }
+        try {
+            Pair<Integer, Integer> allocation = DefaultSlabAllocator.defaultAllocationCount(0,0, Iterators.peekingIterator(sizes.iterator()));
+            assertTrue(allocation.getLeft() == Constants.MAX_SLAB_SIZE/2, "ERROR: allocation has " + allocation.getLeft() + " slots, " + (Constants.MAX_SLAB_SIZE/2) + " expected");
+            _log.info("SUCCESS: allocation has " + allocation.getLeft() + " slots, " + (Constants.MAX_SLAB_SIZE/2) + " expected when " + 0 + " slots already used and " + (Constants.MAX_SLAB_SIZE/2) + " requested");
+        } catch (Exception e) {
+            _log.error("ERROR: " + e.getClass().getName() + " thrown when " + (Constants.MAX_SLAB_SIZE/2) + " events allocated");
+            assert(false);
+        }
+    }
+
+    @Test
+    public void computeAllocationTotalMaxEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE/2; i++) {
+            sizes.add(64);
+        }
+        try {
+            Pair<Integer, Integer> allocation = DefaultSlabAllocator.defaultAllocationCount(Constants.MAX_SLAB_SIZE/2,0, Iterators.peekingIterator(sizes.iterator()));
+            assertTrue(allocation.getLeft() == Constants.MAX_SLAB_SIZE/2, "ERROR: allocation has " + allocation.getLeft() + " slots, " + (Constants.MAX_SLAB_SIZE/2) + " expected");
+            _log.info("SUCCESS: allocation has " + allocation.getLeft() + " slots, " + (Constants.MAX_SLAB_SIZE/2) + " expected when " + (Constants.MAX_SLAB_SIZE/2) + " slots already used and " + Constants.MAX_SLAB_SIZE/2 + " requested");
+        } catch (Exception e) {
+            _log.error("ERROR: " + e.getClass().getName() + " thrown when " + (Constants.MAX_SLAB_SIZE/2) + " events allocated");
+            assert(false);
+        }
+    }
+
+    @Test
+    public void computeAllocationTotalGreaterThanMaxEvents() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE; i++) {
+            sizes.add(64);
+        }
+        try {
+            Pair<Integer, Integer> allocation = DefaultSlabAllocator.defaultAllocationCount(Constants.MAX_SLAB_SIZE/2,0, Iterators.peekingIterator(sizes.iterator()));
+            assertTrue(allocation.getLeft() == Constants.MAX_SLAB_SIZE/2, "ERROR: allocation has " + allocation.getLeft() + " slots, " + (Constants.MAX_SLAB_SIZE/2) + " expected");
+            _log.info("SUCCESS: allocation has " + allocation.getLeft() + " slots, " + (Constants.MAX_SLAB_SIZE/2) + " expected when " + (Constants.MAX_SLAB_SIZE/2) + " slots already used and " + Constants.MAX_SLAB_SIZE + " requested");
+        } catch (Exception e) {
+            _log.error("ERROR: " + e.getClass().getName() + " thrown when " + (Constants.MAX_SLAB_SIZE/2) + " events allocated");
+            assert(false);
+        }
+    }
+
+    @Test
+    public void computeAllocationTotalGreaterThanMaxEventsWithOversizeEvent() {
+        List<Integer> sizes = new ArrayList<Integer>();
+        for (int i=0; i<Constants.MAX_SLAB_SIZE-1; i++) {
+            sizes.add(64);
+        }
+        sizes.add(Constants.MAX_EVENT_SIZE_IN_BYTES+1);
+        try {
+            Pair<Integer, Integer> allocation = DefaultSlabAllocator.defaultAllocationCount(Constants.MAX_SLAB_SIZE/2,0, Iterators.peekingIterator(sizes.iterator()));
+            _log.error("ERROR: allocation did not throw exceptoion for oversize event");
+        } catch (Exception e) {
+            _log.info("SUCCESS: " + e.getClass().getName() + " thrown when " + (Constants.MAX_SLAB_SIZE/2) + " events allocated");
+        }
+    }
+
+}


### PR DESCRIPTION
## Github Issue #

[1234](https://github.com/bazaarvoice/emodb/issues/11)

## What Are We Doing Here?

Solving a problem unearthed by Legion. The problem was that Legion was enqueueing documents large enough to exceed the maximum size in bytes of an EmoDB slab when fewer than 1000 documents had been enqueued. This highlighted a problem with the EmoDB slab allocator, which assumed that a slab could always contain 1,000 documents. If the documents are large enough, however, this may not be true.

The solution is to establish the maximum size in bytes of an EmoDB slab, then keep track of how many bytes have been used up and allocate a new slab as needed if the number of bytes consumed in the slab is great enough OR 1,000 documents have been placed in the slab.

This also requires the addition of a check to be sure that a single document does not exceed the size of a slab.

## How to Test and Verify

1) Deploy a perf test stack for this branch and run an EmoDB stress test (mexed load) to verify that slab allocation and reading is not adversely impacted.

2) Attempt to store a JSON document into EmoDB that is larger than the slab size, verify that you get an error status when you do this (NOTE: the document may need to be appreciably larger than the maximum bytes/slab constant because DropWizard will turn the JSON document into a map, effectively stripping out whitespace before the document size verification is performed)

## Risk

### Level 

`Low`, `Medium`, or `High`. Give an indication of what you think is the level of change introduced by this PR. `High` means a massive change to a core functionality. 
`Low` means a really minor change that shouldn't have any regression effect. 

### Required Testing

Regression

### Risk Summary

should be low


