### PR TITLE
Prevent Delta Blocks from being skipped when the cache is invalidated

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
@@ -103,7 +103,7 @@ abstract public class DeltaIterator<R, T> extends AbstractIterator<T> {
                 }
             } else {
                 // fragmented delta and no other deltas to skip to
-                throw new DeltaStitchingException(_rowKey, getChangeId(_next).toString());
+                throw new DeltaStitchingException(_rowKey, getChangeId(_next).toString(), numBlocks, i - 1);
             }
         }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
@@ -24,12 +24,14 @@ abstract public class DeltaIterator<R, T> extends AbstractIterator<T> {
     private final boolean _reverse;
     private final int _prefixLength;
     private boolean _firstIteration;
+    private String _rowKey;
 
-    public DeltaIterator(Iterator<R> iterator, boolean reverse, int prefixLength) {
+    public DeltaIterator(Iterator<R> iterator, boolean reverse, int prefixLength, String rowKey) {
         _iterator = iterator;
         _reverse = reverse;
         _prefixLength = prefixLength;
         _firstIteration = true;
+        _rowKey = rowKey;
     }
 
     // stitch delta together in reverse
@@ -101,7 +103,7 @@ abstract public class DeltaIterator<R, T> extends AbstractIterator<T> {
                 }
             } else {
                 // fragmented delta and no other deltas to skip to
-                throw new DeltaStitchingException();
+                throw new DeltaStitchingException(_rowKey, getChangeId(_next).toString());
             }
         }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaStitchingException.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaStitchingException.java
@@ -2,7 +2,7 @@ package com.bazaarvoice.emodb.sor.db;
 
 public class DeltaStitchingException extends RuntimeException {
 
-    public DeltaStitchingException(String rowkey, String changeId) {
-        super(String.format("Found fragmented deltas without a compaction record ahead of them.\nrowkey=%s changeid=%s", rowkey, changeId));
+    public DeltaStitchingException(String rowkey, String changeId, int numBlocks, int lastBlockSeen) {
+        super(String.format("Found fragmented deltas without a compaction record ahead of them.\nrowkey=%s changeid=%s\nnumblocks=%d lastblockseen=%d ", rowkey, changeId, numBlocks, lastBlockSeen));
     }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaStitchingException.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaStitchingException.java
@@ -2,7 +2,7 @@ package com.bazaarvoice.emodb.sor.db;
 
 public class DeltaStitchingException extends RuntimeException {
 
-    public DeltaStitchingException() {
-        super("Found fragmented deltas without a compaction record ahead of them.");
+    public DeltaStitchingException(String rowkey, String changeId) {
+        super(String.format("Found fragmented deltas without a compaction record ahead of them.\nrowkey=%s changeid=%s", rowkey, changeId));
     }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
@@ -304,7 +304,7 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
             ColumnFamily<ByteBuffer, DeltaKey> cf = placement.getBlockedDeltaColumnFamily();
             DeltaKey deltaStart = start != null ? new DeltaKey(start, 0) : null;
             DeltaKey deltaEnd = end != null ? new DeltaKey(end, Integer.MAX_VALUE) : null;
-            deltas = decodeDeltaColumns(new LimitCounter(limit).limit(new AstyanaxDeltaIterator(columnScan(rowKey, placement, cf, deltaStart, deltaEnd, reversed, _deltaKeyInc, Long.MAX_VALUE, 0, consistency), reversed, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey))));
+            deltas = decodeDeltaColumns(new LimitCounter(limit).limit(new AstyanaxDeltaIterator(columnScan(rowKey, placement, cf, deltaStart, deltaEnd, reversed, _deltaKeyInc, Long.MAX_VALUE, 0, consistency), reversed, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey)))));
 
         }
 
@@ -1239,9 +1239,9 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
                     getFilteredColumnIter(columnScan(rowKey, placement, columnFamily, lastColumn, null, false, _deltaKeyInc, Long.MAX_VALUE, 1, consistency), cutoffTime));
         }
 
-        Iterator<Map.Entry<UUID, Change>> deltaChangeIter = decodeChanges(new AstyanaxDeltaIterator(changeIter, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey)));
-        Iterator<Map.Entry<UUID, Compaction>> deltaCompactionIter = decodeCompactions(new AstyanaxDeltaIterator(compactionIter, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey)));
-        Iterator<RecordEntryRawMetadata> deltaRawMetadataIter = rawMetadata(new AstyanaxDeltaIterator(rawMetadataIter, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey)));
+        Iterator<Map.Entry<UUID, Change>> deltaChangeIter = decodeChanges(new AstyanaxDeltaIterator(changeIter, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey))));
+        Iterator<Map.Entry<UUID, Compaction>> deltaCompactionIter = decodeCompactions(new AstyanaxDeltaIterator(compactionIter, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey))));
+        Iterator<RecordEntryRawMetadata> deltaRawMetadataIter = rawMetadata(new AstyanaxDeltaIterator(rawMetadataIter, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey))));
 
         return new RecordImpl(key, deltaCompactionIter, deltaChangeIter, deltaRawMetadataIter);
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
@@ -304,7 +304,7 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
             ColumnFamily<ByteBuffer, DeltaKey> cf = placement.getBlockedDeltaColumnFamily();
             DeltaKey deltaStart = start != null ? new DeltaKey(start, 0) : null;
             DeltaKey deltaEnd = end != null ? new DeltaKey(end, Integer.MAX_VALUE) : null;
-            deltas = decodeDeltaColumns(new LimitCounter(limit).limit(new AstyanaxDeltaIterator(columnScan(rowKey, placement, cf, deltaStart, deltaEnd, reversed, _deltaKeyInc, Long.MAX_VALUE, 0, consistency), reversed, _deltaPrefixLength, StringSerializer.get().fromByteBuffer(rowKey))));
+            deltas = decodeDeltaColumns(new LimitCounter(limit).limit(new AstyanaxDeltaIterator(columnScan(rowKey, placement, cf, deltaStart, deltaEnd, reversed, _deltaKeyInc, Long.MAX_VALUE, 0, consistency), reversed, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey))));
 
         }
 
@@ -1239,9 +1239,9 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
                     getFilteredColumnIter(columnScan(rowKey, placement, columnFamily, lastColumn, null, false, _deltaKeyInc, Long.MAX_VALUE, 1, consistency), cutoffTime));
         }
 
-        Iterator<Map.Entry<UUID, Change>> deltaChangeIter = decodeChanges(new AstyanaxDeltaIterator(changeIter, false, _deltaPrefixLength, StringSerializer.get().fromByteBuffer(rowKey)));
-        Iterator<Map.Entry<UUID, Compaction>> deltaCompactionIter = decodeCompactions(new AstyanaxDeltaIterator(compactionIter, false, _deltaPrefixLength, StringSerializer.get().fromByteBuffer(rowKey)));
-        Iterator<RecordEntryRawMetadata> deltaRawMetadataIter = rawMetadata(new AstyanaxDeltaIterator(rawMetadataIter, false, _deltaPrefixLength, StringSerializer.get().fromByteBuffer(rowKey)));
+        Iterator<Map.Entry<UUID, Change>> deltaChangeIter = decodeChanges(new AstyanaxDeltaIterator(changeIter, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey)));
+        Iterator<Map.Entry<UUID, Compaction>> deltaCompactionIter = decodeCompactions(new AstyanaxDeltaIterator(compactionIter, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey)));
+        Iterator<RecordEntryRawMetadata> deltaRawMetadataIter = rawMetadata(new AstyanaxDeltaIterator(rawMetadataIter, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex((rowKey)));
 
         return new RecordImpl(key, deltaCompactionIter, deltaChangeIter, deltaRawMetadataIter);
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataReaderDAO.java
@@ -1296,6 +1296,6 @@ public class AstyanaxDataReaderDAO implements DataReaderDAO, DataCopyDAO, Astyan
         if (cutoffTime == null) {
             return columnIter;
         }
-        return Iterators.filter(columnIter, column -> (TimeUUIDs.getTimeMillis(column.getUUIDValue()) < cutoffTime.toEpochMilli()));
+        return Iterators.filter(columnIter, column -> (TimeUUIDs.getTimeMillis(column.getName()) < cutoffTime.toEpochMilli()));
     }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDeltaIterator.java
@@ -8,8 +8,8 @@ import java.util.Iterator;
 import java.util.UUID;
 
 public class AstyanaxDeltaIterator extends DeltaIterator<Column<DeltaKey>, Column<UUID>> {
-    public AstyanaxDeltaIterator(Iterator<Column<DeltaKey>> iterator, boolean reversed, int prefixLength) {
-        super(iterator, reversed, prefixLength);
+    public AstyanaxDeltaIterator(Iterator<Column<DeltaKey>> iterator, boolean reversed, int prefixLength, String rowKey) {
+        super(iterator, reversed, prefixLength, rowKey);
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
@@ -723,8 +723,8 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
         protected ResultSet queryRowGroupRowsAfter(Row row) {
             Statement statement = selectDeltaFrom(_placement.getBlockedDeltaTableDDL())
                     .where(eq(_placement.getBlockedDeltaTableDDL().getRowKeyColumnName(), getKey(row)))
-                    .and(gte(_placement.getBlockedDeltaTableDDL().getChangeIdColumnName(), getChangeId(row)))
-                    .and(gt(_placement.getBlockedDeltaTableDDL().getBlockColumnName(), getBlock(row)))
+                    .and(gt(ImmutableList.of(_placement.getBlockedDeltaTableDDL().getChangeIdColumnName(), _placement.getBlockedDeltaTableDDL().getBlockColumnName()),
+                            ImmutableList.of(getChangeId(row), getBlock(row))))
                     .orderBy(asc(_placement.getBlockedDeltaTableDDL().getChangeIdColumnName()))
                     .setConsistencyLevel(_consistency);
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
@@ -726,7 +726,6 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
                     .and(gte(_placement.getBlockedDeltaTableDDL().getChangeIdColumnName(), getChangeId(row)))
                     .and(gt(_placement.getBlockedDeltaTableDDL().getBlockColumnName(), getBlock(row)))
                     .orderBy(asc(_placement.getBlockedDeltaTableDDL().getChangeIdColumnName()))
-                    .orderBy(asc(_placement.getBlockedDeltaTableDDL().getBlockColumnName()))
                     .setConsistencyLevel(_consistency);
 
             return AdaptiveResultSet.executeAdaptiveQuery(_placement.getKeyspace().getCqlSession(), statement, _driverConfig.getSingleRowFetchSize());

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlBlockedDataReaderDAO.java
@@ -185,7 +185,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
         }
 
         // Convert the results into a Record object, lazily fetching the rest of the columns as necessary.
-        return newRecordFromCql(key, rows, placement, StringSerializer.get().fromByteBuffer(rowKey));
+        return newRecordFromCql(key, rows, placement, ByteBufferUtil.bytesToHex(rowKey));
     }
 
     /**
@@ -358,7 +358,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
                     ByteBuffer keyBytes = getRawKeyFromRowGroup(rows);
                     Key key = rawKeyMap.remove(keyBytes);
                     assert key != null : "Query returned row with a key out of bound";
-                    return newRecordFromCql(key, rows, placement, StringSerializer.get().fromByteBuffer(keyBytes));
+                    return newRecordFromCql(key, rows, placement, ByteBufferUtil.bytesToHex(keyBytes));
                 }),
                 // Second iterator returns an empty Record for each key queried but not found.
                 new AbstractIterator<Record>() {
@@ -549,7 +549,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
     private Iterator<Record> decodeRows(Iterator<Iterable<Row>> rowGroups, final AstyanaxTable table, Placement placement) {
         return Iterators.transform(rowGroups, rowGroup -> {
             String key = AstyanaxStorage.getContentKey(getRawKeyFromRowGroup(rowGroup));
-            return newRecordFromCql(new Key(table, key), rowGroup, placement, StringSerializer.get().fromByteBuffer(getRawKeyFromRowGroupOrNull(rowGroup)));
+            return newRecordFromCql(new Key(table, key), rowGroup, placement, ByteBufferUtil.bytesToHex(getRawKeyFromRowGroupOrNull(rowGroup)));
         });
     }
 
@@ -636,7 +636,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
 
                     int shardId = AstyanaxStorage.getShardId(rowKey);
                     String key = AstyanaxStorage.getContentKey(rowKey);
-                    Record record = newRecordFromCql(new Key(_table, key), filteredRows, placement, StringSerializer.get().fromByteBuffer(rowKey));
+                    Record record = newRecordFromCql(new Key(_table, key), filteredRows, placement, ByteBufferUtil.bytesToHex(rowKey));
                     return new MultiTableScanResult(rowKey, shardId, tableUuid, _droppedTable, record);
                 }
 
@@ -790,7 +790,7 @@ public class CqlBlockedDataReaderDAO implements DataReaderDAO {
             ProtocolVersion protocolVersion = placement.getKeyspace().getCqlSession().getCluster().getConfiguration().getProtocolOptions().getProtocolVersion();
             CodecRegistry codecRegistry = placement.getKeyspace().getCqlSession().getCluster().getConfiguration().getCodecRegistry();
 
-            deltas = decodeDeltaColumns(Iterators.limit(new CqlDeltaIterator(columnScan(placement, deltaDDL, rowKey, columnRange, !reversed, consistency).iterator(), BLOCK_RESULT_SET_COLUMN, CHANGE_ID_RESULT_SET_COLUMN, VALUE_RESULT_SET_COLUMN, reversed, _deltaPrefixLength, protocolVersion, codecRegistry, StringSerializer.get().fromByteBuffer(rowKey)), scaledLimit));
+            deltas = decodeDeltaColumns(Iterators.limit(new CqlDeltaIterator(columnScan(placement, deltaDDL, rowKey, columnRange, !reversed, consistency).iterator(), BLOCK_RESULT_SET_COLUMN, CHANGE_ID_RESULT_SET_COLUMN, VALUE_RESULT_SET_COLUMN, reversed, _deltaPrefixLength, protocolVersion, codecRegistry, ByteBufferUtil.bytesToHex(rowKey)), scaledLimit));
         }
 
         // Read History objects

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDeltaIterator.java
@@ -22,8 +22,8 @@ public class CqlDeltaIterator extends DeltaIterator<Row, Row> {
     private final int _contentIndex;
 
     public CqlDeltaIterator(Iterator<Row> iterator, final int blockIndex, final int changeIdIndex, final int contentIndex, boolean reversed, int prefixLength,
-                            ProtocolVersion protocolVersion, CodecRegistry codecRegistry) {
-        super(iterator, reversed, prefixLength);
+                            ProtocolVersion protocolVersion, CodecRegistry codecRegistry, String rowKey) {
+        super(iterator, reversed, prefixLength, rowKey);
         _blockIndex = blockIndex;
         _changeIdIndex = changeIdIndex;
         _contentIndex = contentIndex;

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiScanCutoffTimeTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiScanCutoffTimeTest.java
@@ -103,7 +103,7 @@ public class MultiScanCutoffTimeTest {
 
     private Column<UUID> astyanaxColumn(UUID uuidValue, String value) {
         Column<UUID> column = mock(Column.class);
-        when(column.getUUIDValue()).thenReturn(uuidValue);
+        when(column.getName()).thenReturn(uuidValue);
         when(column.getStringValue()).thenReturn(value);
 
         return column;

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/db/DeltaBlockingTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/db/DeltaBlockingTest.java
@@ -150,7 +150,7 @@ public class DeltaBlockingTest {
 
 class ListDeltaIterator extends DeltaIterator<TestRow, ByteBuffer> {
     public ListDeltaIterator(Iterator<TestRow> iterator, boolean reverse, int prefixLength) {
-        super(iterator, reverse, prefixLength);
+        super(iterator, reverse, prefixLength, "<row key placeholder>");
     }
 
     @Override


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

When running validation stashes for blocked deltas, I encountered `DeltaStitchingExceptions`'s, which are only thrown when a fragmented delta is encountered without a compaction delta ahead of it. After an exhaustive investigation, I discovered that this was occurring when the `AdaptiveResultSet`'s soft cache was exhausted. This would lead the result set to request all rows after the last on it had seen. This call was not properly updated to fit blocked deltas, as it was selecting rows `WHERE changeid > <last changeid seen>`. This was causing all remaining blocks for this changeid to be skipped. To fix this issue, I have changed the query to `WHERE (changeid, block) > (<last changeid seen>, <last block seen>)`, which ensure are remaining rows will be encountered. Additionally, I have added more information to `DeltaStitchingException` so that there is more insight available if they somehow occur again (I don't forsee this happening).

## How to Test and Verify

This is difficult to test locally, as there is a degree of randomness associated related to when the soft cache is invalidated. The best way to test is to run several stashes in a larger environment that contains large deltas and ensure that no stitching errors are thrown.

## Risk

### Level 

`Medium`

### Required Testing

`Regression`

### Risk Summary

This is fairly low risk, as its scope is small. That being said, I regard any change that affects data integrity to be at least `medium` risk. 

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
