### PR TITLE
EMO-6784 Restrict databus TTLs to 1 year

### DIFF
--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DefaultSubscription.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DefaultSubscription.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 import static com.bazaarvoice.emodb.databus.api.Names.isLegalSubscriptionName;
 
 public final class DefaultSubscription implements Subscription {
+    // Currently, by default, subscription event ttl limit is set to 365 days,
+    // but that could be changed in future
     private final static Duration EVENT_TTL_LIMIT = Duration.ofDays(365);
 
     private final String _name;

--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DefaultSubscription.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DefaultSubscription.java
@@ -4,22 +4,51 @@ import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 
 import java.time.Duration;
 import java.util.Date;
+import java.util.Objects;
+
+import static com.bazaarvoice.emodb.databus.api.Names.isLegalSubscriptionName;
 
 public final class DefaultSubscription implements Subscription {
+    private final static Duration EVENT_TTL_LIMIT = Duration.ofDays(365);
+
     private final String _name;
     private final Condition _tableFilter;
     private final Date _expiresAt;
     private final Duration _eventTtl;
 
     public DefaultSubscription(String name, Condition tableFilter, Date expiresAt, Duration eventTtl) {
-        _name = name;
+        _name = validateName(name);
         _tableFilter = tableFilter;
-        _expiresAt = expiresAt;
-        _eventTtl = eventTtl;
+        _expiresAt =  Objects.requireNonNull(expiresAt);
+        _eventTtl = validateEventTtl(eventTtl);
+    }
+
+    private static String validateName(final String name) {
+        Objects.requireNonNull(name);
+
+        if (!isLegalSubscriptionName(name)) {
+            throw new IllegalArgumentException("Subscription name must be a lowercase ASCII string between 1 and 255 characters in length. " +
+                    "Allowed punctuation characters are -.:@_ and the subscription name may not start with a single underscore character. " +
+                    "An example of a valid subscription name would be 'polloi:review'.");
+        }
+
+        return name;
+    }
+
+    private static Duration validateEventTtl(final Duration eventTtl) {
+        Objects.requireNonNull(eventTtl);
+
+        if (eventTtl.compareTo(Duration.ZERO) < 0) {
+            throw new IllegalArgumentException("EventTtl must be >0");
+        }
+
+        if (eventTtl.compareTo(EVENT_TTL_LIMIT) > 0) {
+            throw new IllegalArgumentException(String.format("EventTtl duration should be within %s days", EVENT_TTL_LIMIT.toDays()));
+        }
+        return eventTtl;
     }
 
     @JsonCreator
@@ -64,16 +93,16 @@ public final class DefaultSubscription implements Subscription {
 
         if (o instanceof Subscription) {
             Subscription toCompare = (Subscription) o;
-            return Objects.equal(this.getName(), toCompare.getName()) &&
-                    Objects.equal(this.getTableFilter(), toCompare.getTableFilter()) &&
-                    Objects.equal(this.getExpiresAt(), toCompare.getExpiresAt()) &&
-                    Objects.equal(this.getEventTtl(), toCompare.getEventTtl());
+            return Objects.equals(this.getName(), toCompare.getName()) &&
+                    Objects.equals(this.getTableFilter(), toCompare.getTableFilter()) &&
+                    Objects.equals(this.getExpiresAt(), toCompare.getExpiresAt()) &&
+                    Objects.equals(this.getEventTtl(), toCompare.getEventTtl());
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_name, _tableFilter, _expiresAt, _eventTtl);
+        return Objects.hash(_name, _tableFilter, _expiresAt, _eventTtl);
     }
 }

--- a/databus-api/src/test/java/com/bazaarvoice/emodb/databus/api/SubscriptionJsonTest.java
+++ b/databus-api/src/test/java/com/bazaarvoice/emodb/databus/api/SubscriptionJsonTest.java
@@ -47,4 +47,34 @@ public class SubscriptionJsonTest {
         assertEquals(actual.getExpiresAt(), expected.getExpiresAt());
         assertEquals(actual.getEventTtl(), expected.getEventTtl());
     }
+
+    @Test(expectedExceptions=IllegalArgumentException.class, expectedExceptionsMessageRegExp=".* EventTtl duration should be within 365 days .*")
+    public void testSubscriptionJsonWithEventTttGreaterThat365Days() throws Exception {
+        Date now = new Date();
+        String nowString = DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC).format(now.toInstant());
+
+        String subscriptionJsonString = "{" +
+                "\"name\":\"test-subscription\"," +
+                "\"tableFilter\":\"intrinsic(\\\"~table\\\":\\\"review:testcustomer\\\")\"," +
+                "\"expiresAt\":\"" + nowString + "\"," +
+                "\"eventTtl\":31622400000" +
+                "}";
+
+        JsonHelper.fromJson(subscriptionJsonString, Subscription.class);
+    }
+
+    @Test(expectedExceptions=IllegalArgumentException.class, expectedExceptionsMessageRegExp=".* EventTtl must be >0 .*")
+    public void testSubscriptionJsonWithNegativeEventTtl() throws Exception {
+        Date now = new Date();
+        String nowString = DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC).format(now.toInstant());
+
+        String subscriptionJsonString = "{" +
+                "\"name\":\"test-subscription\"," +
+                "\"tableFilter\":\"intrinsic(\\\"~table\\\":\\\"review:testcustomer\\\")\"," +
+                "\"expiresAt\":\"" + nowString + "\"," +
+                "\"eventTtl\":-1" +
+                "}";
+
+        JsonHelper.fromJson(subscriptionJsonString, Subscription.class);
+    }
 }

--- a/databus-api/src/test/java/com/bazaarvoice/emodb/databus/api/SubscriptionJsonTest.java
+++ b/databus-api/src/test/java/com/bazaarvoice/emodb/databus/api/SubscriptionJsonTest.java
@@ -49,7 +49,7 @@ public class SubscriptionJsonTest {
     }
 
     @Test(expectedExceptions=IllegalArgumentException.class, expectedExceptionsMessageRegExp=".* EventTtl duration should be within 365 days .*")
-    public void testSubscriptionJsonWithEventTttGreaterThat365Days() throws Exception {
+    public void testSubscriptionJsonWithEventTtlGreaterThan365Days() throws Exception {
         Date now = new Date();
         String nowString = DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC).format(now.toInstant());
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -276,7 +276,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
     private void createDatabusReplaySubscription() {
         // Create a master databus replay subscription where the events expire every 50 hours (2 days + 2 hours)
         subscribe(_systemOwnerId, ChannelNames.getMasterReplayChannel(), Conditions.alwaysTrue(),
-                Duration.ofDays(3650), DatabusChannelConfiguration.REPLAY_TTL, false);
+                Duration.ofDays(365), DatabusChannelConfiguration.REPLAY_TTL, false);
     }
 
     private Meter newEventMeter(String name, MetricRegistry metricRegistry) {

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/db/cql/CqlSubscriptionDAO.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/db/cql/CqlSubscriptionDAO.java
@@ -13,13 +13,14 @@ import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.TableMetadata;
-import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.StreamSupport;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.delete;
@@ -27,7 +28,6 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.ttl;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class CqlSubscriptionDAO implements SubscriptionDAO {
 
@@ -44,27 +44,36 @@ public class CqlSubscriptionDAO implements SubscriptionDAO {
 
     @Inject
     public CqlSubscriptionDAO(CassandraKeyspace keyspace, Clock clock) {
-        _keyspace = checkNotNull(keyspace, "keyspace");
-        _clock = checkNotNull(clock, "clock");
+        _keyspace = Objects.requireNonNull(keyspace, "keyspace");
+        _clock = Objects.requireNonNull(clock, "clock");
     }
 
     @Timed(name = "bv.emodb.databus.CqlSubscriptionDAO.insertSubscription", absolute = true)
     @Override
-    public void insertSubscription(String ownerId, String subscription, Condition tableFilter,
-                                   Duration subscriptionTtl, Duration eventTtl) {
-        Map<String, Object> json = ImmutableMap.<String, Object>builder()
-                .put("filter", tableFilter.toString())
-                .put("expiresAt", _clock.millis() + subscriptionTtl.toMillis())
-                .put("eventTtl", Ttls.toSeconds(eventTtl, 1, Integer.MAX_VALUE))
-                .put("ownerId", ownerId)
-                .build();
+    public void insertSubscription(String ownerId, String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl) {
+        insertSubscription(new DefaultOwnedSubscription(
+                subscription,
+                tableFilter,
+                new Date(_clock.millis() + subscriptionTtl.toMillis()),
+                Duration.ofSeconds(Ttls.toSeconds(eventTtl, 1, Integer.MAX_VALUE)),
+                ownerId)
+        );
+    }
+
+    private void insertSubscription(OwnedSubscription subscription) {
+        Map<String, Object> json = new HashMap<String, Object>() {{
+            put("filter", subscription.getTableFilter().toString());
+            put("expiresAt", subscription.getExpiresAt().getTime());
+            put("eventTtl", subscription.getEventTtl().getSeconds());
+            put("ownerId", subscription.getOwnerId());
+        }};
 
         _keyspace.getCqlSession().execute(
                 insertInto(CF_NAME)
                         .value(rowkeyColumn(), ROW_KEY)
-                        .value(subscriptionNameColumn(), subscription)
+                        .value(subscriptionNameColumn(), subscription.getName())
                         .value(subscriptionColumn(), JsonHelper.asJson(json))
-                        .using(ttl(Ttls.toSeconds(subscriptionTtl, 1, Integer.MAX_VALUE)))
+                        .using(ttl(Math.toIntExact(subscription.getEventTtl().getSeconds())))
                         .setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM));
     }
 
@@ -114,9 +123,9 @@ public class CqlSubscriptionDAO implements SubscriptionDAO {
     private OwnedSubscription rowToOwnedSubscription(Row row) {
         String name = row.getString(0);
         Map<?, ?> json = JsonHelper.fromJson(row.getString(1), Map.class);
-        Condition tableFilter = Conditions.fromString((String) checkNotNull(json.get("filter"), "filter"));
-        Date expiresAt = new Date(((Number) checkNotNull(json.get("expiresAt"), "expiresAt")).longValue());
-        Duration eventTtl = Duration.ofSeconds(((Number) checkNotNull(json.get("eventTtl"), "eventTtl")).intValue());
+        Condition tableFilter = Conditions.fromString((String) Objects.requireNonNull(json.get("filter"), "filter"));
+        Date expiresAt = new Date(((Number) Objects.requireNonNull(json.get("expiresAt"), "expiresAt")).longValue());
+        Duration eventTtl = Duration.ofSeconds(((Number) Objects.requireNonNull(json.get("eventTtl"), "eventTtl")).intValue());
         // TODO:  Once API keys are fully integrated enforce non-null
         String ownerId = (String) json.get("ownerId");
         return new DefaultOwnedSubscription(name, tableFilter, expiresAt, eventTtl, ownerId);

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/db/generic/InMemorySubscriptionDAO.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/db/generic/InMemorySubscriptionDAO.java
@@ -1,25 +1,26 @@
 package com.bazaarvoice.emodb.databus.db.generic;
 
+import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
 import com.bazaarvoice.emodb.databus.model.DefaultOwnedSubscription;
 import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.sor.condition.Condition;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Date;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Generic in-memory implementation of SubscriptionDAO.  Useful for unit testing.
  */
 public class InMemorySubscriptionDAO implements SubscriptionDAO {
 
-    private final ConcurrentMap<String, OwnedSubscription> _subscriptions = Maps.newConcurrentMap();
+    private final ConcurrentMap<String, OwnedSubscription> _subscriptions = new ConcurrentHashMap<>();
     private final Clock _clock;
 
     public InMemorySubscriptionDAO() {
@@ -32,8 +33,12 @@ public class InMemorySubscriptionDAO implements SubscriptionDAO {
 
     @Override
     public void insertSubscription(String ownerId, String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl) {
-        _subscriptions.put(subscription, new DefaultOwnedSubscription(subscription, tableFilter,
+        insertSubscription(new DefaultOwnedSubscription(subscription, tableFilter,
                 new Date(_clock.millis() + subscriptionTtl.toMillis()), eventTtl, ownerId));
+    }
+
+    private void insertSubscription(OwnedSubscription subscription) {
+        _subscriptions.put(subscription.getName(), subscription);
     }
 
     @Override
@@ -61,6 +66,8 @@ public class InMemorySubscriptionDAO implements SubscriptionDAO {
 
     @Override
     public Iterable<String> getAllSubscriptionNames() {
-        return Iterables.transform(getAllSubscriptions(), OwnedSubscription::getName);
+        return StreamSupport.stream(getAllSubscriptions().spliterator(), false)
+                .map(Subscription::getName)
+                .collect(Collectors.toList());
     }
 }

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusChannelConfigurationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusChannelConfigurationTest.java
@@ -19,7 +19,7 @@ public class DatabusChannelConfigurationTest {
     @Test
     public void testGetTTLForReplay() {
         OwnedSubscription replaySubscription = new DefaultOwnedSubscription(ChannelNames.getMasterReplayChannel(),
-                Conditions.alwaysTrue(), Date.from(Instant.now().plus(Duration.ofDays(3650))),
+                Conditions.alwaysTrue(), Date.from(Instant.now().plus(Duration.ofDays(364))),
                 DatabusChannelConfiguration.REPLAY_TTL, "id");
         SubscriptionDAO mockSubscriptionDao = mock(SubscriptionDAO.class);
         when(mockSubscriptionDao.getSubscription(ChannelNames.getMasterReplayChannel())).thenReturn(replaySubscription);


### PR DESCRIPTION
## What Are We Doing Here?

Restrict databus TTLs to a 1 year limit

## How to Test and Verify

`mvn clean verify`

## Risk

Subscriptions with eventTTL more that 1 year won't work anymore.

### Level 

`Medium`
 
### Required Testing

`Smoke`, `Regression`, or `Manual`. (All changes except documentation need smoke
testing at a minimum).



## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
