### PR TITLE
Use cell tombstones in blocked delta tables

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
@@ -68,7 +68,15 @@ public class DataStoreConfiguration {
     @Valid
     @NotNull
     @JsonProperty("deltaBlockSizeInKb")
-    private int _deltaBlockSizeInKb = 64;
+    private int _deltaBlockSizeInKb = 16;
+
+    @Valid
+    @JsonProperty("cellTombstoneCompactionEnabled")
+    private boolean _cellTombstoneCompactionEnabled = true;
+
+    @Valid
+    @JsonProperty("cellTombstoneBlockLimit")
+    private int _cellTombstoneBlockLimit = 2;
 
     @Valid
     @NotNull
@@ -171,6 +179,14 @@ public class DataStoreConfiguration {
 
     public int getDeltaBlockSizeInKb() {
         return _deltaBlockSizeInKb;
+    }
+
+    public boolean isCellTombstoneCompactionEnabled() {
+        return _cellTombstoneCompactionEnabled;
+    }
+
+    public int getCellTombstoneBlockLimit() {
+        return _cellTombstoneBlockLimit;
     }
 
     public AuditWriterConfiguration getAuditWriterConfiguration() {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DefaultCompactor.java
@@ -3,11 +3,13 @@ package com.bazaarvoice.emodb.sor.core;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.sor.api.Compaction;
 import com.bazaarvoice.emodb.sor.db.Record;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.PeekingIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,19 +30,19 @@ public class DefaultCompactor extends AbstractCompactor {
     }
 
     public Expanded doExpand(Record record, long fullConsistencyTimestamp, MutableIntrinsics intrinsics, boolean ignoreRecent,
-                                Map.Entry<UUID, Compaction> compactionEntry)
+                                Map.Entry<DeltaClusteringKey, Compaction> compactionEntry)
             throws RestartException {
         checkNotNull(compactionEntry, "A legacy compaction needs to be provided to this legacy compactor");
-        List<UUID> keysToDelete = Lists.newArrayList();
+        List<DeltaClusteringKey> keysToDelete = Lists.newArrayList();
         DeltasArchive deltasArchive = new DeltasArchive();
 
         // Save the number of collected compaction Ids to delete in the pending compaction
-        List<UUID> compactionKeysToDelete = Lists.newArrayList(keysToDelete.iterator());
+        List<DeltaClusteringKey> compactionKeysToDelete = Lists.newArrayList(keysToDelete.iterator());
 
-        PeekingIterator<Map.Entry<UUID, DeltaTagPair>> deltaIterator = Iterators.peekingIterator(
+        PeekingIterator<Map.Entry<DeltaClusteringKey, DeltaTagPair>> deltaIterator = Iterators.peekingIterator(
                 deltaIterator(record.passTwoIterator(), compactionEntry));
 
-        UUID compactionKey = compactionEntry.getKey();
+        DeltaClusteringKey compactionKey = compactionEntry.getKey();
         Compaction compaction = compactionEntry.getValue();
         UUID cutoffId = compaction.getCutoff();
         UUID initialCutoff = compaction.getCutoff();
@@ -56,12 +58,12 @@ public class DefaultCompactor extends AbstractCompactor {
         resolver = new DefaultResolver(intrinsics, compaction);
 
         // Concurrent compaction operations can race and leave deltas older than the chosen cutoff.  Delete those deltas.
-        while (deltaIterator.hasNext() && TimeUUIDs.compare(deltaIterator.peek().getKey(), cutoffId) < 0) {
+        while (deltaIterator.hasNext() && TimeUUIDs.compare(deltaIterator.peek().getKey().getChangeId(), cutoffId) < 0) {
             keysToDelete.add(deltaIterator.next().getKey());
             numPersistentDeltas++;
         }
         // The next delta in the sequence must exist and be cutoffId.  If it's not, we have lost data somewhere?!
-        if (!deltaIterator.peek().getKey().equals(cutoffId)) {
+        if (!deltaIterator.peek().getKey().getChangeId().equals(cutoffId)) {
             // The only legitimate reason for the cutoff delta to be missing is because it was compacted away.
             // Scan for the compaction that replaced it to trigger a RestartException, assert if we don't find it.
             Iterators.advance(deltaIterator, Integer.MAX_VALUE);
@@ -77,27 +79,26 @@ public class DefaultCompactor extends AbstractCompactor {
 
 
         // Resolve deltas older than the current fullConsistencyTimestamp.  These deltas may be compacted together.
-        List<UUID> compactibleChangeIds = Lists.newArrayList();
-        while (deltaIterator.hasNext() && TimeUUIDs.getTimeMillis(deltaIterator.peek().getKey()) < fullConsistencyTimestamp) {
-            Map.Entry<UUID, DeltaTagPair> entry = deltaIterator.next();
-            resolver.update(entry.getKey(), entry.getValue().delta, entry.getValue().tags);
-            compactibleChangeIds.add(entry.getKey());
+        List<DeltaClusteringKey> compactibleClusteringKeys = Lists.newArrayList();
+        while (deltaIterator.hasNext() && TimeUUIDs.getTimeMillis(deltaIterator.peek().getKey().getChangeId()) < fullConsistencyTimestamp) {
+            Map.Entry<DeltaClusteringKey, DeltaTagPair> entry = deltaIterator.next();
+            resolver.update(entry.getKey().getChangeId(), entry.getValue().delta, entry.getValue().tags);
+            compactibleClusteringKeys.add(entry.getKey());
             // We would like to keep these deltas in pending compaction object in memory so we don't have to
             // go to C* to get them.
-            deltasArchive.addDeltaArchive(entry.getKey(), entry.getValue().delta);
+            deltasArchive.addDeltaArchive(entry.getKey().getChangeId(), entry.getValue().delta);
             numPersistentDeltas++;
         }
-        if (!compactibleChangeIds.isEmpty()) {
+        if (!compactibleClusteringKeys.isEmpty()) {
             // Merge the N oldest deltas and write the result into the new compaction.
             Resolved resolved = resolver.resolved();
 
             // Delete old compaction record and old deltas.
             keysToDelete.add(compactionKey);
             compactionKeysToDelete.add(compactionKey);
-            keysToDelete.addAll(compactibleChangeIds);
+            keysToDelete.addAll(compactibleClusteringKeys);
 
             // Write a new compaction record and re-write the preceding delta with the content resolved to this point.
-            compactionKey = TimeUUIDs.newUUID();
             compaction = new Compaction(
                     resolved.getIntrinsics().getVersion(),
                     resolved.getIntrinsics().getFirstUpdateAtUuid(),
@@ -118,7 +119,7 @@ public class DefaultCompactor extends AbstractCompactor {
         // be sure that eventually consistent readers don't see the result of the deletions w/o also
         // seeing the accompanying compaction.
         PendingCompaction pendingCompaction = (compactionChanged || !keysToDelete.isEmpty()) ?
-                new PendingCompaction(compactionKey, compaction, cutoffId, initialCutoff, cutoffDelta, initialCutoffDelta, keysToDelete,
+                new PendingCompaction(TimeUUIDs.newUUID(), compaction, cutoffId, initialCutoff, cutoffDelta, initialCutoffDelta, keysToDelete,
                         compactionKeysToDelete, deltasArchive.deltasToArchive)
                 : null;
 
@@ -133,7 +134,8 @@ public class DefaultCompactor extends AbstractCompactor {
         // Resolve recent deltas.
         if (!ignoreRecent) {
             while (deltaIterator.hasNext()) {
-                Map.Entry<UUID, DeltaTagPair> entry = deltaIterator.next();
+                Map.Entry<DeltaClusteringKey, DeltaTagPair> entryToTransform = deltaIterator.next();
+                Map.Entry<UUID, DeltaTagPair> entry = Maps.immutableEntry(entryToTransform.getKey().getChangeId(), entryToTransform.getValue());
                 resolver.update(entry.getKey(), entry.getValue().delta, entry.getValue().tags);
                 numPersistentDeltas++;
             }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DistributedCompactor.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.sor.core;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.sor.api.Compaction;
 import com.bazaarvoice.emodb.sor.db.Record;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
@@ -52,11 +53,11 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
      */
     protected Expanded doExpand(Record record, long fullConsistencyTimestamp, long compactionConsistencyTimeStamp, long compactionControlTimestamp, MutableIntrinsics intrinsics, boolean ignoreRecent)
             throws RestartException {
-        List<UUID> keysToDelete = Lists.newArrayList();
+        List<DeltaClusteringKey> keysToDelete = Lists.newArrayList();
         DeltasArchive deltasArchive = new DeltasArchive();
 
         // Loop through the compaction records and find the one that is most up-to-date.  Obsolete ones may be deleted.
-        Map.Entry<UUID, Compaction> compactionEntry = findEffectiveCompaction(record.passOneIterator(), keysToDelete, compactionConsistencyTimeStamp);
+        Map.Entry<DeltaClusteringKey, Compaction> compactionEntry = findEffectiveCompaction(record.passOneIterator(), keysToDelete, compactionConsistencyTimeStamp);
 
         // Check to see if this is a legacy compaction
         if (compactionEntry != null && !compactionEntry.getValue().hasCompactedDelta()) {
@@ -65,9 +66,9 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
         }
 
         // Save the number of collected compaction Ids to delete in the pending compaction
-        List<UUID> compactionKeysToDelete = Lists.newArrayList(keysToDelete.iterator());
+        List<DeltaClusteringKey> compactionKeysToDelete = Lists.newArrayList(keysToDelete.iterator());
 
-        PeekingIterator<Map.Entry<UUID, DeltaTagPair>> deltaIterator = Iterators.peekingIterator(
+        PeekingIterator<Map.Entry<DeltaClusteringKey, DeltaTagPair>> deltaIterator = Iterators.peekingIterator(
                 deltaIterator(record.passTwoIterator(), compactionEntry));
 
         UUID compactionKey = null;
@@ -93,10 +94,10 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
         if (compactionEntry == null) {
             resolver = new DefaultResolver(intrinsics);
         } else {
-            deleteDeltasForCompaction = TimeUUIDs.getTimeMillis(compactionEntry.getKey()) < compactionConsistencyTimeStamp;
+            deleteDeltasForCompaction = TimeUUIDs.getTimeMillis(compactionEntry.getKey().getChangeId()) < compactionConsistencyTimeStamp;
             createNewCompaction = deleteDeltasForCompaction;
 
-            compactionKey = compactionEntry.getKey();
+            compactionKey = compactionEntry.getKey().getChangeId();
             compaction = compactionEntry.getValue();
             numDeletedDeltas = compaction.getCount();
 
@@ -106,12 +107,12 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
             // Also, safe-delete: We need to make sure that compaction is fully consistent before we delete any deltas
             cutoffId = compaction.getCutoff();
             initialCutoff = compaction.getCutoff();
-            while (deltaIterator.hasNext() && TimeUUIDs.compare(deltaIterator.peek().getKey(), cutoffId) <= 0) {
+            while (deltaIterator.hasNext() && TimeUUIDs.compare(deltaIterator.peek().getKey().getChangeId(), cutoffId) <= 0) {
                 if (!deleteDeltasForCompaction) {
                     deltaIterator.next();
                     continue;
                 }
-                Map.Entry<UUID, DeltaTagPair> deltaEntry = deltaIterator.next();
+                Map.Entry<DeltaClusteringKey, DeltaTagPair> deltaEntry = deltaIterator.next();
                 keysToDelete.add(deltaEntry.getKey());
                 numPersistentDeltas++;
             }
@@ -123,14 +124,14 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
             initialCutoffDelta = compaction.getCompactedDelta();
         }
 
-        List<UUID> compactibleChangeIds = Lists.newArrayList();
-        while (createNewCompaction && deltaIterator.hasNext() && TimeUUIDs.getTimeMillis(deltaIterator.peek().getKey()) < fullConsistencyTimestamp) {
-            Map.Entry<UUID, DeltaTagPair> entry = deltaIterator.next();
-            resolver.update(entry.getKey(), entry.getValue().delta, entry.getValue().tags);
+        List<DeltaClusteringKey> compactibleChangeIds = Lists.newArrayList();
+        while (createNewCompaction && deltaIterator.hasNext() && TimeUUIDs.getTimeMillis(deltaIterator.peek().getKey().getChangeId()) < fullConsistencyTimestamp) {
+            Map.Entry<DeltaClusteringKey, DeltaTagPair> entry = deltaIterator.next();
+            resolver.update(entry.getKey().getChangeId(), entry.getValue().delta, entry.getValue().tags);
             compactibleChangeIds.add(entry.getKey());
             // We would like to keep these deltas in pending compaction object in memory so we don't have to
             // go to C* to get them.
-            deltasArchive.addDeltaArchive(entry.getKey(), entry.getValue().delta);
+            deltasArchive.addDeltaArchive(entry.getKey().getChangeId(), entry.getValue().delta);
             numPersistentDeltas++;
         }
         if (!compactibleChangeIds.isEmpty()) {
@@ -163,8 +164,8 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
         // consider compactionControlTimestamp here (one case could be that there is a stash run in progress) and not include those Ids.
         // With this, we are halting the deletion of these deltas in this run.
         // We could have not included these Ids at the first place in the top section, but just to be cleaner and for better separation, excluding these Ids here.
-        keysToDelete = keysToDelete.stream().filter(keyToDelete -> (TimeUUIDs.getTimeMillis(keyToDelete) > compactionControlTimestamp)).collect(Collectors.toList());
-        compactionKeysToDelete = compactionKeysToDelete.stream().filter(compactionKeyToDelete -> (TimeUUIDs.getTimeMillis(compactionKeyToDelete) > compactionControlTimestamp)).collect(Collectors.toList());
+        keysToDelete = keysToDelete.stream().filter(keyToDelete -> (TimeUUIDs.getTimeMillis(keyToDelete.getChangeId()) > compactionControlTimestamp)).collect(Collectors.toList());
+        compactionKeysToDelete = compactionKeysToDelete.stream().filter(compactionKeyToDelete -> (TimeUUIDs.getTimeMillis(compactionKeyToDelete.getChangeId()) > compactionControlTimestamp)).collect(Collectors.toList());
 
         // Persist the compaction, and keys-to-delete.  We must write compaction and delete synchronously to
         // be sure that eventually consistent readers don't see the result of the deletions w/o also
@@ -184,11 +185,11 @@ public class DistributedCompactor extends AbstractCompactor implements Compactor
 
         // Resolve recent deltas.
         while (deltaIterator.hasNext()) {
-            Map.Entry<UUID, DeltaTagPair> entry = deltaIterator.next();
-            if (ignoreRecent && TimeUUIDs.getTimeMillis(entry.getKey()) >= fullConsistencyTimestamp) {
+            Map.Entry<DeltaClusteringKey, DeltaTagPair> entry = deltaIterator.next();
+            if (ignoreRecent && TimeUUIDs.getTimeMillis(entry.getKey().getChangeId()) >= fullConsistencyTimestamp) {
                 break;
             }
-            resolver.update(entry.getKey(), entry.getValue().delta, entry.getValue().tags);
+            resolver.update(entry.getKey().getChangeId(), entry.getValue().delta, entry.getValue().tags);
             numPersistentDeltas++;
         }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/PendingCompaction.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/PendingCompaction.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.sor.core;
 
 import com.bazaarvoice.emodb.sor.api.Compaction;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 
 import javax.annotation.Nullable;
@@ -23,12 +24,12 @@ public class PendingCompaction {
     private final UUID _initialCutoffId;
     private final Delta _delta;
     private final Delta _startingDelta;
-    private final List<UUID> _keysToDelete;
-    private final List<UUID> _compactionKeysToDelete;
+    private final List<DeltaClusteringKey> _keysToDelete;
+    private final List<DeltaClusteringKey> _compactionKeysToDelete;
     private final List<Map.Entry<UUID, Delta>> _deltasToArchive;
 
-    public PendingCompaction(UUID compactionKey, Compaction compaction, UUID changeId, UUID initialCutoffId, Delta delta, Delta startingDelta, List<UUID> keysToDelete,
-                             List<UUID> compactionKeysToDelete, List<Map.Entry<UUID, Delta>> deltasToArchive) {
+    public PendingCompaction(UUID compactionKey, Compaction compaction, UUID changeId, UUID initialCutoffId, Delta delta, Delta startingDelta, List<DeltaClusteringKey> keysToDelete,
+                             List<DeltaClusteringKey> compactionKeysToDelete, List<Map.Entry<UUID, Delta>> deltasToArchive) {
         _compactionKey = compactionKey;
         _compaction = compaction;
         _changeId = changeId;
@@ -62,11 +63,11 @@ public class PendingCompaction {
         return _startingDelta;
     }
 
-    public List<UUID> getKeysToDelete() {
+    public List<DeltaClusteringKey> getKeysToDelete() {
         return _keysToDelete;
     }
 
-    public List<UUID> getCompactionKeysToDelete() {
+    public List<DeltaClusteringKey> getCompactionKeysToDelete() {
         return _compactionKeysToDelete;
     }
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DataWriterDAO.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.sor.db;
 import com.bazaarvoice.emodb.sor.api.Compaction;
 import com.bazaarvoice.emodb.sor.api.History;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.table.db.Table;
 
@@ -34,7 +35,7 @@ public interface DataWriterDAO {
 
     /** Deletes one or more deltas and replaces them with the specified update. */
     void compact(Table table, String key, UUID compactionKey, Compaction compaction, UUID changeId, Delta delta,
-                 Collection<UUID> changesToDelete, List<History> historyList, WriteConsistency consistency);
+                 Collection<DeltaClusteringKey> changesToDelete, List<History> historyList, WriteConsistency consistency);
 
     /** Writes delta histories. */
     void storeCompactedDeltas(Table tbl, String key, List<History> histories, WriteConsistency consistency);

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/Record.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/Record.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.emodb.sor.db;
 import com.bazaarvoice.emodb.sor.api.Change;
 import com.bazaarvoice.emodb.sor.api.Compaction;
 
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
@@ -14,9 +15,9 @@ public interface Record {
 
     Key getKey();
 
-    Iterator<Map.Entry<UUID, Compaction>> passOneIterator();
+    Iterator<Map.Entry<DeltaClusteringKey, Compaction>> passOneIterator();
 
-    Iterator<Map.Entry<UUID, Change>> passTwoIterator();
+    Iterator<Map.Entry<DeltaClusteringKey, Change>> passTwoIterator();
 
     Iterator<RecordEntryRawMetadata> rawMetadata();
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/Record.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/Record.java
@@ -6,7 +6,6 @@ import com.bazaarvoice.emodb.sor.api.Compaction;
 import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * A record read from the DAO layer.

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDataWriterDAO.java
@@ -11,6 +11,7 @@ import com.bazaarvoice.emodb.sor.core.HistoryStore;
 import com.bazaarvoice.emodb.sor.db.DAOUtils;
 import com.bazaarvoice.emodb.sor.db.DataWriterDAO;
 import com.bazaarvoice.emodb.sor.db.RecordUpdate;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.Literal;
 import com.bazaarvoice.emodb.sor.delta.MapDelta;
@@ -308,7 +309,7 @@ public class AstyanaxDataWriterDAO implements DataWriterDAO, DataPurgeDAO {
     @Timed(name = "bv.emodb.sor.AstyanaxDataWriterDAO.compact", absolute = true)
     @Override
     public void compact(Table tbl, String key, UUID compactionKey, Compaction compaction, UUID changeId,
-                        Delta delta, Collection<UUID> changesToDelete, List<History> historyList, WriteConsistency consistency) {
+                        Delta delta, Collection<DeltaClusteringKey> changesToDelete, List<History> historyList, WriteConsistency consistency) {
         // delegate to CQL Writer for double compaction writing
         _cqlWriterDAO.compact(tbl, key, compactionKey, compaction, changeId, delta, changesToDelete, historyList, consistency);
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDeltaIterator.java
@@ -1,25 +1,21 @@
 package com.bazaarvoice.emodb.sor.db.astyanax;
 
 import com.bazaarvoice.emodb.sor.db.DeltaIterator;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.netflix.astyanax.model.Column;
 
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.UUID;
 
-public class AstyanaxDeltaIterator extends DeltaIterator<Column<DeltaKey>, Column<UUID>> {
+public class AstyanaxDeltaIterator extends DeltaIterator<Column<DeltaKey>, StitchedColumn> {
     public AstyanaxDeltaIterator(Iterator<Column<DeltaKey>> iterator, boolean reversed, int prefixLength, String rowKey) {
         super(iterator, reversed, prefixLength, rowKey);
     }
 
     @Override
-    protected Column<UUID> convertDelta(Column<DeltaKey> delta, ByteBuffer content) {
-        return new StitchedColumn(delta, content);
-    }
-
-    @Override
-    protected Column<UUID> convertDelta(Column<DeltaKey> delta) {
-        return new StitchedColumn(delta);
+    protected StitchedColumn convertDelta(Column<DeltaKey> delta, BlockedDelta blockedDelta) {
+        return new StitchedColumn(delta, blockedDelta.getContent(), blockedDelta.getNumBlocks());
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxDeltaIterator.java
@@ -1,7 +1,6 @@
 package com.bazaarvoice.emodb.sor.db.astyanax;
 
 import com.bazaarvoice.emodb.sor.db.DeltaIterator;
-import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.netflix.astyanax.model.Column;
 
 import java.nio.ByteBuffer;

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CellTombstoneBlockLimit.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CellTombstoneBlockLimit.java
@@ -1,0 +1,18 @@
+package com.bazaarvoice.emodb.sor.db.astyanax;
+
+import com.google.inject.BindingAnnotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for identifying the minimum number of blocks in a delta for it to be compacted using a
+ * range tombstone rather than a cell tombstone.
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface CellTombstoneBlockLimit {
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CellTombstoneBlockLimit.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CellTombstoneBlockLimit.java
@@ -9,8 +9,8 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Guice binding annotation for identifying the minimum number of blocks in a delta for it to be compacted using a
- * range tombstone rather than a cell tombstone.
+ * Guice binding annotation for identifying the maximum number of blocks in a delta for it to be compacted using cell
+ * tombstones rather than a single range tombstone.
  */
 @BindingAnnotation
 @Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CellTombstoneCompactionEnabled.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CellTombstoneCompactionEnabled.java
@@ -1,0 +1,18 @@
+package com.bazaarvoice.emodb.sor.db.astyanax;
+
+import com.google.inject.BindingAnnotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Guice binding annotation for determining whether or not to delete compacted deltas using cell tombstones if the
+ * number of blocks in a delta is less than or equal to {@link CellTombstoneBlockLimit}
+ */
+@BindingAnnotation
+@Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface CellTombstoneCompactionEnabled {
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDeltaIterator.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 * CQL implementation of DeltaIterator.
 * Used to stitch blocked deltas back together on read.
  */
-public class CqlDeltaIterator extends DeltaIterator<Row, Row> {
+public class CqlDeltaIterator extends DeltaIterator<Row, StitchedRow> {
 
     private final ProtocolVersion _protocolVersion;
     private final CodecRegistry _codecRegistry;
@@ -32,13 +32,8 @@ public class CqlDeltaIterator extends DeltaIterator<Row, Row> {
     }
 
     @Override
-    protected Row convertDelta(Row row) {
-        return row;
-    }
-
-    @Override
-    protected Row convertDelta(Row row, ByteBuffer content) {
-        return new StitchedRow(_protocolVersion, _codecRegistry, row, content, _contentIndex);
+    protected StitchedRow convertDelta(Row row, BlockedDelta blockedDelta) {
+        return new StitchedRow(_protocolVersion, _codecRegistry, row, blockedDelta.getContent(), _contentIndex, blockedDelta.getNumBlocks());
     }
 
     @Override

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DAOModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DAOModule.java
@@ -112,6 +112,22 @@ public class DAOModule extends PrivateModule {
         return configuration.getDeltaBlockSizeInKb() * 1024;
     }
 
+    @Provides
+    @Singleton
+    @CellTombstoneBlockLimit
+    int provideCellTombstoneBlockLimit(DataStoreConfiguration configuration) {
+        return configuration.getCellTombstoneBlockLimit();
+    }
+
+    @Provides
+    @Singleton
+    @CellTombstoneCompactionEnabled
+    boolean provideCellTombstoneCompactionEnabled(DataStoreConfiguration configuration) {
+        return configuration.isCellTombstoneCompactionEnabled();
+    }
+
+
+
 
 
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/RecordImpl.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/RecordImpl.java
@@ -9,7 +9,6 @@ import com.bazaarvoice.emodb.sor.db.RecordEntryRawMetadata;
 import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/RecordImpl.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/RecordImpl.java
@@ -6,6 +6,7 @@ import com.bazaarvoice.emodb.sor.db.Key;
 import com.bazaarvoice.emodb.sor.db.Record;
 import com.bazaarvoice.emodb.sor.db.RecordEntryRawMetadata;
 
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
@@ -14,13 +15,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 class RecordImpl implements Record {
     private final Key _key;
-    private Iterator<Map.Entry<UUID, Compaction>> _passOneIterator;
-    private Iterator<Map.Entry<UUID, Change>> _passTwoIterator;
+    private Iterator<Map.Entry<DeltaClusteringKey, Compaction>> _passOneIterator;
+    private Iterator<Map.Entry<DeltaClusteringKey, Change>> _passTwoIterator;
     private Iterator<RecordEntryRawMetadata> _rawMetadataIterator;
 
     RecordImpl(Key key,
-               Iterator<Map.Entry<UUID, Compaction>> passOneIterator,
-               Iterator<Map.Entry<UUID, Change>> passTwoIterator,
+               Iterator<Map.Entry<DeltaClusteringKey, Compaction>> passOneIterator,
+               Iterator<Map.Entry<DeltaClusteringKey, Change>> passTwoIterator,
                Iterator<RecordEntryRawMetadata> rawMetadataIterator) {
         _key = key;
         _passOneIterator = passOneIterator;
@@ -34,15 +35,15 @@ class RecordImpl implements Record {
     }
 
     @Override
-    public Iterator<Map.Entry<UUID, Compaction>> passOneIterator() {
-        Iterator<Map.Entry<UUID, Compaction>> result = checkNotNull(_passOneIterator, "Already consumed.");
+    public Iterator<Map.Entry<DeltaClusteringKey, Compaction>> passOneIterator() {
+        Iterator<Map.Entry<DeltaClusteringKey, Compaction>> result = checkNotNull(_passOneIterator, "Already consumed.");
         _passOneIterator = null;
         return result;
     }
 
     @Override
-    public Iterator<Map.Entry<UUID, Change>> passTwoIterator() {
-        Iterator<Map.Entry<UUID, Change>> result = checkNotNull(_passTwoIterator, "Already consumed.");
+    public Iterator<Map.Entry<DeltaClusteringKey, Change>> passTwoIterator() {
+        Iterator<Map.Entry<DeltaClusteringKey, Change>> result = checkNotNull(_passTwoIterator, "Already consumed.");
         _passTwoIterator = null;
         return result;
     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/StitchedColumn.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/StitchedColumn.java
@@ -12,16 +12,19 @@ import java.util.UUID;
 public class StitchedColumn extends AbstractColumnImpl<UUID> {
     private Column<DeltaKey> _oldColumn;
     private ByteBuffer _content;
+    private int _numBlocks;
 
-    public StitchedColumn(Column<DeltaKey> oldColumn, ByteBuffer content) {
+    public StitchedColumn(Column<DeltaKey> oldColumn, ByteBuffer content, int numBlocks) {
         super(oldColumn.getName().getChangeId());
         _oldColumn = oldColumn;
         _content = content;
+        _numBlocks = numBlocks;
     }
 
     public StitchedColumn(Column<DeltaKey> oldColumn) {
         super(oldColumn.getName().getChangeId());
         _oldColumn = oldColumn;
+        _numBlocks = 1;
     }
 
     @Override
@@ -48,5 +51,9 @@ public class StitchedColumn extends AbstractColumnImpl<UUID> {
     @Override
     public boolean hasValue() {
         return _oldColumn.hasValue();
+    }
+
+    public int getNumBlocks() {
+        return _numBlocks;
     }
 }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/StitchedRow.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/StitchedRow.java
@@ -7,17 +7,19 @@ import java.nio.ByteBuffer;
 
 public class StitchedRow extends AbstractGettableData implements Row {
 
-    private ByteBuffer _content;
-    private Row _oldRow;
-    private int _contentIndex;
-    private CodecRegistry _codecRegistry;
+    private final ByteBuffer _content;
+    private final Row _oldRow;
+    private final int _contentIndex;
+    private final CodecRegistry _codecRegistry;
+    private final int _numBlocks;
 
-    public StitchedRow(ProtocolVersion protocolVersion, CodecRegistry codecRegistry, Row oldRow, ByteBuffer content, int contentIndex) {
+    public StitchedRow(ProtocolVersion protocolVersion, CodecRegistry codecRegistry, Row oldRow, ByteBuffer content, int contentIndex, int numBlocks) {
         super(protocolVersion);
         _codecRegistry = codecRegistry;
         _oldRow = oldRow;
         _content = content;
         _contentIndex = contentIndex;
+        _numBlocks = numBlocks;
     }
 
     @Override
@@ -61,6 +63,10 @@ public class StitchedRow extends AbstractGettableData implements Row {
     @Override
     public Token getPartitionKeyToken() {
         return _oldRow.getPartitionKeyToken();
+    }
+
+    public int getNumBlocks() {
+        return _numBlocks;
     }
 
     /**

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/DeltaClusteringKey.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/DeltaClusteringKey.java
@@ -1,0 +1,61 @@
+package com.bazaarvoice.emodb.sor.db.test;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DeltaClusteringKey {
+
+    private final UUID _changeId;
+    private final int _numBlocks;
+
+    public DeltaClusteringKey(UUID changeId, int numBlocks) {
+        checkArgument(numBlocks > 0);
+        _changeId = checkNotNull(changeId);
+        _numBlocks = numBlocks;
+    }
+
+    public DeltaClusteringKey(UUID changeId) {
+        _changeId = checkNotNull(changeId);
+        _numBlocks = 0;
+    }
+
+    public UUID getChangeId() {
+        return _changeId;
+    }
+
+    public int getNumBlocks() {
+        if (_numBlocks == 0) {
+            throw new IllegalStateException(String.format("ChangeId %s does not have blocking data.", _changeId));
+        }
+        return _numBlocks;
+    }
+
+    public boolean hasNumBlocks() {
+        return _numBlocks != 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DeltaClusteringKey that = (DeltaClusteringKey) o;
+        return _numBlocks == that.getNumBlocks() &&
+                Objects.equals(_changeId, that.getChangeId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_changeId, _numBlocks);
+    }
+
+    @Override
+    public String toString() {
+        return "DeltaClusteringKey{" +
+                "_changeId=" + _changeId +
+                ", _numBlocks=" + _numBlocks +
+                '}';
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/InMemoryDataReaderDAO.java
@@ -19,7 +19,6 @@ import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
@@ -29,8 +28,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.RateLimiter;
 import java.util.concurrent.TimeoutException;
-import org.apache.cassandra.dht.ByteOrderedPartitioner;
-import org.apache.cassandra.dht.Token;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/CompactorTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/CompactorTest.java
@@ -12,6 +12,7 @@ import com.bazaarvoice.emodb.sor.api.WriteConsistency;
 import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
 import com.bazaarvoice.emodb.sor.db.Key;
 import com.bazaarvoice.emodb.sor.db.Record;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.bazaarvoice.emodb.sor.db.test.InMemoryDataReaderDAO;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
@@ -75,12 +76,12 @@ public class CompactorTest {
         Delta delta3 = Deltas.mapBuilder().put("key2", "change").build();
         // Old style compaction
         Compaction compaction2 = new Compaction(2, t1, t3, "abcdef0123456789", t3, t3);
-        final List<Map.Entry<UUID, Compaction>> compactions2 = ImmutableList.of(
-                Maps.immutableEntry(t5, compaction2));
-        final List<Map.Entry<UUID,Change>> deltas2 = ImmutableList.of(
-                Maps.immutableEntry(t3, ChangeBuilder.just(t3, delta2)),
-                Maps.immutableEntry(t5, ChangeBuilder.just(t5, compaction2)),
-                Maps.immutableEntry(t6, ChangeBuilder.just(t6, delta3)));
+        final List<Map.Entry<DeltaClusteringKey, Compaction>> compactions2 = ImmutableList.of(
+                Maps.immutableEntry(new DeltaClusteringKey(t5 ,1), compaction2));
+        final List<Map.Entry<DeltaClusteringKey,Change>> deltas2 = ImmutableList.of(
+                Maps.immutableEntry(new DeltaClusteringKey(t3, 1), ChangeBuilder.just(t3, delta2)),
+                Maps.immutableEntry(new DeltaClusteringKey(t5, 1), ChangeBuilder.just(t5, compaction2)),
+                Maps.immutableEntry(new DeltaClusteringKey(t6, 1), ChangeBuilder.just(t6, delta3)));
 
         // This record will make it to LegacyCompactor, but will not "double-dip" in Cassandra as it has already found
         // compaction.
@@ -130,10 +131,10 @@ public class CompactorTest {
         assertNotNull(expanded.getPendingCompaction().getCompaction().getCompactedDelta(), "Not a new version of compaction");
 
         Compaction newCompaction = expanded.getPendingCompaction().getCompaction();
-        final List<Map.Entry<UUID, Compaction>> compactions3 = ImmutableList.of(
-                Maps.immutableEntry(t7, newCompaction));
-        final List<Map.Entry<UUID,Change>> deltas3 = ImmutableList.of(
-                Maps.immutableEntry(t7, ChangeBuilder.just(t7, newCompaction)));
+        final List<Map.Entry<DeltaClusteringKey, Compaction>> compactions3 = ImmutableList.of(
+                Maps.immutableEntry(new DeltaClusteringKey(t7, 1), newCompaction));
+        final List<Map.Entry<DeltaClusteringKey,Change>> deltas3 = ImmutableList.of(
+                Maps.immutableEntry(new DeltaClusteringKey(t7, 1), ChangeBuilder.just(t7, newCompaction)));
 
         Record record3 = mock(Record.class);
         when(record3.getKey()).thenReturn(key);
@@ -179,19 +180,19 @@ public class CompactorTest {
 
         // Compaction records after the first compaction
         Compaction compaction1 = new Compaction(2, t1, t2, "0123456789abcdef", t2, t2);
-        final List<Map.Entry<UUID, Compaction>> compactions1 = ImmutableList.of(
-                Maps.immutableEntry(t4, compaction1));
+        final List<Map.Entry<DeltaClusteringKey, Compaction>> compactions1 = ImmutableList.of(
+                Maps.immutableEntry(new DeltaClusteringKey(t4, 1), compaction1));
 
         // Compaction and delta records after the second compaction
         Delta delta2 = Deltas.literal(ImmutableMap.of("key", "value"));
         Delta delta3 = Deltas.mapBuilder().put("key2", "change").build();
         Compaction compaction2 = new Compaction(2, t1, t3, "abcdef0123456789", t3, t3);
-        final List<Map.Entry<UUID, Compaction>> compactions2 = ImmutableList.of(
-                Maps.immutableEntry(t5, compaction2));
-        final List<Map.Entry<UUID,Change>> deltas2 = ImmutableList.of(
-                Maps.immutableEntry(t3, ChangeBuilder.just(t3, delta2)),
-                Maps.immutableEntry(t5, ChangeBuilder.just(t5, compaction2)),
-                Maps.immutableEntry(t6, ChangeBuilder.just(t6, delta3)));
+        final List<Map.Entry<DeltaClusteringKey, Compaction>> compactions2 = ImmutableList.of(
+                Maps.immutableEntry(new DeltaClusteringKey(t5, 1), compaction2));
+        final List<Map.Entry<DeltaClusteringKey, Change>> deltas2 = ImmutableList.of(
+                Maps.immutableEntry(new DeltaClusteringKey(t3, 1), ChangeBuilder.just(t3, delta2)),
+                Maps.immutableEntry(new DeltaClusteringKey(t5, 1), ChangeBuilder.just(t5, compaction2)),
+                Maps.immutableEntry(new DeltaClusteringKey(t6, 1), ChangeBuilder.just(t6, delta3)));
 
         // First try will delegate to legacy compactor and fail because compaction record 1 is not present in the 2nd sequence of deltas
         Record record1 = mock(Record.class);
@@ -252,11 +253,11 @@ public class CompactorTest {
 
         Delta delta2 = Deltas.literal(ImmutableMap.of("key", "value"));
         Delta delta3 = Deltas.mapBuilder().put("key2", "change").build();
-        final List<Map.Entry<UUID, Compaction>> compactions = Lists.newArrayList();
-        final List<Map.Entry<UUID, Change>> deltas2 = ImmutableList.of(
-                Maps.immutableEntry(t1, ChangeBuilder.just(t1, delta2)),
-                Maps.immutableEntry(t2, ChangeBuilder.just(t2, delta2)),
-                Maps.immutableEntry(t3, ChangeBuilder.just(t3, delta3)));
+        final List<Map.Entry<DeltaClusteringKey, Compaction>> compactions = Lists.newArrayList();
+        final List<Map.Entry<DeltaClusteringKey, Change>> deltas2 = ImmutableList.of(
+                Maps.immutableEntry(new DeltaClusteringKey(t1, 1), ChangeBuilder.just(t1, delta2)),
+                Maps.immutableEntry(new DeltaClusteringKey(t2, 1), ChangeBuilder.just(t2, delta2)),
+                Maps.immutableEntry(new DeltaClusteringKey(t3, 1), ChangeBuilder.just(t3, delta3)));
 
         Record record = mock(Record.class);
         when(record.getKey()).thenReturn(key);
@@ -332,11 +333,11 @@ public class CompactorTest {
 
         Delta delta2 = Deltas.literal(ImmutableMap.of("key", "value"));
         Delta delta3 = Deltas.mapBuilder().put("key2", "change").build();
-        final List<Map.Entry<UUID, Compaction>> compactions = Lists.newArrayList();
-        Map.Entry<UUID, Change> firstDelta = Maps.immutableEntry(t1, ChangeBuilder.just(t1, delta2));
-        final List<Map.Entry<UUID, Change>> deltas2 = Lists.newArrayList(firstDelta,
-                Maps.immutableEntry(t2, ChangeBuilder.just(t2, delta2)),
-                Maps.immutableEntry(t3, ChangeBuilder.just(t3, delta3)));
+        final List<Map.Entry<DeltaClusteringKey, Compaction>> compactions = Lists.newArrayList();
+        Map.Entry<DeltaClusteringKey, Change> firstDelta = Maps.immutableEntry(new DeltaClusteringKey(t1, 1), ChangeBuilder.just(t1, delta2));
+        final List<Map.Entry<DeltaClusteringKey, Change>> deltas2 = Lists.newArrayList(firstDelta,
+                Maps.immutableEntry(new DeltaClusteringKey(t2, 1), ChangeBuilder.just(t2, delta2)),
+                Maps.immutableEntry(new DeltaClusteringKey(t3, 1), ChangeBuilder.just(t3, delta3)));
 
         Record record = mock(Record.class);
         when(record.getKey()).thenReturn(key);
@@ -359,7 +360,7 @@ public class CompactorTest {
         // Do not delete deltas just yet
         assertTrue(expanded.getPendingCompaction().getKeysToDelete().isEmpty());
         // Add the compactions to the compaction list
-        compactions.add(Maps.immutableEntry(expanded.getPendingCompaction().getChangeId(), expanded.getPendingCompaction().getCompaction()));
+        compactions.add(Maps.immutableEntry(new DeltaClusteringKey(expanded.getPendingCompaction().getChangeId(), 1), expanded.getPendingCompaction().getCompaction()));
         // Resetting now
         SystemClock.tick();
         now = System.currentTimeMillis();
@@ -370,7 +371,7 @@ public class CompactorTest {
         expanded = compactor.expand(record, now, now, Long.MIN_VALUE, MutableIntrinsics.create(key), false, requeryFn);
         // Verify that our deltas are going to be deleted now
         assertTrue(expanded.getPendingCompaction().getKeysToDelete().size() == 3, "All 3 deltas should be up for deletion");
-        assertTrue(ImmutableSet.copyOf(expanded.getPendingCompaction().getKeysToDelete()).equals(ImmutableSet.of(t1, t2, t3)));
+        assertTrue(ImmutableSet.copyOf(expanded.getPendingCompaction().getKeysToDelete()).equals(ImmutableSet.of(new DeltaClusteringKey(t1, 1), new DeltaClusteringKey(t2, 1), new DeltaClusteringKey(t3, 1))));
 
         // Finally, let's assume only one delta really got deleted, and two of these deltas
         // "resurrected" themselves due to no tombstones in Cassandra
@@ -382,7 +383,7 @@ public class CompactorTest {
 
         expanded = compactor.expand(record, now, now, Long.MIN_VALUE, MutableIntrinsics.create(key), false, requeryFn);
         assertTrue(expanded.getPendingCompaction().getKeysToDelete().size() == 2, "The 2 'resurrected' deltas are simply deleted again");
-        assertTrue(ImmutableSet.copyOf(expanded.getPendingCompaction().getKeysToDelete()).equals(ImmutableSet.of(t2, t3)));
+        assertTrue(ImmutableSet.copyOf(expanded.getPendingCompaction().getKeysToDelete()).equals(ImmutableSet.of(new DeltaClusteringKey(t2, 1), new DeltaClusteringKey(t3, 1))));
         expectedContent = ImmutableMap.of("key", "value", "key2", "change");
         assertEquals(expanded.getResolved().getContent(), expectedContent);
 
@@ -403,21 +404,21 @@ public class CompactorTest {
         // Add a new delta so we can discard the old compaction, and then resurrect compaction again for our test
         UUID t4 = TimeUUIDs.newUUID();
         Delta delta4 = Deltas.mapBuilder().put("key4", "change4").build();
-        deltas2.add(Maps.immutableEntry(t4, ChangeBuilder.just(t4, delta4)));
+        deltas2.add(Maps.immutableEntry(new DeltaClusteringKey(t4, 1), ChangeBuilder.just(t4, delta4)));
         when(record.passOneIterator()).thenReturn(compactions.iterator());
         when(record.passTwoIterator()).thenReturn(deltas2.iterator());
 
         expanded = compactor.expand(record, now, now, Long.MIN_VALUE, MutableIntrinsics.create(key), false, requeryFn);
         // The above should create a new compaction
         assertTrue(expanded.getPendingCompaction().getCompaction() != null);
-        UUID toBeResurrectedCompaction = compactions.get(0).getKey();
+        DeltaClusteringKey toBeResurrectedCompaction = compactions.get(0).getKey();
         // Make sure the old compaction is getting deleted
         assertTrue(expanded.getPendingCompaction().getKeysToDelete().contains(toBeResurrectedCompaction));
         expectedContent = ImmutableMap.of("key", "value", "key2", "change", "key4", "change4");
         assertEquals(expanded.getResolved().getContent(), expectedContent);
 
         // Add the newest compaction to our list of compaction, but do not delete the old one simulating resurrection
-        compactions.add(Maps.immutableEntry(expanded.getPendingCompaction().getChangeId(), expanded.getPendingCompaction().getCompaction()));
+        compactions.add(Maps.immutableEntry(new DeltaClusteringKey(expanded.getPendingCompaction().getChangeId(), 1), expanded.getPendingCompaction().getCompaction()));
         // Let's fetch the record again, and see if the existing old compaction affect anything
         when(record.passOneIterator()).thenReturn(compactions.iterator());
         when(record.passTwoIterator()).thenReturn(deltas2.iterator());
@@ -443,7 +444,7 @@ public class CompactorTest {
         InMemoryDataReaderDAO dataDAO = new InMemoryDataReaderDAO() {
             @Override
             public void compact(Table table, String key, UUID compactionKey, Compaction compaction,
-                                UUID changeId, Delta delta, Collection<UUID> changesToDelete, List<History> historyList, WriteConsistency consistency) {
+                                UUID changeId, Delta delta, Collection<DeltaClusteringKey> changesToDelete, List<History> historyList, WriteConsistency consistency) {
                 checkNotNull(table, "table");
                 checkNotNull(key, "key");
                 checkNotNull(compactionKey, "compactionKey");

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiDCCompactionTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MultiDCCompactionTest.java
@@ -12,6 +12,7 @@ import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
 import com.bazaarvoice.emodb.sor.db.Key;
 import com.bazaarvoice.emodb.sor.db.Record;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.bazaarvoice.emodb.sor.db.test.InMemoryDataReaderDAO;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
@@ -150,10 +151,10 @@ public class MultiDCCompactionTest {
         Compaction c2 = new Compaction(4, t1, t1, signature, null, null, delta);
         Compaction c3 = new Compaction(3, t1, t1, signature, null, null, delta);
 
-        final List<Map.Entry<UUID, Compaction>> compactions = Lists.newArrayList(
-                Maps.immutableEntry(t1, c1),
-                Maps.immutableEntry(t2, c2),
-                Maps.immutableEntry(t3, c3)
+        final List<Map.Entry<DeltaClusteringKey, Compaction>> compactions = Lists.newArrayList(
+                Maps.immutableEntry(new DeltaClusteringKey(t1, 1), c1),
+                Maps.immutableEntry(new DeltaClusteringKey(t2, 1), c2),
+                Maps.immutableEntry(new DeltaClusteringKey(t3, 1), c3)
                 );
 
         Record record = mock(Record.class);
@@ -171,10 +172,10 @@ public class MultiDCCompactionTest {
 
         // Change the FCT such that the winning compaction (c2) is before FCT
         expand = compactor.expand(record, fctAfterT2, fctAfterT2, Long.MIN_VALUE, MutableIntrinsics.create(key), false, requeryFn);
-        List<UUID> deletedCompactions = expand.getPendingCompaction().getCompactionKeysToDelete();
+        List<DeltaClusteringKey> deletedCompactions = expand.getPendingCompaction().getCompactionKeysToDelete();
         // Verify that compactions other than c2, are deleted
-        Assert.assertTrue(deletedCompactions.contains(t1));
-        Assert.assertTrue(deletedCompactions.contains(t3));
+        Assert.assertTrue(deletedCompactions.contains(new DeltaClusteringKey(t1, 1)));
+        Assert.assertTrue(deletedCompactions.contains(new DeltaClusteringKey(t3, 1)));
     }
 
     private Audit newAudit(String comment) {

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/db/DeltaBlockingTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/db/DeltaBlockingTest.java
@@ -154,13 +154,8 @@ class ListDeltaIterator extends DeltaIterator<TestRow, ByteBuffer> {
     }
 
     @Override
-    protected ByteBuffer convertDelta(TestRow delta) {
-        return delta.getContent();
-    }
-
-    @Override
-    protected ByteBuffer convertDelta(TestRow delta, ByteBuffer content) {
-        return content;
+    protected ByteBuffer convertDelta(TestRow delta, BlockedDelta blockedDelta) {
+        return blockedDelta.getContent();
     }
 
     @Override

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/test/PausableDataWriterDAO.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/test/PausableDataWriterDAO.java
@@ -5,6 +5,7 @@ import com.bazaarvoice.emodb.sor.api.History;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
 import com.bazaarvoice.emodb.sor.db.DataWriterDAO;
 import com.bazaarvoice.emodb.sor.db.RecordUpdate;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.bazaarvoice.emodb.sor.db.test.InMemoryDataReaderDAO;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.table.db.Table;
@@ -50,7 +51,7 @@ public class PausableDataWriterDAO implements DataWriterDAO {
 
     @Override
     public void compact(final Table table, final String key, @Nullable final UUID compactionKey, @Nullable final Compaction compaction, @Nullable final UUID changeId, @Nullable final Delta delta,
-                        final Collection<UUID> changesToDelete, final List<History> historyList, final WriteConsistency consistency) {
+                        final Collection<DeltaClusteringKey> changesToDelete, final List<History> historyList, final WriteConsistency consistency) {
         if (_onlyReplicateDeletesUponCompaction) {
             ((InMemoryDataReaderDAO)_delegate).deleteDeltasOnly(table, key, compactionKey, compaction, changeId, delta,
                     changesToDelete, historyList, consistency);

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/test/ReplicatingDataWriterDAO.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/test/ReplicatingDataWriterDAO.java
@@ -5,6 +5,7 @@ import com.bazaarvoice.emodb.sor.api.History;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
 import com.bazaarvoice.emodb.sor.db.DataWriterDAO;
 import com.bazaarvoice.emodb.sor.db.RecordUpdate;
+import com.bazaarvoice.emodb.sor.db.test.DeltaClusteringKey;
 import com.bazaarvoice.emodb.sor.delta.Delta;
 import com.bazaarvoice.emodb.table.db.Table;
 import com.google.common.collect.ImmutableList;
@@ -69,7 +70,7 @@ public class ReplicatingDataWriterDAO implements DataWriterDAO {
 
     @Override
     public void compact(Table table, String key, UUID compactionKey, Compaction compaction, UUID changeId, Delta delta,
-                        Collection<UUID> changesToDelete, List<History> historyList, WriteConsistency consistency) {
+                        Collection<DeltaClusteringKey> changesToDelete, List<History> historyList, WriteConsistency consistency) {
         _local.compact(table, key, compactionKey, compaction, changeId, delta, changesToDelete, historyList, consistency);
         for (DataWriterDAO remote : _remotes) {
             remote.compact(table, key, compactionKey, compaction, changeId, delta, changesToDelete, historyList, consistency);

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -58,6 +58,8 @@ dataCenter:
 systemOfRecord:
   migrationPhase: PRE_MIGRATION
   deltaBlockSizeInKb: 16
+  cellTombstoneCompactionEnabled: true
+  cellTombstoneBlockLimit: 2
   stashRoot: s3://emodb-us-east-1/stash/ci
 
   # Optional property - to exclude the tables satisfying the condition from the daily Stash run.


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

In our QA environments, we have observed tombstone issues in blocked tables. Unlike the old delta tables, the new delta tables use range tombstones for deletes instead of cell tombstones. Because of a bug in Cassandra 2.1, we cannot use tracing to observe how many tombstones exist in a given row. 

My best guess as to why the blocked tables are having tombstone issues is that range tombstones are less efficient for our use than cell tombstones. This PR alters our compaction process to use cell tombstones whenever a delta has 2 or fewer blocks.

This PR continues to use range tombstones on the blocked tables whenever the `migrationStage` is set read from the old tables. This is because it extremely complicated to compute the number blocks in a delta if we did not read it from the blocked table. We should first test this PR in environments that are already reading from the blocked tables and see if it improves performance. If we are successful, I can then make a different pull request with adds support for cell tombstones when reading from the legacy delta tables.

## How to Test and Verify

1. Check out this PR
2. Set `migrationPhase` to `DOUBLE_WRITE_BLOCKED_READ`
3. Write large deltas to Emo and ensure they get compacted properly under the new model
4. Additionally, set `DOUBLE_WRITE_LEGACY_READ` and ensure that the old tables are unharmed by this change

## Risk

### Level 

`High`

### Required Testing

The whole kitchen sink!

### Risk Summary

This is pretty high risk, as we are modifying the way Emo does compaction on the new table. If something is wrong with it, we could potentially cause a corruption.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
