### PR TITLE
Revert "EMO-6784 Restrict databus TTLs to 1 year (#221)"

### DIFF
--- a/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DefaultSubscription.java
+++ b/databus-api/src/main/java/com/bazaarvoice/emodb/databus/api/DefaultSubscription.java
@@ -4,53 +4,22 @@ import com.bazaarvoice.emodb.sor.condition.Condition;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
 
 import java.time.Duration;
 import java.util.Date;
-import java.util.Objects;
-
-import static com.bazaarvoice.emodb.databus.api.Names.isLegalSubscriptionName;
 
 public final class DefaultSubscription implements Subscription {
-    // Currently, by default, subscription event ttl limit is set to 365 days,
-    // but that could be changed in future
-    private final static Duration EVENT_TTL_LIMIT = Duration.ofDays(365);
-
     private final String _name;
     private final Condition _tableFilter;
     private final Date _expiresAt;
     private final Duration _eventTtl;
 
     public DefaultSubscription(String name, Condition tableFilter, Date expiresAt, Duration eventTtl) {
-        _name = validateName(name);
+        _name = name;
         _tableFilter = tableFilter;
-        _expiresAt =  Objects.requireNonNull(expiresAt);
-        _eventTtl = validateEventTtl(eventTtl);
-    }
-
-    private static String validateName(final String name) {
-        Objects.requireNonNull(name);
-
-        if (!isLegalSubscriptionName(name)) {
-            throw new IllegalArgumentException("Subscription name must be a lowercase ASCII string between 1 and 255 characters in length. " +
-                    "Allowed punctuation characters are -.:@_ and the subscription name may not start with a single underscore character. " +
-                    "An example of a valid subscription name would be 'polloi:review'.");
-        }
-
-        return name;
-    }
-
-    private static Duration validateEventTtl(final Duration eventTtl) {
-        Objects.requireNonNull(eventTtl);
-
-        if (eventTtl.compareTo(Duration.ZERO) < 0) {
-            throw new IllegalArgumentException("EventTtl must be >0");
-        }
-
-        if (eventTtl.compareTo(EVENT_TTL_LIMIT) > 0) {
-            throw new IllegalArgumentException(String.format("EventTtl duration should be within %s days", EVENT_TTL_LIMIT.toDays()));
-        }
-        return eventTtl;
+        _expiresAt = expiresAt;
+        _eventTtl = eventTtl;
     }
 
     @JsonCreator
@@ -95,16 +64,16 @@ public final class DefaultSubscription implements Subscription {
 
         if (o instanceof Subscription) {
             Subscription toCompare = (Subscription) o;
-            return Objects.equals(this.getName(), toCompare.getName()) &&
-                    Objects.equals(this.getTableFilter(), toCompare.getTableFilter()) &&
-                    Objects.equals(this.getExpiresAt(), toCompare.getExpiresAt()) &&
-                    Objects.equals(this.getEventTtl(), toCompare.getEventTtl());
+            return Objects.equal(this.getName(), toCompare.getName()) &&
+                    Objects.equal(this.getTableFilter(), toCompare.getTableFilter()) &&
+                    Objects.equal(this.getExpiresAt(), toCompare.getExpiresAt()) &&
+                    Objects.equal(this.getEventTtl(), toCompare.getEventTtl());
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_name, _tableFilter, _expiresAt, _eventTtl);
+        return Objects.hashCode(_name, _tableFilter, _expiresAt, _eventTtl);
     }
 }

--- a/databus-api/src/test/java/com/bazaarvoice/emodb/databus/api/SubscriptionJsonTest.java
+++ b/databus-api/src/test/java/com/bazaarvoice/emodb/databus/api/SubscriptionJsonTest.java
@@ -47,34 +47,4 @@ public class SubscriptionJsonTest {
         assertEquals(actual.getExpiresAt(), expected.getExpiresAt());
         assertEquals(actual.getEventTtl(), expected.getEventTtl());
     }
-
-    @Test(expectedExceptions=IllegalArgumentException.class, expectedExceptionsMessageRegExp=".* EventTtl duration should be within 365 days .*")
-    public void testSubscriptionJsonWithEventTtlGreaterThan365Days() throws Exception {
-        Date now = new Date();
-        String nowString = DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC).format(now.toInstant());
-
-        String subscriptionJsonString = "{" +
-                "\"name\":\"test-subscription\"," +
-                "\"tableFilter\":\"intrinsic(\\\"~table\\\":\\\"review:testcustomer\\\")\"," +
-                "\"expiresAt\":\"" + nowString + "\"," +
-                "\"eventTtl\":31622400000" +
-                "}";
-
-        JsonHelper.fromJson(subscriptionJsonString, Subscription.class);
-    }
-
-    @Test(expectedExceptions=IllegalArgumentException.class, expectedExceptionsMessageRegExp=".* EventTtl must be >0 .*")
-    public void testSubscriptionJsonWithNegativeEventTtl() throws Exception {
-        Date now = new Date();
-        String nowString = DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC).format(now.toInstant());
-
-        String subscriptionJsonString = "{" +
-                "\"name\":\"test-subscription\"," +
-                "\"tableFilter\":\"intrinsic(\\\"~table\\\":\\\"review:testcustomer\\\")\"," +
-                "\"expiresAt\":\"" + nowString + "\"," +
-                "\"eventTtl\":-1" +
-                "}";
-
-        JsonHelper.fromJson(subscriptionJsonString, Subscription.class);
-    }
 }

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -276,7 +276,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
     private void createDatabusReplaySubscription() {
         // Create a master databus replay subscription where the events expire every 50 hours (2 days + 2 hours)
         subscribe(_systemOwnerId, ChannelNames.getMasterReplayChannel(), Conditions.alwaysTrue(),
-                Duration.ofDays(365), DatabusChannelConfiguration.REPLAY_TTL, false);
+                Duration.ofDays(3650), DatabusChannelConfiguration.REPLAY_TTL, false);
     }
 
     private Meter newEventMeter(String name, MetricRegistry metricRegistry) {

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/db/generic/InMemorySubscriptionDAO.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/db/generic/InMemorySubscriptionDAO.java
@@ -1,26 +1,25 @@
 package com.bazaarvoice.emodb.databus.db.generic;
 
-import com.bazaarvoice.emodb.databus.api.Subscription;
 import com.bazaarvoice.emodb.databus.db.SubscriptionDAO;
 import com.bazaarvoice.emodb.databus.model.DefaultOwnedSubscription;
 import com.bazaarvoice.emodb.databus.model.OwnedSubscription;
 import com.bazaarvoice.emodb.sor.condition.Condition;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 
 import javax.annotation.Nullable;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Date;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * Generic in-memory implementation of SubscriptionDAO.  Useful for unit testing.
  */
 public class InMemorySubscriptionDAO implements SubscriptionDAO {
 
-    private final ConcurrentMap<String, OwnedSubscription> _subscriptions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, OwnedSubscription> _subscriptions = Maps.newConcurrentMap();
     private final Clock _clock;
 
     public InMemorySubscriptionDAO() {
@@ -33,12 +32,8 @@ public class InMemorySubscriptionDAO implements SubscriptionDAO {
 
     @Override
     public void insertSubscription(String ownerId, String subscription, Condition tableFilter, Duration subscriptionTtl, Duration eventTtl) {
-        insertSubscription(new DefaultOwnedSubscription(subscription, tableFilter,
+        _subscriptions.put(subscription, new DefaultOwnedSubscription(subscription, tableFilter,
                 new Date(_clock.millis() + subscriptionTtl.toMillis()), eventTtl, ownerId));
-    }
-
-    private void insertSubscription(OwnedSubscription subscription) {
-        _subscriptions.put(subscription.getName(), subscription);
     }
 
     @Override
@@ -66,8 +61,6 @@ public class InMemorySubscriptionDAO implements SubscriptionDAO {
 
     @Override
     public Iterable<String> getAllSubscriptionNames() {
-        return StreamSupport.stream(getAllSubscriptions().spliterator(), false)
-                .map(Subscription::getName)
-                .collect(Collectors.toList());
+        return Iterables.transform(getAllSubscriptions(), OwnedSubscription::getName);
     }
 }

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusChannelConfigurationTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/DatabusChannelConfigurationTest.java
@@ -19,7 +19,7 @@ public class DatabusChannelConfigurationTest {
     @Test
     public void testGetTTLForReplay() {
         OwnedSubscription replaySubscription = new DefaultOwnedSubscription(ChannelNames.getMasterReplayChannel(),
-                Conditions.alwaysTrue(), Date.from(Instant.now().plus(Duration.ofDays(364))),
+                Conditions.alwaysTrue(), Date.from(Instant.now().plus(Duration.ofDays(3650))),
                 DatabusChannelConfiguration.REPLAY_TTL, "id");
         SubscriptionDAO mockSubscriptionDao = mock(SubscriptionDAO.class);
         when(mockSubscriptionDao.getSubscription(ChannelNames.getMasterReplayChannel())).thenReturn(replaySubscription);


### PR DESCRIPTION
This reverts commit d17b09000a16f5feebe2d5ab9f65fa0cf58d0025.

## Github Issue #

`None`

## What Are We Doing Here?

We are reverting #221, which introduced a bug where subscription TTL's were given the were replaced with event TTL's accidentally.

## How to Test and Verify

1. Check out this PR
2. Build and Run locally
3. Check the subscription table for the replay subscription
4. Ensure that the replay subscription has a ttl of 10 years

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The risk of this is low, as we are reverting back to code that we know works.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
