### PR TITLE
Enable cell tombstones deletions during legacy read period of migration

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
@@ -61,14 +61,11 @@ public class DataStoreConfiguration {
     @JsonProperty("migrationPhase")
     private DeltaMigrationPhase _migrationPhase = DeltaMigrationPhase.PRE_MIGRATION;
 
-
-    /*
-    Only temporarily configurable during the migration period
-    */
-    @Valid
-    @NotNull
-    @JsonProperty("deltaBlockSizeInKb")
-    private int _deltaBlockSizeInKb = 16;
+//    TODO: uncomment this out and make this configurable after the delta migration is complete
+//    @Valid
+//    @NotNull
+//    @JsonProperty("deltaBlockSizeInKb")
+//    private int _deltaBlockSizeInKb = 16;
 
     @Valid
     @JsonProperty("cellTombstoneCompactionEnabled")
@@ -177,8 +174,12 @@ public class DataStoreConfiguration {
         return _migrationPhase;
     }
 
+    /**
+     * This temporarily set to a static 16 kilobytes because it is unsafe for this to be configurable during the migration
+     * period
+     */
     public int getDeltaBlockSizeInKb() {
-        return _deltaBlockSizeInKb;
+        return 16;
     }
 
     public boolean isCellTombstoneCompactionEnabled() {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/DataStoreConfiguration.java
@@ -14,6 +14,8 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class DataStoreConfiguration {
 
     @Valid
@@ -61,11 +63,10 @@ public class DataStoreConfiguration {
     @JsonProperty("migrationPhase")
     private DeltaMigrationPhase _migrationPhase = DeltaMigrationPhase.PRE_MIGRATION;
 
-//    TODO: uncomment this out and make this configurable after the delta migration is complete
-//    @Valid
-//    @NotNull
-//    @JsonProperty("deltaBlockSizeInKb")
-//    private int _deltaBlockSizeInKb = 16;
+    @Valid
+    @NotNull
+    @JsonProperty("deltaBlockSizeInKb")
+    private int _deltaBlockSizeInKb = 16;
 
     @Valid
     @JsonProperty("cellTombstoneCompactionEnabled")
@@ -175,11 +176,12 @@ public class DataStoreConfiguration {
     }
 
     /**
-     * This temporarily set to a static 16 kilobytes because it is unsafe for this to be configurable during the migration
+     * This temporarily locked to a static 16 kilobytes because it is unsafe for this to be configurable during the migration
      * period
      */
     public int getDeltaBlockSizeInKb() {
-        return 16;
+        checkArgument(_deltaBlockSizeInKb == 16);
+        return _deltaBlockSizeInKb;
     }
 
     public boolean isCellTombstoneCompactionEnabled() {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
@@ -247,7 +247,7 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
         if (_writeToBlockedDeltaTable) {
             BatchStatement newTableStatement = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (DeltaClusteringKey change : changesToDelete) {
-                if (change.hasNumBlocks() && _cellTombstoneCompactionEnabled && change.getNumBlocks() <= _cellTombstoneBlockLimit) {
+                if (_cellTombstoneCompactionEnabled && change.getNumBlocks() <= _cellTombstoneBlockLimit) {
                     for (int i = 0; i < change.getNumBlocks(); i++) {
                         newTableStatement.add(blockDeleteStatement(placement.getBlockedDeltaTableDDL(), rowKey, change.getChangeId(), i, consistencyLevel));
                     }

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/DeltaClusteringKey.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/test/DeltaClusteringKey.java
@@ -17,26 +17,13 @@ public class DeltaClusteringKey {
         _numBlocks = numBlocks;
     }
 
-    public DeltaClusteringKey(UUID changeId) {
-        _changeId = checkNotNull(changeId);
-        _numBlocks = 0;
-    }
-
     public UUID getChangeId() {
         return _changeId;
     }
 
     public int getNumBlocks() {
-        if (_numBlocks == 0) {
-            throw new IllegalStateException(String.format("ChangeId %s does not have blocking data.", _changeId));
-        }
         return _numBlocks;
     }
-
-    public boolean hasNumBlocks() {
-        return _numBlocks != 0;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/core/MinSplitSizeTest.java
@@ -5,6 +5,7 @@ import com.bazaarvoice.emodb.sor.api.DataStore;
 import com.bazaarvoice.emodb.sor.api.TableOptionsBuilder;
 import com.bazaarvoice.emodb.sor.api.WriteConsistency;
 import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
+import com.bazaarvoice.emodb.sor.db.DAOUtils;
 import com.bazaarvoice.emodb.sor.db.astyanax.AstyanaxDataReaderDAO;
 import com.bazaarvoice.emodb.sor.db.astyanax.ChangeEncoder;
 import com.bazaarvoice.emodb.sor.db.test.InMemoryDataReaderDAO;
@@ -66,7 +67,7 @@ public class MinSplitSizeTest {
 
     @Test
     public void testLocalResplitting() {
-        AstyanaxDataReaderDAO astyanaxDataReaderDAO = new AstyanaxDataReaderDAO(mock(PlacementCache.class), mock(ChangeEncoder.class), new MetricRegistry());
+        AstyanaxDataReaderDAO astyanaxDataReaderDAO = new AstyanaxDataReaderDAO(mock(PlacementCache.class), mock(ChangeEncoder.class), mock(DAOUtils.class), new MetricRegistry());
 
         String[] minMaxResplits3Times = {
                 "0000000000000000000000000000000000000000",

--- a/sor/src/test/java/com/bazaarvoice/emodb/sor/db/DeltaBlockingTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/sor/db/DeltaBlockingTest.java
@@ -44,6 +44,7 @@ public class DeltaBlockingTest {
         List<TestRow> rows = Lists.newArrayListWithCapacity(deltas.length * 5); // lazy guess at future size
         for (String encodedDelta : encodedDeltas) {
             List<ByteBuffer> blocks = _daoUtils.getDeltaBlocks(ByteBuffer.wrap(encodedDelta.getBytes()));
+            assertEquals(blocks.size(), _daoUtils.getNumDeltaBlocks(ByteBuffer.wrap(encodedDelta.getBytes())));
             UUID changeId = UUID.randomUUID();
             for (int i = 0; i < blocks.size(); i++) {
                 rows.add(new TestRow(i, changeId, blocks.get(i)));
@@ -91,6 +92,7 @@ public class DeltaBlockingTest {
         String delta = generateLargeDelta();
         String encodedDelta = StringUtils.repeat('0', _prefixLength) + delta;
         List<ByteBuffer> blocks = daoUtils.getDeltaBlocks(ByteBuffer.wrap(encodedDelta.getBytes()));
+        assertEquals(blocks.size(), daoUtils.getNumDeltaBlocks(ByteBuffer.wrap(encodedDelta.getBytes())));
         List<TestRow> rows = Lists.newArrayListWithCapacity(blocks.size());
         UUID changeId = UUID.randomUUID();
         for (int i = 0; i < blocks.size(); i++) {
@@ -114,6 +116,7 @@ public class DeltaBlockingTest {
         String delta = generateLargeDelta();
         String encodedDelta = StringUtils.repeat('0', _prefixLength) + delta;
         List<ByteBuffer> blocks = _daoUtils.getDeltaBlocks(ByteBuffer.wrap(encodedDelta.getBytes()));
+        assertEquals(blocks.size(), _daoUtils.getNumDeltaBlocks(ByteBuffer.wrap(encodedDelta.getBytes())));
         List<TestRow> rows = Lists.newArrayList();
         UUID changeId = UUID.randomUUID();
         for (int i = 0; i < blocks.size() - 1; i++) {
@@ -123,6 +126,7 @@ public class DeltaBlockingTest {
         UUID secondDeltaUUID = UUID.randomUUID();
 
         List<ByteBuffer> secondDeltaBlocks = _daoUtils.getDeltaBlocks(ByteBuffer.wrap("0000D3:[]:0:{..,\"name\":\"bobåååååຄຄຄຄຄຄຄຄຄຄ\"}".getBytes()));
+        assertEquals(secondDeltaBlocks.size(), _daoUtils.getNumDeltaBlocks(ByteBuffer.wrap("0000D3:[]:0:{..,\"name\":\"bobåååååຄຄຄຄຄຄຄຄຄຄ\"}".getBytes())));
 
         for (int i = 0; i < secondDeltaBlocks.size(); i++) {
             rows.add(new TestRow(i, secondDeltaUUID, secondDeltaBlocks.get(i)));
@@ -158,6 +162,8 @@ public class DeltaBlockingTest {
         String delta = generateLargeDelta();
         String encodedDelta = StringUtils.repeat('0', _prefixLength) + delta;
         List<ByteBuffer> blocks = _daoUtils.getDeltaBlocks(ByteBuffer.wrap(encodedDelta.getBytes()));
+        assertEquals(blocks.size(), _daoUtils.getNumDeltaBlocks(ByteBuffer.wrap(encodedDelta.getBytes())));
+
         List<TestRow> rows = Lists.newArrayList();
         UUID changeId = UUID.randomUUID();
         for (int i = 0; i < blocks.size(); i++) {
@@ -173,6 +179,7 @@ public class DeltaBlockingTest {
         UUID secondDeltaUUID = UUID.randomUUID();
 
         List<ByteBuffer> secondDeltaBlocks = _daoUtils.getDeltaBlocks(ByteBuffer.wrap("0000D3:[]:0:{..,\"name\":\"bobåååååຄຄຄຄຄຄຄຄຄຄ\"}".getBytes()));
+        assertEquals(secondDeltaBlocks.size(), _daoUtils.getNumDeltaBlocks(ByteBuffer.wrap("0000D3:[]:0:{..,\"name\":\"bobåååååຄຄຄຄຄຄຄຄຄຄ\"}".getBytes())));
 
         for (int i = 0; i < secondDeltaBlocks.size(); i++) {
             rows.add(new TestRow(i, secondDeltaUUID, secondDeltaBlocks.get(i)));

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -56,7 +56,7 @@ dataCenter:
 
 
 systemOfRecord:
-  migrationPhase: DOUBLE_WRITE_LEGACY_READ
+  migrationPhase: PRE_MIGRATION
   deltaBlockSizeInKb: 16
   cellTombstoneCompactionEnabled: true
   cellTombstoneBlockLimit: 2

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -56,7 +56,7 @@ dataCenter:
 
 
 systemOfRecord:
-  migrationPhase: PRE_MIGRATION
+  migrationPhase: DOUBLE_WRITE_LEGACY_READ
   deltaBlockSizeInKb: 16
   cellTombstoneCompactionEnabled: true
   cellTombstoneBlockLimit: 2

--- a/web-local/config-migrator.yaml
+++ b/web-local/config-migrator.yaml
@@ -40,7 +40,7 @@ dataCenter:
 
 systemOfRecord:
   migrationPhase: DOUBLE_WRITE_LEGACY_READ
-  deltaBlockSizeInKb: 8
+  deltaBlockSizeInKb: 16
   stashRoot: s3://emodb-us-east-1/stash/ci
 
   # How long should we retain historical deltas? To disable, use PT0S


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

In #222, we modified deletion strategy of Emo to use cell tombstones when deleting deltas from blocked tables. Testing of this is QA confirmed that this did indeed make reads faster. 

This PR addresses the fact that #222 only works when Emo is reading from the blocked table. It previously only worked for the blocked table because it is difficult to determine how many blocks a delta is comprised of before we are reading from the blocked table. 

This PR determines how a blocks a delta is by via a new function, `getNumBlocks()` in `DAOUtils.java`. This function is simply an optimized version of `getDeltaBlocks()`. It mimics writing a delta into blocks without actually creating the blocks. 

## How to Test and Verify

1. Check out this PR
2. Run Emo locally
3. Write to a multiblocked delta several times then force it to compact by reading after 5 minutes. 
4. Ensure that both delta tables deleted the delta correctly, and that the emo output of the document is as you expect. 

## Risk

### Level 

`Medium`

### Required Testing

`Regression` and `Manual`

### Risk Summary

The scope of this is small, but it could cause data corruption if there is an issue with it.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
