### PR TITLE
Revert "branch admin -prepare release emodb-5.7.16"

### DIFF
--- a/auth/auth-client/pom.xml
+++ b/auth/auth-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/auth/auth-core/pom.xml
+++ b/auth/auth-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/auth/auth-store/pom.xml
+++ b/auth/auth-store/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/auth/auth-test/pom.xml
+++ b/auth/auth-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/blob-api/pom.xml
+++ b/blob-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/blob-client-common/pom.xml
+++ b/blob-client-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/blob-client/pom.xml
+++ b/blob-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/blob/pom.xml
+++ b/blob/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/cachemgr/pom.xml
+++ b/cachemgr/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/api/pom.xml
+++ b/common/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/astyanax/pom.xml
+++ b/common/astyanax/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/client/pom.xml
+++ b/common/client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/dropwizard-client/pom.xml
+++ b/common/dropwizard-client/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/common/dropwizard/pom.xml
+++ b/common/dropwizard/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/json/pom.xml
+++ b/common/json/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/stash/pom.xml
+++ b/common/stash/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/uuid/pom.xml
+++ b/common/uuid/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/zookeeper/pom.xml
+++ b/common/zookeeper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/databus-api/pom.xml
+++ b/databus-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/databus-client-common/pom.xml
+++ b/databus-client-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/databus-client/pom.xml
+++ b/databus-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/databus/pom.xml
+++ b/databus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/datacenter/pom.xml
+++ b/datacenter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/job-api/pom.xml
+++ b/job-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/job/pom.xml
+++ b/job/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/mapreduce/pom.xml
+++ b/mapreduce/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/mapreduce/sor-hadoop/pom.xml
+++ b/mapreduce/sor-hadoop/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-mapreduce</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/mapreduce/sor-hive/pom.xml
+++ b/mapreduce/sor-hive/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-mapreduce</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.bazaarvoice.emodb</groupId>
     <artifactId>emodb-parent</artifactId>
-    <version>5.7.16</version>
+    <version>5.7.17-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>EmoDB Parent</name>
@@ -20,7 +20,7 @@
         <connection>scm:git:git@github.com:bazaarvoice/emodb.git</connection>
         <developerConnection>scm:git:git@github.com:bazaarvoice/emodb.git</developerConnection>
         <url>scm:git:git@github.com:bazaarvoice/emodb.git</url>
-      <tag>emodb-5.7.16</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <properties>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
 
@@ -18,7 +18,7 @@
         <connection>scm:git:git@github.com:bazaarvoice/emodb.git</connection>
         <developerConnection>scm:git:git@github.com:bazaarvoice/emodb.git</developerConnection>
         <url>scm:git:git@github.com:bazaarvoice/emodb.git</url>
-      <tag>emodb-5.7.16</tag>
+      <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/quality/integration/pom.xml
+++ b/quality/integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/quality/pom.xml
+++ b/quality/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/queue-api/pom.xml
+++ b/queue-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/queue-client-common/pom.xml
+++ b/queue-client-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/queue-client/pom.xml
+++ b/queue-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/shaded-clients/pom.xml
+++ b/shaded-clients/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/shaded-clients/shaded-clients-core/pom.xml
+++ b/shaded-clients/shaded-clients-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/shaded-clients/shaded-clients-dropwizard6/pom.xml
+++ b/shaded-clients/shaded-clients-dropwizard6/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/sor-api/pom.xml
+++ b/sor-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sor-client-common/pom.xml
+++ b/sor-client-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sor-client/pom.xml
+++ b/sor-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sor/pom.xml
+++ b/sor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/table/pom.xml
+++ b/table/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/uac-api/pom.xml
+++ b/uac-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/uac-client/pom.xml
+++ b/uac-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/web-local/pom.xml
+++ b/web-local/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/yum/pom.xml
+++ b/yum/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.16</version>
+        <version>5.7.17-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This reverts commit 3b2a6a68e8d18a03a992778ab369c146e76231ac.

## Github Issue #

N/A

## What Are We Doing Here?

For some reason, maven release process changed the versions from 5.7.17-SNAPSHOT to 5.7.16 again. This needs to be changed to "next development version"

## How to Test and Verify

N/A

## Risk

### Level 

`Low`

### Required Testing

`Smoke`