### PR TITLE
EMO-6930: Make MoveTableTask sensitive to delta migration

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/HistoryMigrationScanResult.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/HistoryMigrationScanResult.java
@@ -1,0 +1,17 @@
+package com.bazaarvoice.emodb.sor.db;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+public class HistoryMigrationScanResult extends MigrationScanResult {
+    private final int _ttl;
+
+    public HistoryMigrationScanResult(ByteBuffer rowKey, UUID changeId, ByteBuffer value, int ttl) {
+        super(rowKey, changeId, value);
+        _ttl = ttl;
+    }
+
+    public int getTtl() {
+        return _ttl;
+    }
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/AstyanaxBlockedDataReaderDAO.java
@@ -13,7 +13,9 @@ import com.bazaarvoice.emodb.sor.api.WriteConsistency;
 import com.bazaarvoice.emodb.sor.core.AbstractBatchReader;
 import com.bazaarvoice.emodb.sor.db.DAOUtils;
 import com.bazaarvoice.emodb.sor.db.DataReaderDAO;
+import com.bazaarvoice.emodb.sor.db.HistoryMigrationScanResult;
 import com.bazaarvoice.emodb.sor.db.Key;
+import com.bazaarvoice.emodb.sor.db.MigrationScanResult;
 import com.bazaarvoice.emodb.sor.db.MultiTableScanOptions;
 import com.bazaarvoice.emodb.sor.db.MultiTableScanResult;
 import com.bazaarvoice.emodb.sor.db.Record;
@@ -106,7 +108,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Cassandra implementation of {@link DataReaderDAO} that uses the Netflix Astyanax client library.
  */
-public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO, AstyanaxKeyScanner {
+public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyReaderDAO, AstyanaxKeyScanner {
 
     private final Logger _log = LoggerFactory.getLogger(AstyanaxDataReaderDAO.class);
 
@@ -728,91 +730,54 @@ public class AstyanaxBlockedDataReaderDAO implements DataReaderDAO, DataCopyDAO,
 
     }
 
-    // DataCopyDAO
     @Override
-    public void copy(AstyanaxStorage source, AstyanaxStorage dest, Runnable progress) {
-        checkNotNull(source, "source");
-        checkNotNull(dest, "dest");
-
+    public Iterator<? extends MigrationScanResult> getDeltasForStorage(AstyanaxStorage source) {
         DeltaPlacement sourcePlacement = (DeltaPlacement) source.getPlacement();
-        DeltaPlacement destPlacement = (DeltaPlacement) dest.getPlacement();
+        ColumnFamily<ByteBuffer, DeltaKey> sourceCf = sourcePlacement.getBlockedDeltaColumnFamily();
 
-        // Loop over the source splits.
         Iterator<ByteBufferRange> scanIter = source.scanIterator(null);
-        while (scanIter.hasNext()) {
-            ByteBufferRange keyRange = scanIter.next();
-            // Copy delta records in this split.
-            copyRange(sourcePlacement, sourcePlacement.getBlockedDeltaColumnFamily(),
-                    dest, destPlacement, destPlacement.getBlockedDeltaColumnFamily(),
-                    _deltaKeyInc, keyRange, progress);
-            // Copy delta history records in this split.
-            copyRange(sourcePlacement, sourcePlacement.getDeltaHistoryColumnFamily(),
-                    dest, destPlacement, destPlacement.getDeltaHistoryColumnFamily(),
-                    _uuidInc, keyRange, progress);
-        }
-    }
 
-    private <C> void copyRange(DeltaPlacement sourcePlacement, ColumnFamily<ByteBuffer, C> sourceCf,
-                               AstyanaxStorage dest, DeltaPlacement destPlacement, ColumnFamily<ByteBuffer, C> destCf, ColumnInc<C> columnInc,
-                               ByteBufferRange keyRange, Runnable progress) {
-        ConsistencyLevel writeConsistency = SorConsistencies.toAstyanax(WriteConsistency.STRONG);
+        return Iterators.concat(Iterators.transform(scanIter, keyRange -> {
+            Iterator<Row<ByteBuffer, DeltaKey>> rows =
+                    rowScan(sourcePlacement, sourceCf, keyRange, _maxColumnsRange, LimitCounter.max(), ReadConsistency.STRONG);
 
-        Iterator<List<Row<ByteBuffer, C>>> rowsIter = Iterators.partition(
-                rowScan(sourcePlacement, sourceCf, keyRange, _maxColumnsRange, LimitCounter.max(), ReadConsistency.STRONG),
-                MAX_SCAN_ROWS_BATCH);
-        int largeRowThreshold = _maxColumnsRange.getLimit();
-
-        while (rowsIter.hasNext()) {
-            List<Row<ByteBuffer, C>> rows = rowsIter.next();
-
-            MutationBatch mutation = destPlacement.getKeyspace().prepareMutationBatch(writeConsistency);
-            for (Row<ByteBuffer, C> row : rows) {
-                ColumnList<C> columns = row.getColumns();
-
-                // Map the source row key to the destination row key.  Its table uuid and shard key will be different.
-                ByteBuffer newRowKey = dest.getRowKey(AstyanaxStorage.getContentKey(row.getRawKey()));
-
-                // Copy the first N columns to the multi-row mutation.
-                putAll(mutation.withRow(destCf, newRowKey), columns);
-
-                // If this is a wide row, copy the remaining columns w/separate mutation objects.
-                if (columns.size() >= largeRowThreshold) {
-                    C lastColumn = columns.getColumnByIndex(columns.size() - 1).getName();
-                    Iterator<List<Column<C>>> columnsIter = Iterators.partition(
-                            columnScan(row.getRawKey(), sourcePlacement, sourceCf, lastColumn, null,
-                                    false, columnInc, Long.MAX_VALUE, 1, ReadConsistency.STRONG),
-                            MAX_COLUMN_SCAN_BATCH);
-                    while (columnsIter.hasNext()) {
-                        List<Column<C>> moreColumns = columnsIter.next();
-
-                        MutationBatch wideRowMutation = destPlacement.getKeyspace().prepareMutationBatch(writeConsistency);
-                        putAll(wideRowMutation.withRow(destCf, newRowKey), moreColumns);
-                        progress.run();
-                        execute(wideRowMutation,
-                                "copy key range %s to %s from placement %s, column family %s to placement %s, column family %s",
-                                keyRange.getStart(), keyRange.getEnd(), sourcePlacement.getName(), sourceCf.getName(),
-                                destPlacement.getName(), destCf.getName());
-                    }
+            return Iterators.concat(Iterators.transform(rows, row -> {
+                ColumnList<DeltaKey> columns = row.getColumns();
+                Iterator<Column<DeltaKey>> concatColumns = columns.iterator();
+                if (columns.size() >= _maxColumnsRange.getLimit()) {
+                    DeltaKey lastColumn = row.getColumns().getColumnByIndex(columns.size() - 1).getName();
+                    concatColumns = Iterators.concat(concatColumns, columnScan(row.getRawKey(), sourcePlacement, sourceCf, lastColumn, null,
+                            false, _deltaKeyInc, Long.MAX_VALUE, 1, ReadConsistency.STRONG));
                 }
-            }
-            progress.run();
-            execute(mutation,
-                    "copy key range %s to %s from placement %s, column family %s to placement %s, column family %s",
-                    keyRange.getStart(), keyRange.getEnd(), sourcePlacement.getName(), sourceCf.getName(),
-                    destPlacement.getName(), destCf.getName());
 
-            _copyMeter.mark(rows.size());
-        }
+                Iterator<StitchedColumn> uuidColumns = new AstyanaxDeltaIterator(concatColumns, false, _deltaPrefixLength, ByteBufferUtil.bytesToHex(row.getRawKey()));
+
+                return Iterators.transform(uuidColumns, column -> new MigrationScanResult(row.getRawKey(), column.getName(), _daoUtils.skipPrefix(column.getByteBufferValue())));
+            }));
+        }));
     }
 
-    /**
-     * Copies columns exactly, preserving Cassandra timestamp and ttl values.
-     */
-    private <C> void putAll(ColumnListMutation<C> mutation, Iterable<Column<C>> columns) {
-        for (Column<C> column : columns) {
-            mutation.setTimestamp(column.getTimestamp())
-                    .putColumn(column.getName(), column.getByteBufferValue(), column.getTtl());
-        }
+    @Override
+    public Iterator<? extends HistoryMigrationScanResult> getHistoriesForStorage(AstyanaxStorage source) {
+
+        DeltaPlacement placement = (DeltaPlacement) source.getPlacement();
+        ColumnFamily<ByteBuffer, UUID> cf = placement.getDeltaHistoryColumnFamily();
+
+        return Iterators.concat(Iterators.transform(source.scanIterator(null), keyRange -> {
+            Iterator<Row<ByteBuffer, UUID>> rows =
+                    rowScan(placement, cf, keyRange, _maxColumnsRange, LimitCounter.max(), ReadConsistency.STRONG);
+
+            return Iterators.concat(Iterators.transform(rows, row -> {
+                ColumnList<UUID> columns = row.getColumns();
+                Iterator<Column<UUID>> concatColumns = columns.iterator();
+                if (columns.size() >= _maxColumnsRange.getLimit()) {
+                    UUID lastColumn = row.getColumns().getColumnByIndex(columns.size() - 1).getName();
+                    concatColumns = Iterators.concat(concatColumns, columnScan(row.getRawKey(), placement, cf, lastColumn, null,
+                            false, _uuidInc, Long.MAX_VALUE, 1, ReadConsistency.STRONG));
+                }
+                return Iterators.transform(concatColumns, column -> new HistoryMigrationScanResult(row.getRawKey(), column.getName(), column.getByteBufferValue(), column.getTtl()));
+            }));
+        }));
     }
 
     /**

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DAOModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DAOModule.java
@@ -30,6 +30,8 @@ public class DAOModule extends PrivateModule {
         bind(DataWriterDAO.class).annotatedWith(AstyanaxWriterDAODelegate.class).to(CqlDataWriterDAO.class).asEagerSingleton();
         bind(DataWriterDAO.class).to(CqlDataWriterDAO.class).asEagerSingleton();
         bind(DataPurgeDAO.class).to(AstyanaxDataWriterDAO.class).asEagerSingleton();
+        bind(DataCopyDAO.class).to(DefaultDataCopyDAO.class).asEagerSingleton();
+        bind(DataCopyWriterDAO.class).to(CqlDataWriterDAO.class).asEagerSingleton();
         bind(MigratorWriterDAO.class).to(CqlDataWriterDAO.class).asEagerSingleton();
         bind(MigratorReaderDAO.class).to(CqlDataReaderDAO.class).asEagerSingleton();
 
@@ -37,6 +39,7 @@ public class DAOModule extends PrivateModule {
         // This needs to be done for just about anything that has only public dependencies.
         bind(AstyanaxDataWriterDAO.class).asEagerSingleton();
         bind(CqlDataWriterDAO.class).asEagerSingleton();
+        bind(DefaultDataCopyDAO.class);
 
         // For migration stages, will be reverted in future version
         bind(AstyanaxDataReaderDAO.class).asEagerSingleton();
@@ -91,7 +94,7 @@ public class DAOModule extends PrivateModule {
 
     @Provides
     @Singleton
-    DataCopyDAO provideDataCopyDAO(DataStoreConfiguration configuration, Provider<AstyanaxDataReaderDAO> legacyReader,
+    DataCopyReaderDAO provideDataCopyReaderDAO(DataStoreConfiguration configuration, Provider<AstyanaxDataReaderDAO> legacyReader,
                                    Provider<AstyanaxBlockedDataReaderDAO> blockedReader) {
 
         return configuration.getMigrationPhase().isReadFromLegacyDeltaTables() ? legacyReader.get() : blockedReader.get();

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DAOModule.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DAOModule.java
@@ -39,7 +39,7 @@ public class DAOModule extends PrivateModule {
         // This needs to be done for just about anything that has only public dependencies.
         bind(AstyanaxDataWriterDAO.class).asEagerSingleton();
         bind(CqlDataWriterDAO.class).asEagerSingleton();
-        bind(DefaultDataCopyDAO.class);
+        bind(DefaultDataCopyDAO.class).asEagerSingleton();
 
         // For migration stages, will be reverted in future version
         bind(AstyanaxDataReaderDAO.class).asEagerSingleton();

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DataCopyReaderDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DataCopyReaderDAO.java
@@ -1,0 +1,13 @@
+package com.bazaarvoice.emodb.sor.db.astyanax;
+
+import com.bazaarvoice.emodb.sor.db.HistoryMigrationScanResult;
+import com.bazaarvoice.emodb.sor.db.MigrationScanResult;
+import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxStorage;
+import java.util.Iterator;
+
+interface DataCopyReaderDAO {
+
+    Iterator<? extends MigrationScanResult> getDeltasForStorage(AstyanaxStorage source);
+
+    Iterator<? extends HistoryMigrationScanResult> getHistoriesForStorage(AstyanaxStorage source);
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DataCopyWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DataCopyWriterDAO.java
@@ -1,0 +1,12 @@
+package com.bazaarvoice.emodb.sor.db.astyanax;
+
+import com.bazaarvoice.emodb.sor.db.HistoryMigrationScanResult;
+import com.bazaarvoice.emodb.sor.db.MigrationScanResult;
+import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxStorage;
+import java.util.Iterator;
+
+interface DataCopyWriterDAO {
+    void copyDeltasToDestination(Iterator<? extends MigrationScanResult> rows, AstyanaxStorage dest, Runnable progress);
+
+    void copyHistoriesToDestination(Iterator<? extends HistoryMigrationScanResult> rows, AstyanaxStorage dest, Runnable progress);
+}

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DefaultDataCopyDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/DefaultDataCopyDAO.java
@@ -1,0 +1,28 @@
+package com.bazaarvoice.emodb.sor.db.astyanax;
+
+import com.bazaarvoice.emodb.table.db.astyanax.AstyanaxStorage;
+import com.bazaarvoice.emodb.table.db.astyanax.DataCopyDAO;
+import com.google.inject.Inject;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DefaultDataCopyDAO implements DataCopyDAO {
+
+    private final DataCopyWriterDAO _dataCopyWriterDAO;
+    private final DataCopyReaderDAO _dataCopyReaderDAO;
+
+    @Inject
+    public DefaultDataCopyDAO(DataCopyWriterDAO dataCopyWriterDAO, DataCopyReaderDAO dataCopyReaderDAO) {
+        _dataCopyWriterDAO = checkNotNull(dataCopyWriterDAO);
+        _dataCopyReaderDAO = checkNotNull(dataCopyReaderDAO);
+    }
+
+    @Override
+    public void copy(AstyanaxStorage source, AstyanaxStorage dest, Runnable progress) {
+        checkNotNull(source, "source");
+        checkNotNull(dest, "dest");
+
+        _dataCopyWriterDAO.copyDeltasToDestination(_dataCopyReaderDAO.getDeltasForStorage(source), dest, progress);
+        _dataCopyWriterDAO.copyHistoriesToDestination(_dataCopyReaderDAO.getHistoriesForStorage(source), dest, progress);
+    }
+}

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
@@ -381,7 +381,15 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
                         // Wait until writes in-flight at the time of mirror activation have replicated so copy doesn't miss anything.
                         checkPlacementConsistent(storage.getPrimary().getPlacement(), transitionedAt);
 
-                        copyData(json, storage.getPrimary(), storage, progress);
+                        _log.info("Attempting to copy data now!");
+
+                        try {
+
+                            copyData(json, storage.getPrimary(), storage, progress);
+                        } catch (Exception e) {
+                            _log.error("Error occurred during copy", e);
+                            throw e;
+                        }
 
                         // The next step occurs in the same data center so no need to write/flush globally.
                         stateTransition(json, storage, from, MIRROR_COPIED, InvalidationScope.DATA_CENTER);

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
@@ -381,15 +381,7 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
                         // Wait until writes in-flight at the time of mirror activation have replicated so copy doesn't miss anything.
                         checkPlacementConsistent(storage.getPrimary().getPlacement(), transitionedAt);
 
-                        _log.info("Attempting to copy data now!");
-
-                        try {
-
-                            copyData(json, storage.getPrimary(), storage, progress);
-                        } catch (Exception e) {
-                            _log.error("Error occurred during copy", e);
-                            throw e;
-                        }
+                        copyData(json, storage.getPrimary(), storage, progress);
 
                         // The next step occurs in the same data center so no need to write/flush globally.
                         stateTransition(json, storage, from, MIRROR_COPIED, InvalidationScope.DATA_CENTER);

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -56,7 +56,7 @@ dataCenter:
 
 
 systemOfRecord:
-  migrationPhase: PRE_MIGRATION
+  migrationPhase: DOUBLE_WRITE_BLOCKED_READ
   deltaBlockSizeInKb: 16
   cellTombstoneCompactionEnabled: true
   cellTombstoneBlockLimit: 2

--- a/web-local/config-local.yaml
+++ b/web-local/config-local.yaml
@@ -56,7 +56,7 @@ dataCenter:
 
 
 systemOfRecord:
-  migrationPhase: DOUBLE_WRITE_BLOCKED_READ
+  migrationPhase: DOUBLE_WRITE_LEGACY_READ
   deltaBlockSizeInKb: 16
   cellTombstoneCompactionEnabled: true
   cellTombstoneBlockLimit: 2


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

The `MoveTableTask` does not currently respect delta migration's double writing feature. Because all of its Cassandra level functionality happened in the `ReaderDAO`, we it currently only copies deltas to the delta table that it is currently set to read from.

This PR splits the reading and writing functionality of `DataCopyDAO`, and which allows deltas to be double-written if necessary. 

## How to Test and Verify

Testing this is genuinely and I sincerely apologize to whoever ends up reviewing this. 

For EACH `migrationPhase`, you must boot emo, write data, then run the MoveTableTask. After it completes it's copy you must make sure that the data made it correctly to the destination placement and the tables it should've corresponding with the migration phase. 

I recommend artificially lowering FCL as well as `MIN_CONSISTENCY_DELAY` in `AstyanaxTableDAO` in order to make the move faster.

## Risk

### Level 

`Medium`

### Required Testing

`Manual`

### Risk Summary

The scope of this is relatively small, but a bug in this could cause data loss during table moves.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
