### PR TITLE
EMO-6933: Remove accidental ByteBuffer side effects

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/DeltaIterator.java
@@ -201,7 +201,7 @@ abstract public class DeltaIterator<R, T> extends AbstractIterator<T> {
     private ByteBuffer stitchContent(int contentSize) {
         ByteBuffer content = ByteBuffer.allocate(contentSize);
         for (R delta : _list) {
-            content.put(getValue(delta));
+            content.put(getValue(delta).duplicate());
         }
         content.position(0);
         _list.clear();

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/db/astyanax/CqlDataWriterDAO.java
@@ -321,7 +321,7 @@ public class CqlDataWriterDAO implements DataWriterDAO, MigratorWriterDAO {
             int deltaSize = delta.remaining();
             ByteBuffer encodedDelta = ByteBuffer.allocate(deltaSize + _deltaPrefixLength);
             encodedDelta.put(_deltaPrefixBytes);
-            encodedDelta.put(delta);
+            encodedDelta.put(delta.duplicate());
             encodedDelta.position(0);
 
             _migratorMeter.mark();


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Discovered this issue while working on #230 . It turns out that `ByteBuffer.put(ByteBuffer input)` actually consumers the ByteBuffer that it is inserting. In the particular cases fixed in this PR, this is ok because the ByteBuffer consumed are not used anywhere else. However, it is best to fix preemptively, as it is possible in the future that some new code will try to reuse that ByteBuffer and get incorrect data because of these side effects. 

## How to Test and Verify

There is no functionality changes here, so just make sure that Emo is running the same as it was before. 
## Risk

### Level 

`Low`

### Required Testing

`Smoke`

### Risk Summary

The risk is low here. The only risk i can see is that calls to `duplicate()` have some side effect that I don't know about.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
