### PR TITLE
EMO-6905: Ensure databus replay's are performed at LOCAL_QUORUM

### DIFF
--- a/event/src/main/java/com/bazaarvoice/emodb/event/core/DefaultEventStore.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/core/DefaultEventStore.java
@@ -156,7 +156,7 @@ public class DefaultEventStore implements EventStore {
         checkLimit(limit, Limits.MAX_PEEK_LIMIT);
 
         DaoEventSink daoSink = new DaoEventSink(Integer.MAX_VALUE, sink);
-        _readerDao.readAll(channel, daoSink, null);
+        _readerDao.readAll(channel, daoSink, null, true);
 
         if (isDebugLoggingEnabled(channel)) {
             _log.debug("peek {} limit={} -> #={} more={}", channel, limit, daoSink.getCount(), daoSink.hasMore());
@@ -366,7 +366,7 @@ public class DefaultEventStore implements EventStore {
                 return true;
             }
         };
-        _readerDao.readAll(channel, eventSink, since);
+        _readerDao.readAll(channel, eventSink, since, false);
         if (!events.isEmpty()) {
             sink.accept(events);
         }
@@ -430,7 +430,7 @@ public class DefaultEventStore implements EventStore {
                 }
                 return true;
             }
-        }, null);
+        }, null, false);
         if (!eventsToCopy.isEmpty()) {
             addAndDelete(toChannel, eventsToCopy, fromChannel, eventsToDelete);
         }

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/EventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/EventReaderDAO.java
@@ -16,7 +16,7 @@ public interface EventReaderDAO {
      * If 'since' is non-null, then most of the events before 'since' time will be skipped.
      * Some prior to 'since' time (at most 999) may still get through, but all events on or after since are guaranteed.
      * */
-    void readAll(String channel, EventSink sink, @Nullable Date since);
+    void readAll(String channel, EventSink sink, @Nullable Date since, boolean weak);
 
     /**
      * Read events for the channel and pass then to the sink until the sink returns false.  If called repeatedly

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -238,8 +238,8 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
 
     @ParameterizedTimed(type = "AstyanaxEventReaderDAO")
     @Override
-    public void readAll(String channel, EventSink sink, Date since) {
-        readAll(channel, since != null ? getSlabFilterSince(since, channel) : null, sink, true);
+    public void readAll(String channel, EventSink sink, Date since, boolean weak) {
+        readAll(channel, since != null ? getSlabFilterSince(since, channel) : null, sink, weak);
     }
 
     void readAll(String channel, SlabFilter filter, EventSink sink, boolean weak) {

--- a/event/src/test/java/com/bazaarvoice/emodb/event/core/DedupQueueTest.java
+++ b/event/src/test/java/com/bazaarvoice/emodb/event/core/DedupQueueTest.java
@@ -64,7 +64,7 @@ public class DedupQueueTest {
 
         // The first peek checks the read channel, find it empty, checks the write channel.
         q.peek(new SimpleEventSink(10));
-        verify(readerDao).readAll(eq("read"), Matchers.<EventSink>any(), (Date) Matchers.isNull());
+        verify(readerDao).readAll(eq("read"), Matchers.<EventSink>any(), (Date) Matchers.isNull(), Matchers.eq(true));
         verify(readerDao).readNewer(eq("write"), Matchers.<EventSink>any());
         verifyNoMoreInteractions(readerDao);
 
@@ -72,7 +72,7 @@ public class DedupQueueTest {
 
         // Subsequent peeks w/in a short window still peek the read channel, skip polling the write channel.
         q.peek(new SimpleEventSink(10));
-        verify(readerDao).readAll(eq("read"), Matchers.<EventSink>any(), (Date) Matchers.isNull());
+        verify(readerDao).readAll(eq("read"), Matchers.<EventSink>any(), (Date) Matchers.isNull(), Matchers.eq(true));
         verifyNoMoreInteractions(readerDao);
     }
 


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Databus replays currently rely on queue `copy` functionality, which relies on `scan`, which relies on `readAll()` in the `AstynaxEventReaderDAO`. By default, `readAll` reads at `LOCAL_ONE`, as its primary use is calls from `peek()`.

In this PR, I have modified `readAll` the have an option to read strongly at `LOCAL_QUORUM`, and make sure replay uses that option.

## How to Test and Verify

This is difficult to test, as the output of a `LOCAL_ONE` query is rarely different than the output of a `LOCAL_QUORUM` query. Other than code review, the only way to test this may be by turning on verbose logging in Cassandra.

## Risk

### Level 

`Low`

### Required Testing

`Smoke`

### Risk Summary

The code here is pretty straightforward. The only risk that I see here is that replay's at `LOCAL_QUORUM` put additional load on Cassandra.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
