### PR TITLE
EMO-6913, EMO-6939 - Added pushing events to master queue for all the…

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -205,7 +205,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
             masterFanoutChannels.add(ChannelNames.getMasterFanoutChannel(partition));
         }
         _masterFanoutChannels = masterFanoutChannels.build();
-        
+
         checkNotNull(jobHandlerRegistry, "jobHandlerRegistry");
         registerMoveSubscriptionJobHandler(jobHandlerRegistry);
         registerReplaySubscriptionJobHandler(jobHandlerRegistry);
@@ -398,7 +398,7 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
         }
         _eventStore.addAll(eventIds.build());
     }
-    
+
     @Override
     public long getEventCount(String ownerId, String subscription) {
         return getEventCountUpTo(ownerId, subscription, Long.MAX_VALUE);
@@ -952,6 +952,73 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
 
         _eventStore.purge(subscription);
     }
+
+//    @Override
+//    public Map<Coordinate, List<UUID>> pollWithNoResolve(String ownerId, final String subscription, final Duration claimTtl, int limit) {
+//        checkLegalSubscriptionName(subscription);
+//        checkArgument(claimTtl.compareTo(Duration.ZERO) >= 0, "ClaimTtl must be >=0");
+//        checkArgument(limit > 0, "Limit must be >0");
+//        checkSubscriptionOwner(ownerId, subscription);
+//
+//        Map<Coordinate, EventList> rawEvents = Maps.newHashMap();
+//        int remaining = limit;
+//        boolean eventsAvailableForNextPoll = false;
+//        boolean repeatable = claimTtl.toMillis() > 0;
+//        boolean noMaxPollTimeOut = true;
+//
+//        Stopwatch stopwatch = Stopwatch.createStarted(_ticker);
+//        int padding = 0;
+//        do {
+//            if (remaining == 0) {
+//                break;  // Don't need any more events.
+//            }
+//
+//            // Query the databus event store.  Consolidate multiple events that refer to the same item.
+//            ConsolidatingEventSink sink = new ConsolidatingEventSink(remaining + padding);
+//            boolean more = _eventStore.poll(subscription, claimTtl, sink);
+//            rawEvents.putAll(sink.getEvents());
+//
+//            if (rawEvents.isEmpty()) {
+//                // No events to be had.
+//                eventsAvailableForNextPoll = more;
+//                break;
+//            }
+//
+//            if (!more) {
+//                // There are no more events to be had, so exit now
+//                break;
+//            }
+//
+//            // ideally we should get the raw events to the limit.
+//            remaining = limit - rawEvents.size();
+//
+//            // Note: Due to redundant/unknown events, it's possible that the 'events' list is empty even though, if we
+//            // tried again, we'd find more events.  Try again a few times, but not for more than MAX_POLL_TIME so clients
+//            // don't timeout the request.  This helps move through large amounts of redundant deltas relatively quickly
+//            // while also putting a bound on the total amount of work done by a single call to poll().
+//            padding = 10;
+//        } while (repeatable && (noMaxPollTimeOut = stopwatch.elapsed(TimeUnit.MILLISECONDS) < MAX_POLL_TIME.toMillis()));
+//
+//
+//        Map<Coordinate, List<UUID>> eventResultMap = Maps.newHashMap();
+////        List<String> events = Lists.newArrayList();
+//        for (Map.Entry<Coordinate, EventList> rawEventsEntry : rawEvents.entrySet())  {
+//            Coordinate coordinate = rawEventsEntry.getKey();
+//            List<Pair<String, UUID>> eventAndChangeIds = rawEventsEntry.getValue().getEventAndChangeIds();
+////            events = eventAndChangeIds.stream().map(e -> e.first()).collect(Collectors.toList());
+//            List<UUID> changeIds = eventAndChangeIds.stream().map(e -> e.second()).collect(Collectors.toList());
+//            eventResultMap.put(coordinate, changeIds);
+//        }
+//
+//        return eventResultMap;
+//
+////
+////
+////
+////
+////       return new PollResult(events, events.size(), eventsAvailableForNextPoll);
+//
+//    }
 
     private void checkLegalSubscriptionName(String subscription) {
         checkArgument(Names.isLegalSubscriptionName(subscription),

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
@@ -12,7 +12,6 @@ import com.bazaarvoice.emodb.sor.core.UpdateRef;
 import com.bazaarvoice.emodb.table.db.Table;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Maps;
-import com.bazaarvoice.emodb.table.db.TableFilterIntrinsics;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/UpdateRefSerializer.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/UpdateRefSerializer.java
@@ -5,12 +5,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.netflix.astyanax.Serializer;
 import com.netflix.astyanax.model.Composite;
+import com.netflix.astyanax.serializers.BooleanSerializer;
+import com.netflix.astyanax.serializers.DateSerializer;
+import com.netflix.astyanax.serializers.LongSerializer;
 import com.netflix.astyanax.serializers.SetSerializer;
 import com.netflix.astyanax.serializers.StringSerializer;
 import com.netflix.astyanax.serializers.TimeUUIDSerializer;
 import org.apache.cassandra.db.marshal.UTF8Type;
 
 import java.nio.ByteBuffer;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -21,17 +25,29 @@ public class UpdateRefSerializer {
     private static final List<Serializer<?>> _serializers = ImmutableList.<Serializer<?>>of(
             StringSerializer.get(),
             StringSerializer.get(),
-            TimeUUIDSerializer.get());
+            TimeUUIDSerializer.get(),
+            BooleanSerializer.get(),
+            LongSerializer.get(),
+            DateSerializer.get()
+            // TODO: CHECK IF WE NEED THIS MANUAL SERIALIZATION NECESSARY?? why not JSON default one??? FOR LATER!!!!!!
+            );
     private static final List<String> _comparators = ImmutableList.of(
             StringSerializer.get().getComparatorType().getTypeName(),
             StringSerializer.get().getComparatorType().getTypeName(),
-            TimeUUIDSerializer.get().getComparatorType().getTypeName());
+            TimeUUIDSerializer.get().getComparatorType().getTypeName(),
+            BooleanSerializer.get().getComparatorType().getTypeName(),
+            LongSerializer.get().getComparatorType().getTypeName(),
+            DateSerializer.get().getComparatorType().getTypeName()
+            );
 
     public static ByteBuffer toByteBuffer(UpdateRef ref) {
         Composite composite = newComposite();
         composite.add(ref.getTable());
         composite.add(ref.getKey());
         composite.add(ref.getChangeId());
+        composite.add(ref.getIsDroppedUpdate());
+        composite.add(ref.getVersion());
+        composite.add(ref.getLastMutateAt());
         if (!ref.getTags().isEmpty()) {
             composite.add(_setSerializer.toByteBuffer(ref.getTags()).array());
         }
@@ -45,11 +61,14 @@ public class UpdateRefSerializer {
         String table = (String) composite.get(0);
         String key = (String) composite.get(1);
         UUID changeId = (UUID) composite.get(2);
+        Boolean isDroppedUpdate = (Boolean) composite.get(3);
+        Long version = (Long) composite.get(4);
+        Date lastUpdateAt = (Date) composite.get(5);
         Set<String> tags = ImmutableSet.of();
-        if (composite.size() == 4) {
-            tags = _setSerializer.fromByteBuffer((ByteBuffer) composite.get(3));
+        if (composite.size() == 7) {
+            tags = _setSerializer.fromByteBuffer((ByteBuffer) composite.get(6));
         }
-        return new UpdateRef(table, key, changeId, tags);
+        return new UpdateRef(table, key, changeId, tags, isDroppedUpdate, version, lastUpdateAt);
     }
 
     private static Composite newComposite() {

--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/UpdateRef.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/UpdateRef.java
@@ -1,10 +1,8 @@
 package com.bazaarvoice.emodb.sor.core;
 
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
-import com.google.common.collect.Sets;
 
-import javax.annotation.Nullable;
+import java.util.Date;
 import java.util.Set;
 import java.util.UUID;
 
@@ -19,12 +17,31 @@ public final class UpdateRef {
     private final String _key;
     private final UUID _changeId;
     private final Set<String> _tags;
+    private final Boolean _isDroppedUpdate;
+    private final Long _version;
+    private final Date _lastMutateAt;
+   // TODO: We may need all the intrinsics - to populate the fake delta in POLL. that's for later.
 
     public UpdateRef(String table, String key, UUID changeId, Set<String> tags) {
         _table = checkNotNull(table, "table");
         _key = checkNotNull(key, "key");
         _changeId = checkNotNull(changeId, "changeId");
         _tags = checkNotNull(tags, "tags");
+        _isDroppedUpdate = Boolean.FALSE;
+        _version = null;
+        _lastMutateAt = null;
+    }
+
+    public UpdateRef(String table, String key, UUID changeId, Set<String> tags,
+                     Boolean isDroppedUpdate, Long version, Date lastMutateAt) {
+        _table = checkNotNull(table, "table");
+        _key = checkNotNull(key, "key");
+        _changeId = checkNotNull(changeId, "changeId");
+        _tags = checkNotNull(tags, "tags");
+        _isDroppedUpdate = checkNotNull(isDroppedUpdate, "isDroppedUpdate");
+        _version = checkNotNull(version, "version");
+        _lastMutateAt = checkNotNull(lastMutateAt, "lastMutateAt");
+        // TODO: ALL INTRINSICS
     }
 
     public String getTable() {
@@ -43,6 +60,18 @@ public final class UpdateRef {
         return _tags;
     }
 
+    public Boolean getIsDroppedUpdate() {
+        return _isDroppedUpdate;
+    }
+
+    public Long getVersion() {
+        return _version;
+    }
+
+    public Date getLastMutateAt() {
+        return _lastMutateAt;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -55,12 +84,15 @@ public final class UpdateRef {
         return Objects.equal(_table, that._table) &&
                 Objects.equal(_key, that._key) &&
                 Objects.equal(_changeId, that._changeId) &&
-                Objects.equal(_tags, that._tags);
+                Objects.equal(_tags, that._tags) &&
+                Objects.equal(_isDroppedUpdate, that._isDroppedUpdate) &&
+                Objects.equal(_version, that._version) &&
+                Objects.equal(_lastMutateAt, that._lastMutateAt);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(_table, _key, _changeId, _tags);
+        return Objects.hashCode(_table, _key, _changeId, _tags, _isDroppedUpdate, _version, _lastMutateAt);
     }
 
 }

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/TableDeleteOperations.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/TableDeleteOperations.java
@@ -1,0 +1,12 @@
+package com.bazaarvoice.emodb.table.db;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Internal interface that may be used for the specified delete operations usually on all the keys of a table.
+ */
+public interface TableDeleteOperations {
+    /* to send databus events for all the keys of the table with the given changeId and tags. */
+    void sendDeleteEventsForTable(String table, UUID changeId, Set<String> tags);
+}

--- a/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
+++ b/table/src/main/java/com/bazaarvoice/emodb/table/db/astyanax/AstyanaxTableDAO.java
@@ -40,6 +40,7 @@ import com.bazaarvoice.emodb.table.db.Table;
 import com.bazaarvoice.emodb.table.db.TableBackingStore;
 import com.bazaarvoice.emodb.table.db.TableChangesEnabled;
 import com.bazaarvoice.emodb.table.db.TableDAO;
+import com.bazaarvoice.emodb.table.db.TableDeleteOperations;
 import com.bazaarvoice.emodb.table.db.TableFilterIntrinsics;
 import com.bazaarvoice.emodb.table.db.TableSet;
 import com.bazaarvoice.emodb.table.db.generic.CachingTableDAORegistry;
@@ -98,12 +99,14 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -179,6 +182,7 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
     private final Map<String, String> _placementsUnderMove;
     private CQLStashTableDAO _stashTableDao;
     private final boolean _purgesBlocked;
+    private TableDeleteOperations _tableDeleteOperations;
     private Clock _clock;
 
     @Inject
@@ -245,6 +249,11 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
     @Inject (optional = true)
     public void setCQLStashTableDAO(CQLStashTableDAO stashTableDao) {
         _stashTableDao = stashTableDao;
+    }
+
+    @Inject
+    public void setTableDeleteOperations(TableDeleteOperations tableDeleteOperations) {
+        _tableDeleteOperations = tableDeleteOperations;
     }
 
     @Override
@@ -747,6 +756,10 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
         _log.info("Purging data for table '{}' and table uuid '{}' (facade={}, iteration={}).",
                 json.getTable(), storage.getUuidString(), storage.isFacade(), iteration);
 
+
+        // for other approach - CREATE AND FANOUT DATABUS EVENTS RIGHT HERE.
+
+
         // Cap the # of writes-per-second to avoid saturating the cluster.
         Runnable rateLimitedProgress = rateLimited(_placementCache.get(storage.getPlacement()), progress);
 
@@ -756,6 +769,13 @@ public class AstyanaxTableDAO implements TableDAO, MaintenanceDAO, StashTableDAO
                 .set("_placement", storage.getPlacement())
                 .build());
         _dataPurgeDAO.purge(newAstyanaxStorage(storage, json.getTable()), rateLimitedProgress);
+
+        // post databus delete events for all the keys of the dropped table.
+
+        // TODO: Decide on the changeId and Tags.
+        UUID changeId = TimeUUIDs.newUUID();
+        Set<String> tags = Collections.EMPTY_SET;
+        _tableDeleteOperations.sendDeleteEventsForTable(json.getTable(), changeId, tags);
     }
 
     /**


### PR DESCRIPTION
… keys of the table in the process of its purging.

## Github Issue #

* Just an initial version. 
* Completely scrapped the rewriting a special fanout approach; Nothing is checked in in regard to that in this PR, but saved some code locally (this is the big complex piece that took most of my time)  just in case I have to revert back to that approach. 
* With this current approach, the events are sent during the purging of the records directly to the master queue. The updateRef is modified to add in few/all intrinsics as well as a flag to verify if its the event from the deletion process. The current fanout process will not obstruct these events even though the table may be marked as dropped by that point. The Poller code will also check the special flag in UpdateRef to not resolve the document in the traditional way, instead throw in the  document for that event with the next version number and with ~deleted as true and also with the intrinsics.   
* Second commit coming in with the Tests, Poller changes, appropriate changeId setting and few TODOs mentioned which are being worked on.

## What Are We Doing Here?


## How to Test and Verify

* Testing is in progress, and new tests will be added in next commit, and detailed instructions will be posted here. 
* got to make sure no regression. 
* Events are sent for deleted tables in all cases.

## Risk
* Medium.

### Level 

* Medium

### Required Testing

`Smoke`, `Regression`, or `Manual`. (All changes except documentation need smoke
testing at a minimum).

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
