### PR TITLE
EMO-6981 upgrade aws sdk

### DIFF
--- a/common/json/pom.xml
+++ b/common/json/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
         </dependency>

--- a/common/stash/pom.xml
+++ b/common/stash/pom.xml
@@ -31,7 +31,7 @@
         <!-- 3rd-party dependencies -->
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/mapreduce/sor-hadoop/pom.xml
+++ b/mapreduce/sor-hadoop/pom.xml
@@ -46,7 +46,7 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -32,14 +32,14 @@
         <dropwizard.version>0.7.1</dropwizard.version>
         <guava.version>16.0.1</guava.version>
         <guice.version>4.0</guice.version>
-        <jackson.version>2.4.5</jackson.version>
+        <jackson.version>2.6.7.2</jackson.version>
         <metrics.version>3.0.2</metrics.version>
         <ostrich.version>1.9.2</ostrich.version>
         <rison.version>2.1.1</rison.version>
         <slf4j.version>1.7.4</slf4j.version>
         <commons-io.version>2.1</commons-io.version>
         <commons-compress.version>1.4.1</commons-compress.version>
-        <aws-sdk.version>1.10.1</aws-sdk.version>
+        <aws-sdk.version>1.11.551</aws-sdk.version>
         <jodatime-version>2.8.2</jodatime-version>
         <jersey.version>1.18.1</jersey.version>
         <jacoco.version>0.7.2.201409121644</jacoco.version>
@@ -202,7 +202,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.3.6</version>
+                <version>4.5.5</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -260,34 +260,11 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-guava</artifactId>
-                <version>${jackson.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -331,7 +308,27 @@
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
-                <artifactId>aws-java-sdk</artifactId>
+                <artifactId>aws-java-sdk-cloudwatch</artifactId>
+                <version>${aws-sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-s3</artifactId>
+                <version>${aws-sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-sns</artifactId>
+                <version>${aws-sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-sqs</artifactId>
+                <version>${aws-sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-sts</artifactId>
                 <version>${aws-sdk.version}</version>
             </dependency>
             <dependency>

--- a/sor-client-common/pom.xml
+++ b/sor-client-common/pom.xml
@@ -105,7 +105,7 @@
         <!-- 3rd-party dependencies -->
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
         <!-- Third party dependencies -->
         <dependency>

--- a/sor/pom.xml
+++ b/sor/pom.xml
@@ -76,13 +76,7 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -159,13 +159,19 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>aws-java-sdk-sns</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sqs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-cloudwatch</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>


### PR DESCRIPTION
[JIRA issue](https://bits.bazaarvoice.com/jira/browse/EMO-6981)

## What Are We Doing Here?

- upgrade aws-java-sdk (with transitinal dependencies of jackson and http client)
- use only aws services that's needed not whole sdk
- remove unused aws-java-sdk services

## How to Test and Verify

1. Check out this PR
2. Run `mvn clean verify`
3. Also make sure that emodb-gatekeeper is working against this changes, see https://github.com/bazaarvoice/emodb-gatekeeper/pull/67

## Risk
Medium

### Required Testing

`Manual`

### Risk Summary

Main risk are:
- broken JSON serialization/deserialization
- http client that works differently
- improper interaction with aws services

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
