### PR TITLE
EMO-6981 add missing ec2 dependency

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -313,6 +313,11 @@
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-ec2</artifactId>
+                <version>${aws-sdk.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-s3</artifactId>
                 <version>${aws-sdk.version}</version>
             </dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -173,6 +173,11 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-cloudwatch</artifactId>
         </dependency>
+        <!--   Needed by chameleon -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>


### PR DESCRIPTION
EMO-6981 add missing ec2 dependency

## What Are We Doing Here?

add missing aws sdk ec2 dependency which is used in runtime by chameleon

## How to Test and Verify

1. check out this PR
2. run `mvn clean verify`
3. release snapshot version, as example https://jenkins.nexus.bazaarvoice.com/job/emodb-dev/job/emodb/job/emodb-snapshot-release/62/console
4. deploy test cluster with snapshot version
5. verify that cluster is healthy and there are no errors in logs

## Risk
### Level 

`Medium`

### Required Testing

`Manual`

### Risk Summary

aws ec2 sdk is needed to fetch instance info(tags etc) to register in zookeeper

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
