### PR TITLE
EMO-7011 add datadog metrics for blob writes with TTL

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <astyanax.version>3.8.0-bv8</astyanax.version>
-        <dropwizard-metrics-datadog.version>1.1.1</dropwizard-metrics-datadog.version>
+        <dropwizard-metrics-datadog.version>1.1.13</dropwizard-metrics-datadog.version>
         <cassandra.version>2.2.4</cassandra.version>
         <curator.version>2.4.0</curator.version>
         <curator-extensions.version>1.4.1</curator-extensions.version>

--- a/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/blob/BlobStoreJerseyTest.java
@@ -36,6 +36,7 @@ import com.bazaarvoice.emodb.sor.api.UnknownTableException;
 import com.bazaarvoice.emodb.test.ResourceTest;
 import com.bazaarvoice.emodb.web.auth.EmoPermissionResolver;
 import com.bazaarvoice.emodb.web.resources.blob.BlobStoreResource1;
+import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -116,7 +117,7 @@ public class BlobStoreJerseyTest extends ResourceTest {
         createRole(roleManager, null, "blob-role-b", ImmutableSet.of("blob|read|b*"));
 
         return setupResourceTestRule(
-            Collections.<Object>singletonList(new BlobStoreResource1(_server, _approvedContentTypes)),
+            Collections.<Object>singletonList(new BlobStoreResource1(_server, _approvedContentTypes, new MetricRegistry())),
             authIdentityManager,
             permissionManager);
     }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoService.java
@@ -274,7 +274,7 @@ public class EmoService extends Application<EmoConfiguration> {
                 Key.get(new TypeLiteral<Set<String>>(){}, ApprovedBlobContentTypes.class));
         // Start the Blob service
         ResourceRegistry resources = _injector.getInstance(ResourceRegistry.class);
-        resources.addResource(_cluster, "emodb-blob-1", new BlobStoreResource1(blobStore, approvedContentTypes));
+        resources.addResource(_cluster, "emodb-blob-1", new BlobStoreResource1(blobStore, approvedContentTypes, _environment.metrics()));
     }
 
     private void evaluateDatabus()

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
@@ -88,12 +88,12 @@ public class BlobStoreResource1 {
 
     private final BlobStore _blobStore;
     private final Set<String> _approvedContentTypes;
-    private final Meter _blobWritesWithTtlByTableName;
+    private final Meter _blobWritesWithTtl;
 
     public BlobStoreResource1(BlobStore blobStore, Set<String> approvedContentTypes, MetricRegistry metricRegistry) {
         _blobStore = blobStore;
         _approvedContentTypes = approvedContentTypes;
-        _blobWritesWithTtlByTableName = metricRegistry.meter(MetricRegistry.name("bv.emodb.blob.BlobStore.blobWriteWithTTL"));
+        _blobWritesWithTtl = metricRegistry.meter(MetricRegistry.name("bv.emodb.blob.BlobStore.blobWriteWithTTL"));
     }
 
     @GET
@@ -417,7 +417,7 @@ public class BlobStoreResource1 {
         _blobStore.put(table, blobId, onceOnlySupplier(in), attributes, ttl);
         
         if (null != ttl) {
-            _blobWritesWithTtlByTableName.mark();
+            _blobWritesWithTtl.mark();
         }
 
         return SuccessResponse.instance();

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
@@ -19,8 +19,13 @@ import com.bazaarvoice.emodb.web.jersey.params.SecondsParam;
 import com.bazaarvoice.emodb.web.resources.SuccessResponse;
 import com.bazaarvoice.emodb.web.resources.sor.AuditParam;
 import com.bazaarvoice.emodb.web.resources.sor.TableOptionsParam;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.base.Strings;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.PeekingIterator;
@@ -35,6 +40,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.coursera.metrics.datadog.TaggedName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,10 +92,22 @@ public class BlobStoreResource1 {
 
     private final BlobStore _blobStore;
     private final Set<String> _approvedContentTypes;
+    private final LoadingCache<String, Meter> _blobWritesWithTtlByTableName;
 
-    public BlobStoreResource1(BlobStore blobStore, Set<String> approvedContentTypes) {
+    public BlobStoreResource1(BlobStore blobStore, Set<String> approvedContentTypes, MetricRegistry metricRegistry) {
         _blobStore = blobStore;
         _approvedContentTypes = approvedContentTypes;
+        _blobWritesWithTtlByTableName = CacheBuilder.newBuilder().build(new CacheLoader<String, Meter>() {
+            @Override
+            public Meter load(String key) throws Exception {
+                String metricName = new TaggedName.TaggedNameBuilder()
+                        .metricName("bv.emodb.blob.BlobStore.blobWriteWithTTL")
+                        .addTag("table", key)
+                        .build()
+                        .encode();
+                return metricRegistry.meter(MetricRegistry.name(metricName));
+            }
+        });
     }
 
     @GET
@@ -411,6 +429,7 @@ public class BlobStoreResource1 {
 
         // Perform the put
         _blobStore.put(table, blobId, onceOnlySupplier(in), attributes, ttl);
+        _blobWritesWithTtlByTableName.getUnchecked(table).mark();
 
         return SuccessResponse.instance();
     }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
@@ -429,7 +429,10 @@ public class BlobStoreResource1 {
 
         // Perform the put
         _blobStore.put(table, blobId, onceOnlySupplier(in), attributes, ttl);
-        _blobWritesWithTtlByTableName.getUnchecked(table).mark();
+        
+        if (null != ttl) {
+            _blobWritesWithTtlByTableName.getUnchecked(table).mark();
+        }
 
         return SuccessResponse.instance();
     }

--- a/web/src/test/java/com/bazaarvoice/emodb/web/config/DatadogMetricFilterTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/config/DatadogMetricFilterTest.java
@@ -11,7 +11,6 @@ import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.metrics.ReporterFactory;
-import org.coursera.metrics.datadog.model.DatadogCounter;
 import org.coursera.metrics.datadog.model.DatadogGauge;
 import org.coursera.metrics.datadog.transport.AbstractTransportFactory;
 import org.coursera.metrics.datadog.transport.Transport;
@@ -84,16 +83,16 @@ public class DatadogMetricFilterTest {
         reporter.report();
 
         // Verify only the desired metrics were sent
-        verify(_request).addCounter(argThat(hasCounter("test.counter", 10)));
-        verify(_request).addCounter(argThat(hasCounter("test.histogram.count", 3)));
+        verify(_request).addGauge(argThat(hasGauge("test.counter", 10)));
+        verify(_request).addGauge(argThat(hasGauge("test.histogram.count", 3)));
         verify(_request).addGauge(argThat(hasGauge("test.histogram.min", 1)));
         verify(_request).addGauge(argThat(hasGauge("test.histogram.max", 3)));
         verify(_request).addGauge(argThat(hasGauge("test.histogram.p95", 3.0)));
-        verify(_request).addCounter(argThat(hasCounter("test.timer.count", 3)));
+        verify(_request).addGauge(argThat(hasGauge("test.timer.count", 3)));
         verify(_request).addGauge(argThat(hasGauge("test.timer.min", 1000f)));
         verify(_request).addGauge(argThat(hasGauge("test.timer.max", 3000f)));
         verify(_request).addGauge(argThat(hasGauge("test.timer.p95", 3000f)));
-        verify(_request).addCounter(argThat(hasCounter("test.meter.count", 100)));
+        verify(_request).addGauge(argThat(hasGauge("test.meter.count", 100)));
         verify(_request).addGauge(argThat(hasGauge("test.gauge", 50)));
 
         // Send was called exactly once
@@ -127,7 +126,7 @@ public class DatadogMetricFilterTest {
         reporter.report();
 
         // Verify only the desired metrics were sent.  Notably min, max, and the nth percentiles should be absent.
-        verify(_request).addCounter(argThat(hasCounter("test.histogram.count", 3)));
+        verify(_request).addGauge(argThat(hasGauge("test.histogram.count", 3)));
         verify(_request).addGauge(argThat(hasGauge("test.histogram.mean", 2)));
         verify(_request).addGauge(argThat(hasGauge("test.histogram.median", 2)));
         verify(_request).addGauge(argThat(hasGauge("test.histogram.stddev", 1.0)));
@@ -160,22 +159,7 @@ public class DatadogMetricFilterTest {
         return datadogReporterFactory.build(_metricRegistry);
     }
 
-    private Matcher<DatadogCounter> hasCounter(final String metricName, final Number value) {
-        return new BaseMatcher<DatadogCounter>() {
-            @Override
-            public boolean matches(Object item) {
-                DatadogCounter counter = (DatadogCounter) item;
-                return metricName.equals(counter.getMetric()) && value.floatValue() == counter.getPoints().get(0).get(1).floatValue();
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description.appendText("metric ").appendText(metricName).appendText(" has value ").appendValue(value);
-            }
-        };
-    }
-
-    private Matcher<DatadogGauge> hasGauge(final String metricName, final Number value) {
+    private static Matcher<DatadogGauge> hasGauge(final String metricName, final Number value) {
         return new BaseMatcher<DatadogGauge>() {
             @Override
             public boolean matches(Object item) {


### PR DESCRIPTION
[EMO-7011](https://bits.bazaarvoice.com/jira/browse/EMO-7011)

## What Are We Doing Here?

- Upgrade datadog metrics library
- Add datadog metrics to determine usage of Blob writes with TTL.

## How to Test and Verify

1. Check out this PR
2. `mvn clean verify`
3. run gatekeeper jenkins job with this PR

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

- possibility of coursera datadog metrics library runtime issues
- possibility of returning non 200 HTTP status code in case of failed metric calculation

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
