### PR TITLE
EMO-7022 - Persisting the status synchronously before the sleep

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploader.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploader.java
@@ -247,8 +247,7 @@ public class ScanUploader {
         try {
             _scanStatusDAO.setCanceled(scanId);
         } catch (Exception e2) {
-            // Don't mask the original exception but log it
-
+            _log.error("Failed to set the status to cancelled. ScanId: {}", scanId, e2);
         }
     }
 


### PR DESCRIPTION
## Github Issue #

EMO-7022

## What Are We Doing Here?
Persisting the status synchronously before the sleep as that it can be picked up by Megabus. 

Tested the behavior locally. Started stash, verified that the status comes back quick, and starting the stash again "before 5 minutes" with same ID says stash exists which is what we wanted!!!!

```
curl -XPOST 'localhost:8780/stash/1/job/SUJITH-TEST-2019-06-18-00-00-00?dest=null&maxConcurrency=16&placement=ugc_global:ugc&placement=catalog_global:cat&APIKey=xxx' | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  132k    0  132k    0     0   492k      0 --:--:-- --:--:-- --:--:--  492k
{
  "scanId": "SUJITH-TEST-2019-06-18-00-00-00",
......

curl -s 'localhost:8780/stash/1/job/SUJITH-TEST-2019-06-18-00-00-00?dest=null&maxConcurrency=16&placement=ugc_global:ugc&placement=catalog_global:cat&APIKey=xxx' | jq .


curl -XPOST 'localhost:8780/stash/1/job/SUJITH-TEST-2019-06-18-00-00-00?dest=null&maxConcurrency=16&placement=ugc_global:ugc&placement=catalog_global:cat&APIKey=xxx' | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    49    0    49    0     0   2615      0 --:--:-- --:--:-- --:--:--  2722
{
  "scan_exists": "SUJITH-TEST-2019-06-18-00-00-00"
}

```

## How to Test and Verify
Make sure the Temporal stash starts and works as normal. 

## Risk
Minimal Risk. Only relates to Temporal Stash.

### Level 
LOW

### Required Testing
Manual.

