### PR TITLE
Send null to megabus for deleted documents

### DIFF
--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -122,7 +122,7 @@ public class MegabusRefResolver extends AbstractService {
         resolutionResults
                 // extract the resolved documents
                 .flatMap((key, value) -> value.getKeyedResolvedDocs())
-                //convert deleted documents to null
+                // convert deleted documents to null
                 .mapValues(doc -> !Intrinsic.isDeleted(doc) ? doc : null)
                 // send to megabus
                 .to(_megabusResolvedTopic.getName(), Produced.with(Serdes.String(), new JsonPOJOSerde<>(new TypeReference<Map<String, Object>>() {})));

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -111,9 +111,11 @@ public class MegabusRefResolver extends AbstractService {
 
         StreamsBuilder streamsBuilder = new StreamsBuilder();
 
+        // merge the ref stream with the ref-retry stream. They must be merged into a single stream for ordering purposes
         final KStream<String, List<MegabusRef>> refStream = streamsBuilder.stream(_megabusRefTopic.getName(), Consumed.with(Serdes.String(), new JsonPOJOSerde<>(new TypeReference<List<MegabusRef>>() {})))
                 .merge(streamsBuilder.stream(_retryRefTopic.getName(), Consumed.with(Serdes.String(), new JsonPOJOSerde<>(new TypeReference<List<MegabusRef>>() {}))));
 
+        // resolve refs into documents
         KStream<String, ResolutionResult> resolutionResults = refStream.mapValues(value -> resolveRefs(value.iterator()));
 
 

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -161,6 +161,7 @@ public class MegabusRefResolver extends AbstractService {
 
         public Iterable<KeyValue<String, Map<String, Object>>> getKeyedResolvedDocs() {
             return Lists.transform(_resolvedDocs, doc -> new KeyValue<>(Coordinate.fromJson(doc).toString(), doc));
+
         }
     }
 

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -6,10 +6,12 @@ import com.bazaarvoice.emodb.kafka.KafkaCluster;
 import com.bazaarvoice.emodb.kafka.Topic;
 import com.bazaarvoice.emodb.kafka.metrics.DropwizardMetricsReporter;
 import com.bazaarvoice.emodb.sor.api.Coordinate;
+import com.bazaarvoice.emodb.sor.api.Intrinsic;
 import com.bazaarvoice.emodb.sor.api.ReadConsistency;
 import com.bazaarvoice.emodb.sor.api.UnknownPlacementException;
 import com.bazaarvoice.emodb.sor.api.UnknownTableException;
 import com.bazaarvoice.emodb.sor.core.DataProvider;
+import com.bazaarvoice.emodb.sor.delta.eval.Intrinsics;
 import com.bazaarvoice.megabus.MegabusApplicationId;
 import com.bazaarvoice.megabus.MegabusRef;
 import com.bazaarvoice.megabus.MegabusRefTopic;
@@ -150,7 +152,7 @@ public class MegabusRefResolver extends AbstractService {
         }
 
         public Iterable<KeyValue<String, Map<String, Object>>> getKeyedResolvedDocs() {
-            return Lists.transform(_resolvedDocs, doc -> new KeyValue<>(Coordinate.fromJson(doc).toString(), doc));
+            return Lists.transform(_resolvedDocs, doc -> new KeyValue<>(Coordinate.fromJson(doc).toString(), Intrinsic.isDeleted(doc) ? null : doc));
 
         }
     }

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -152,7 +152,6 @@ public class MegabusRefResolver extends AbstractService {
 
         public Iterable<KeyValue<String, Map<String, Object>>> getKeyedResolvedDocs() {
             return Lists.transform(_resolvedDocs, doc -> new KeyValue<>(Coordinate.fromJson(doc).toString(), doc));
-
         }
     }
 

--- a/web-local/config-megabus.yaml
+++ b/web-local/config-megabus.yaml
@@ -80,6 +80,10 @@ megabus:
     scanStatusTable: __system_megabus_boot
     pendingScanRangeQueueName: megabus-boot-pending-scan-ranges
     completeScanRangeQueueName: megabus-boot-complete-scan-ranges
+  refProducer:
+    batchSize: 400
+    skipWaitThreshold: 250
+    pollIntervalMs: 100
 
 
 


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Currently, deleted documents appear on the megabus as Emo tombstones like
```{
  "client": "TestCustomer",
  "type": "review",
  "~id": "demo1",
  "~table": "review:testcustomer",
  "~version": 5,
  "~signature": "292bbb8d9adbbbf2b572e8325287b16b",
  "~deleted": true,
  "~firstUpdateAt": "2019-07-16T17:43:34.653Z",
  "~lastUpdateAt": "2019-07-16T17:44:55.725Z",
  "~lastMutateAt": "2019-07-16T17:44:55.725Z"
}
```

In line with Kafka convention, these documents should simply be as `null` instead. 

## How to Test and Verify

1. Start the megabus locally and write a new document.
2. Check to megabus and verify that it was sent
3. Delete the document
4. Ensure that `null` was written to the megabus for that document

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The risk on this minimal. The code change is small and the megabus is not in production yet.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
