### PR TITLE
Prevent Megabus from executing jobs

### DIFF
--- a/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/service/EmoServiceMode.java
+++ b/common/dropwizard/src/main/java/com/bazaarvoice/emodb/common/dropwizard/service/EmoServiceMode.java
@@ -52,7 +52,8 @@ public enum EmoServiceMode {
             Aspect.report,
             Aspect.compaction_control,
             Aspect.compaction_control_web,
-            Aspect.job,
+            Aspect.job_module,
+            Aspect.job_processing,
             Aspect.security,
             Aspect.full_consistency,
             Aspect.invalidation_cache_listener,
@@ -131,7 +132,7 @@ public enum EmoServiceMode {
             Aspect.full_consistency,
             Aspect.queue_module,
             Aspect.dataBus_module,
-            Aspect.job,
+            Aspect.job_module,
             Aspect.megabus,
             Aspect.kafka
     );
@@ -192,7 +193,8 @@ public enum EmoServiceMode {
         report,
         compaction_control,
         compaction_control_web,
-        job,
+        job_module,
+        job_processing,
         full_consistency, // This wires in the fct global zookeeper location
         security,
         invalidation_cache_listener, // This makes sure the node is registered in zookeeper to invalidate its caches

--- a/job/src/main/java/com/bazaarvoice/emodb/job/JobModule.java
+++ b/job/src/main/java/com/bazaarvoice/emodb/job/JobModule.java
@@ -88,10 +88,10 @@ public class JobModule extends PrivateModule {
 
     @Provides @Singleton @JobConcurrencyLevel
     protected Integer provideJobConcurrencyLevel(JobConfiguration configuration) {
-        if (_serviceMode.specifies(EmoServiceMode.Aspect.job)) {
+        if (_serviceMode.specifies(EmoServiceMode.Aspect.job_processing)) {
             return configuration.getConcurrencyLevel();
         }
-        // Don't process jobs if not running in server mode
+        // Don't process jobs if not running in a job processing mode
         return 0;
     }
 

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.23-SNAPSHOT</version>
+        <version>5.7.25-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/megabus/pom.xml
+++ b/megabus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>5.7.23-SNAPSHOT</version>
+        <version>5.7.25-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -185,7 +185,7 @@ import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Asp
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.dataStore_web;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.delta_migrator;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.full_consistency;
-import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.job;
+import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.job_module;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.leader_control;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.megabus;
 import static com.bazaarvoice.emodb.common.dropwizard.service.EmoServiceMode.Aspect.kafka;
@@ -229,7 +229,7 @@ public class EmoModule extends AbstractModule {
         evaluate(scanner, new ScannerSetup());
         evaluate(delta_migrator, new MigratorSetup());
         evaluate(report, new ReportSetup());
-        evaluate(job, new JobSetup());
+        evaluate(job_module, new JobSetup());
         evaluate(security, new SecuritySetup());
         evaluate(full_consistency, new FullConsistencySetup());
         evaluate(dataStore_web, new DataStoreAsyncSetup());


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

During testing of the Megabus, the following error was encountered:
```
WARN [2019-07-19 14:32:01,542] com.bazaarvoice.emodb.job.service.DefaultJobService: Unable to execute job: [id=KRWXJOT6FNHNHECTPJKHM5MSFBYHK4THMU, type=purge] ! java.lang.IllegalArgumentException: No handler found for job type: purge ! at com.bazaarvoice.emodb.job.service.DefaultJobService.run(DefaultJobService.java:272) [emodb-web-5.7.23-SNAPSHOT.jar:5.7.23-SNAPSHOT] ! at com.bazaarvoice.emodb.job.service.DefaultJobService.runNextJob(DefaultJobService.java:227) [emodb-web-5.7.23-SNAPSHOT.jar:5.7.23-SNAPSHOT] ! at com.bazaarvoice.emodb.job.service.DefaultJobService$2.run(DefaultJobService.java:134) [emodb-web-5.7.23-SNAPSHOT.jar:5.7.23-SNAPSHOT] ! at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_222] ! at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_222] ! at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_222] ! at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_222] ! at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [na:1.8.0_222] ! at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [na:1.8.0_222] ! at java.lang.Thread.run(Thread.java:748) [na:1.8.0_222]
```
This is occurring because the megabus is registering the `job` service aspect without all of the appropriate job handlers. It must register the `job` aspect because the databus relies on it for submitting replay and move jobs. 

It is not ideal for the megabus to be attempting job execution at all, so in this PR I split the `job` aspect into two aspects, `job_module` and `job_processing`. The megabus will only declare `job_module`, which will enable job submission without job processing.

## How to Test and Verify

1. Check out this PR
2. Run the megabus with `mvn verify -P init-cassandra,start-emodb-megabus-role`
3. Create a table and run the purge command on it a few times
4. Ensure that all purges completed sucessfully, and that the megabus never attempted to execute one
5. Also, look for `[com.bazaarvoice.emodb.local.EmoServiceWithZK.main()] com.bazaarvoice.emodb.job.service.DefaultJobService: Job processing has been disabled` in the megabus logs


## Risk

### Level 

`Low`

### Required Testing

`Manual` and `Regression`

### Risk Summary

The only risk here is that we compromised non-megabus job processing in some way, but the code change is small and I'm pretty certain I didn't do so.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
