### PR TITLE
Specify full configuration for all kafka interactions

### DIFF
--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/DefaultKafkaCluster.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/DefaultKafkaCluster.java
@@ -8,6 +8,7 @@ import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Futures;
 import com.google.inject.Inject;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -42,9 +43,9 @@ public class DefaultKafkaCluster implements KafkaCluster {
     }
 
     @Override
-    public void createTopicIfNotExists(Topic topic) {
+    public void createTopicIfNotExists(Topic topic, Map<String, String> config) {
         NewTopic newTopic = new NewTopic(topic.getName(), topic.getPartitions(), topic.getReplicationFactor());
-
+        newTopic.configs(config);
         try {
             _adminClient.createTopics(Collections.singleton(newTopic)).all().get();
         } catch (ExecutionException | InterruptedException e) {

--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaCluster.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaCluster.java
@@ -2,12 +2,13 @@ package com.bazaarvoice.emodb.kafka;
 
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 
 public interface KafkaCluster {
 
-    void createTopicIfNotExists(Topic topic);
+    void createTopicIfNotExists(Topic topic, Map<String, String> config);
 
     Producer<String, JsonNode> producer();
 

--- a/megabus/src/main/java/com/bazaarvoice/megabus/MegabusModule.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/MegabusModule.java
@@ -12,13 +12,16 @@ import com.bazaarvoice.megabus.refproducer.NumRefPartitions;
 import com.bazaarvoice.megabus.resolver.DocumentResolverManager;
 import com.bazaarvoice.megabus.resolver.MegabusRefResolver;
 import com.bazaarvoice.megabus.resolver.MissingRefDelayProcessor;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import java.time.Duration;
+import org.apache.kafka.common.config.TopicConfig;
 
 public class MegabusModule extends PrivateModule {
 
-    private final int REF_PARTITIONS = 8;
+    private final int REF_PARTITIONS = 4;
 
     private final EmoServiceMode _serviceMode;
 
@@ -44,7 +47,11 @@ public class MegabusModule extends PrivateModule {
     @Singleton
     @MegabusRefTopic
     Topic provideMegabusRefTopic(MegabusConfiguration megabusConfiguration, KafkaCluster kafkaCluster) {
-        kafkaCluster.createTopicIfNotExists(megabusConfiguration.getMegabusRefTopic());
+
+        kafkaCluster.createTopicIfNotExists(megabusConfiguration.getMegabusRefTopic(),
+                ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE,
+                        TopicConfig.RETENTION_MS_CONFIG, Long.toString(Duration.ofDays(30).toMillis()),
+                        TopicConfig.COMPRESSION_TYPE_CONFIG, "zstd"));
         return megabusConfiguration.getMegabusRefTopic();
     }
 
@@ -52,7 +59,10 @@ public class MegabusModule extends PrivateModule {
     @Singleton
     @MegabusTopic
     Topic provideMegabusTopic(MegabusConfiguration megabusConfiguration, KafkaCluster kafkaCluster) {
-        kafkaCluster.createTopicIfNotExists(megabusConfiguration.getMegabusTopic());
+        kafkaCluster.createTopicIfNotExists(megabusConfiguration.getMegabusTopic(),
+                ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT,
+                        TopicConfig.DELETE_RETENTION_MS_CONFIG, Long.toString(Duration.ofDays(14).toMillis()),
+                        TopicConfig.COMPRESSION_TYPE_CONFIG, "zstd"));
         return megabusConfiguration.getMegabusTopic();
     }
 
@@ -60,7 +70,10 @@ public class MegabusModule extends PrivateModule {
     @Singleton
     @MissingRefTopic
     Topic provideMissingRefTopic(MegabusConfiguration megabusConfiguration, KafkaCluster kafkaCluster) {
-        kafkaCluster.createTopicIfNotExists(megabusConfiguration.getMissingRefTopic());
+        kafkaCluster.createTopicIfNotExists(megabusConfiguration.getMissingRefTopic(),
+                ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE,
+                        TopicConfig.RETENTION_MS_CONFIG, Long.toString(Duration.ofDays(30).toMillis()),
+                        TopicConfig.COMPRESSION_TYPE_CONFIG, "zstd"));
         return megabusConfiguration.getMissingRefTopic();
     }
 
@@ -68,7 +81,10 @@ public class MegabusModule extends PrivateModule {
     @Singleton
     @RetryRefTopic
     Topic provideRetryRefTopic(MegabusConfiguration megabusConfiguration, KafkaCluster kafkaCluster) {
-        kafkaCluster.createTopicIfNotExists(megabusConfiguration.getRetryRefTopic());
+        kafkaCluster.createTopicIfNotExists(megabusConfiguration.getRetryRefTopic(),
+                ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE,
+                        TopicConfig.RETENTION_MS_CONFIG, Long.toString(Duration.ofDays(30).toMillis()),
+                        TopicConfig.COMPRESSION_TYPE_CONFIG, "zstd"));
         return megabusConfiguration.getRetryRefTopic();
     }
 

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
@@ -106,6 +107,8 @@ public class MegabusRefResolver extends AbstractService {
         streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, _megabusRefTopic.getPartitions());
 
         streamsConfiguration.put(StreamsConfig.METRIC_REPORTER_CLASSES_CONFIG, DropwizardMetricsReporter.class.getName());
+
+        streamsConfiguration.put(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG), "all");
 
         streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, _instanceId);
 


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Currently there exists no specific compression and retention configuration for Kafka topics that interact with the megabus. In this PR, I set all topics' compression to ZStandard, and set appropriate retention or compaction configuration for all topics.

Additionally, there were some config options missing from the embedded Streams applications, which I have now added.
 
## How to Test and Verify

1. Check out this PR
2. Start the megabus
3. Inspect the topics via kafka CLI tools and ensure that proper configuration is set.

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The only risk here is that these configuration options somehow cause the megabus to be incompatible with the Kafka it will be running against. This should be easily noticeable on startup though.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
