### PR TITLE
Set 15 MB kafka producer max request size

### DIFF
--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/DefaultKafkaCluster.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/DefaultKafkaCluster.java
@@ -72,6 +72,7 @@ public class DefaultKafkaCluster implements KafkaCluster {
         props.put(ProducerConfig.ACKS_CONFIG, "all");
         props.put(ProducerConfig.RETRIES_CONFIG, 0);
         props.put(ProducerConfig.LINGER_MS_CONFIG, 5); // 5 msloc
+        props.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 15 * 1024 * 1024); // 15 MB
 
         props.put(ProducerConfig.CLIENT_ID_CONFIG, _instanceIdentifier);
 

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -110,6 +110,9 @@ public class MegabusRefResolver extends AbstractService {
 
         streamsConfiguration.put(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG), "all");
 
+        // 15 MB max message size
+        streamsConfiguration.put(StreamsConfig.producerPrefix(ProducerConfig.MAX_REQUEST_SIZE_CONFIG), 15 * 1024 * 1024);
+
         streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, _instanceId);
 
         StreamsBuilder streamsBuilder = new StreamsBuilder();


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

There are many documents in Emo above the 1MB, which is the default maximum message size of KafkaProducer. In PR, we set the KafkaProducer max message size to 15MB.

## How to Test and Verify

1. Check out this PR
2. Manually inspect the code and ensure that the 15 MB message request limit is being set

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The only risk here is that large messages could affect Kafka performance. 

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
