### PR TITLE
Adding restarting kafka streams on unexpected failures.

### DIFF
--- a/megabus/src/main/java/com/bazaarvoice/megabus/MegabusModule.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/MegabusModule.java
@@ -9,7 +9,7 @@ import com.bazaarvoice.megabus.refproducer.MegabusRefProducerConfiguration;
 import com.bazaarvoice.megabus.refproducer.MegabusRefProducerManager;
 import com.bazaarvoice.megabus.refproducer.MegabusRefSubscriptionMonitorManager;
 import com.bazaarvoice.megabus.refproducer.NumRefPartitions;
-import com.bazaarvoice.megabus.resolver.DocumentResolverManager;
+import com.bazaarvoice.megabus.resolver.MegabusRefResolverManager;
 import com.bazaarvoice.megabus.resolver.MegabusRefResolver;
 import com.bazaarvoice.megabus.resolver.MissingRefDelayProcessor;
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +38,7 @@ public class MegabusModule extends PrivateModule {
         bind(MegabusRefProducerManager.class).asEagerSingleton();
         bind(MegabusRefResolver.class).asEagerSingleton();
         bind(MissingRefDelayProcessor.class).asEagerSingleton();
-        bind(DocumentResolverManager.class).asEagerSingleton();
+        bind(MegabusRefResolverManager.class).asEagerSingleton();
         bind(MegabusBootWorkflowManager.class).asEagerSingleton();
         bind(MegabusRefSubscriptionMonitorManager.class).asEagerSingleton();
     }

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolveFailureListener.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolveFailureListener.java
@@ -1,0 +1,80 @@
+package com.bazaarvoice.megabus.resolver;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Watches the MegabusRefResolverManager service.
+ * Main implementation is on failure to restart the service.
+ * One failure case is when the service's new state gets to NOT RUNNING through the ERROR state.
+ * Its also when an uncaught exception get bubbled out of the main service run method.
+ */
+public class MegabusRefResolveFailureListener extends Service.Listener {
+    private static final Logger _log = LoggerFactory.getLogger(MegabusRefResolveFailureListener.class);
+    private final static long RESTART_SLEEP_TIME_IN_MS = Duration.ofMinutes(1).toMillis();
+
+    private final Meter _restartMeter;
+
+    private final Service _service;
+
+    private final String _applicationId;
+
+    public static void listenTo(Service service, String applicationId, MetricRegistry metricRegistry) {
+        service.addListener(new MegabusRefResolveFailureListener(service, applicationId, metricRegistry), MoreExecutors.sameThreadExecutor());
+    }
+
+    public MegabusRefResolveFailureListener(Service service, String applicationId, MetricRegistry metricRegistry) {
+        _service = checkNotNull(service);
+        _applicationId = checkNotNull(applicationId);
+        _restartMeter = metricRegistry.meter(MegabusRefResolver.getMetricName("restart" + _service));
+    }
+
+    @Override
+    public void starting() {
+        // Do nothing
+    }
+
+    @Override
+    public void running() {
+        // Do nothing
+    }
+
+    @Override
+    public void stopping(Service.State from) {
+        // Do nothing
+    }
+
+    @Override
+    public void terminated(Service.State from) {
+        // Do nothing
+    }
+
+    @Override
+    public void failed(Service.State from, Throwable failure) {
+        _log.error("Service {} with applicationId {} has failed while in the {} state.", _service.toString(), _applicationId + "-resolver", from, failure);
+
+        _service.stopAsync();
+        _service.awaitTerminated();
+
+        try {
+            Thread.sleep(RESTART_SLEEP_TIME_IN_MS);
+        } catch (InterruptedException e) {
+            _log.error("sleep is interrupted: ", e.getMessage());
+        }
+
+        // update the metrics
+        _restartMeter.mark();
+
+        _log.info("Restarting service {} at: ", _service.toString(), LocalDateTime.now());
+        _service.startAsync();
+    }
+}

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolverManager.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolverManager.java
@@ -3,6 +3,7 @@ package com.bazaarvoice.megabus.resolver;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.megabus.MegabusApplicationId;
 import com.bazaarvoice.megabus.MegabusBootDAO;
+import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
 import io.dropwizard.lifecycle.Managed;
 import java.util.concurrent.Executors;
@@ -11,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class DocumentResolverManager implements Managed {
+public class MegabusRefResolverManager implements Managed {
 
     private final MegabusBootDAO _statusDAO;
     private final ScheduledExecutorService _bootService;
@@ -20,14 +21,15 @@ public class DocumentResolverManager implements Managed {
     private final String _applicationId;
 
     @Inject
-    public DocumentResolverManager(LifeCycleRegistry lifeCycle, MegabusBootDAO statusDAO,
-                                   MegabusRefResolver megabusRefResolver, MissingRefDelayProcessor missingRefDelayProcessor,
-                                   @MegabusApplicationId String applicationId) {
+    public MegabusRefResolverManager(LifeCycleRegistry lifeCycle, MegabusBootDAO statusDAO,
+                                     MegabusRefResolver megabusRefResolver, MissingRefDelayProcessor missingRefDelayProcessor,
+                                     @MegabusApplicationId String applicationId, MetricRegistry metricRegistry) {
         _statusDAO = checkNotNull(statusDAO, "statusDAO");
         _megabusRefResolver = checkNotNull(megabusRefResolver);
         _missingRefDelayProcessor = checkNotNull(missingRefDelayProcessor);
         _applicationId = checkNotNull(applicationId);
         _bootService = Executors.newSingleThreadScheduledExecutor();
+        MegabusRefResolveFailureListener.listenTo(_megabusRefResolver, _applicationId, metricRegistry);
         lifeCycle.manage(this);
     }
 


### PR DESCRIPTION
## Github Issue #

Kafka stream failure handling case. 

## What Are We Doing Here?
Restarting the Ref Resolver in case of any unexpected failures with the stream processing. We are pausing for a minute and restarting. One other idea was to have an exponential restart, but didn't think it was necessary in this case. Also, we could max out the restarts but thought not necessary either. A Metric is also added to keep track of these restarts.   

## How to Test and Verify

Testing probably will need us to explicitly throw a unexpected expection somewhere in the code, and watch for the metric. 

