### PR TITLE
Enable a non-temporal stash megabus boot

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/megabus/StashMegabusBootDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/megabus/StashMegabusBootDAO.java
@@ -26,6 +26,7 @@ public class StashMegabusBootDAO implements MegabusBootDAO {
     @Override
     public void initiateBoot(String applicationId, Topic topic) {
         ScanOptions scanOptions = new ScanOptions(_dataTools.getTablePlacements(false, true));
+        scanOptions.setTemporalEnabled(false);
         scanOptions.addDestination(ScanDestination.to(URI.create("kafka://" + topic.getName())));
 
         _scanUploader.scanAndUpload(applicationId, scanOptions).start();

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
@@ -40,6 +40,8 @@ public class ScanOptions {
     private Duration _maxRangeScanTime = DEFAULT_MAX_RANGE_SCAN_TIME;
     // Allow compaction of records during the scan.  Potentially increases the total scan time.  Default is false
     private boolean _compactionEnabled = false;
+    // Where or not to stash temporally
+    private boolean _temporalEnabled = true;
 
     public ScanOptions(String placement) {
         this(ImmutableSortedSet.of(placement));
@@ -57,7 +59,8 @@ public class ScanOptions {
                         @JsonProperty ("maxConcurrentSubRangeScans") Integer maxConcurrentSubRangeScans,
                         @JsonProperty ("rangeScanSplitSize") Integer rangeScanSplitSize,
                         @JsonProperty ("maxRangeScanTime") Long maxRangeScanTime,
-                        @JsonProperty ("compactionEnabled") Boolean compactionEnabled) {
+                        @JsonProperty ("compactionEnabled") Boolean compactionEnabled,
+                        @JsonProperty ("temporalEnabled") Boolean temporalEnabled) {
         this(placements);
         if (destinations != null) {
             addDestinations(destinations);
@@ -76,6 +79,9 @@ public class ScanOptions {
         }
         if (compactionEnabled != null) {
             _compactionEnabled = compactionEnabled;
+        }
+        if (temporalEnabled != null) {
+            _temporalEnabled = temporalEnabled;
         }
     }
 
@@ -153,6 +159,14 @@ public class ScanOptions {
     public ScanOptions setCompactionEnabled(boolean compactionEnabled) {
         _compactionEnabled = compactionEnabled;
         return this;
+    }
+
+    public boolean isTemporalEnabled() {
+        return _temporalEnabled;
+    }
+
+    public void setTemporalEnabled(boolean temporalEnabled) {
+        _temporalEnabled = temporalEnabled;
     }
 
     @Override

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
@@ -40,7 +40,7 @@ public class ScanOptions {
     private Duration _maxRangeScanTime = DEFAULT_MAX_RANGE_SCAN_TIME;
     // Allow compaction of records during the scan.  Potentially increases the total scan time.  Default is false
     private boolean _compactionEnabled = false;
-    // Where or not to stash temporally
+    // Whether or not to stash temporally
     private boolean _temporalEnabled = true;
 
     public ScanOptions(String placement) {

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/LocalScanUploadMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/LocalScanUploadMonitor.java
@@ -477,6 +477,12 @@ public class LocalScanUploadMonitor extends AbstractService {
     private void scheduleOverrunCheck(ScanStatus status) {
         final String scanId = status.getScanId();
 
+        // If temporal stash is disabled, this is likely not a traditional stash run, and it may take longer than 24 hours
+        // In this case, don't interrupt it if it is taking a while.
+        if (!status.getOptions().isTemporalEnabled()) {
+            return;
+        }
+
         Instant now = Instant.now();
         Instant overrunTime = status.getStartTime().toInstant().plus(OVERRUN_SCAN_TIME);
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/LocalScanUploadMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/LocalScanUploadMonitor.java
@@ -477,7 +477,7 @@ public class LocalScanUploadMonitor extends AbstractService {
     private void scheduleOverrunCheck(ScanStatus status) {
         final String scanId = status.getScanId();
 
-        // If temporal stash is disabled, this is likely not a traditional stash run, and it may take longer than 24 hours
+        // If temporal stash is disabled, this is likely not a daily stash run, and it may take longer than 24 hours.
         // In this case, don't interrupt it if it is taking a while.
         if (!status.getOptions().isTemporalEnabled()) {
             return;


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Currently the megabus boots using temporal stash with kafka as its destination. This is problematic for a few reasons:

1. It can take much longer than a stash to S3, and compaction must be turned off for the duration of temporal stash. Turing of compaction for an extended period of time can be dangerous.
2. Because of the danger of turning off compaction for an extended period of time, Emo currently forced compaction control to turn off after 10 hours. This means that if stash runs longer than 10 hours, the boot will be corrupt.
3. Stash automatically cancel's itself after 24 hours. Emo currently takes the position that any stash that takes over 24 hours is overrun, and automatically cancels it. When booting the megabus, it can take longer than 24 hours, and that is ok.

For megabus boot purposes, we should simply use a stash that is non-temporal. In scope of this PR, we should build such a capability.



## How to Test and Verify

1. Check out this PR
2. Run the megabus
3. Ensure that the compaction control is not used during boot

## Risk

### Level 

`Medium`

### Required Testing

`Regression`

### Risk Summary

This PR modifies a critical part of temporal stash. There is definitely some implicit risk here. 

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
