### PR TITLE
Fix Kafka Streams Client ID Collision

### DIFF
--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -48,6 +48,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public class MegabusRefResolver extends AbstractService {
 
+    private static final String SUFFIX = "-resolver";
+
     private final DataProvider _dataProvider;
     private final Topic _megabusRefTopic;
     private final Topic _megabusResolvedTopic;
@@ -100,7 +102,7 @@ public class MegabusRefResolver extends AbstractService {
         final Properties streamsConfiguration = new Properties();
         // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
         // against which the application is run.
-        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, _applicationId  + "-resolver");
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, _applicationId + SUFFIX);
         // Where to find Kafka broker(s).
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, _kafkaCluster.getBootstrapServers());
 
@@ -113,7 +115,7 @@ public class MegabusRefResolver extends AbstractService {
         // 15 MB max message size
         streamsConfiguration.put(StreamsConfig.producerPrefix(ProducerConfig.MAX_REQUEST_SIZE_CONFIG), 15 * 1024 * 1024);
 
-        streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, _instanceId);
+        streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, _instanceId + SUFFIX);
 
         StreamsBuilder streamsBuilder = new StreamsBuilder();
 

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MissingRefDelayProcessor.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MissingRefDelayProcessor.java
@@ -34,6 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class MissingRefDelayProcessor extends AbstractService {
 
     private static Logger _log = LoggerFactory.getLogger(MissingRefDelayProcessor.class);
+    private static final String SUFFIX = "-retry";
 
     private final Topic _retryRefTopic;
     private final Topic _missingRefTopic;
@@ -66,7 +67,7 @@ public class MissingRefDelayProcessor extends AbstractService {
         final Properties streamsConfiguration = new Properties();
         // Give the Streams application a unique name.  The name must be unique in the Kafka cluster
         // against which the application is run.
-        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, _applicationId + "-retry");
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, _applicationId + SUFFIX);
         // Where to find Kafka broker(s).
         streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, _kafkaCluster.getBootstrapServers());
 
@@ -74,7 +75,7 @@ public class MissingRefDelayProcessor extends AbstractService {
 
         streamsConfiguration.put(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG), "all");
 
-        streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, _instanceId);
+        streamsConfiguration.put(StreamsConfig.CLIENT_ID_CONFIG, _instanceId + SUFFIX);
 
         StreamsBuilder streamsBuilder = new StreamsBuilder();
 


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

While testing the megabus in CI, the following error was encountered:
```
WARN  [2019-07-25 17:51:08,395] org.apache.kafka.common.utils.AppInfoParser: Error registering AppInfo mbean
! javax.management.InstanceAlreadyExistsException: kafka.admin.client:type=app-info,id="10.110.152.228:8080-admin"
! at com.sun.jmx.mbeanserver.Repository.addMBean(Repository.java:437) ~[na:1.8.0_222]
! at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerWithRepository(DefaultMBeanServerInterceptor.java:1898) ~[na:1.8.0_222]
! at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerDynamicMBean(DefaultMBeanServerInterceptor.java:966) ~[na:1.8.0_222]
! at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerObject(DefaultMBeanServerInterceptor.java:900) ~[na:1.8.0_222]
! at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.registerMBean(DefaultMBeanServerInterceptor.java:324) ~[na:1.8.0_222]
! at com.sun.jmx.mbeanserver.JmxMBeanServer.registerMBean(JmxMBeanServer.java:522) ~[na:1.8.0_222]
! at org.apache.kafka.common.utils.AppInfoParser.registerAppInfo(AppInfoParser.java:62) ~[emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at org.apache.kafka.clients.admin.KafkaAdminClient.<init>(KafkaAdminClient.java:435) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at org.apache.kafka.clients.admin.KafkaAdminClient.createInternal(KafkaAdminClient.java:379) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at org.apache.kafka.clients.admin.AdminClient.create(AdminClient.java:65) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier.getAdminClient(DefaultKafkaClientSupplier.java:34) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:713) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:634) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:544) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at com.bazaarvoice.megabus.resolver.MissingRefDelayProcessor.doStart(MissingRefDelayProcessor.java:86) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at com.google.common.util.concurrent.AbstractService.startAsync(AbstractService.java:185) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at com.bazaarvoice.megabus.resolver.DocumentResolverManager.lambda$start$0(DocumentResolverManager.java:40) [emodb-web-5.7.25-SNAPSHOT.jar:5.7.25-SNAPSHOT]
! at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[na:1.8.0_222]
! at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) ~[na:1.8.0_222]
! at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) ~[na:1.8.0_222]
! at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) ~[na:1.8.0_222]
! at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_222]
! at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_222]
! at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_222]
```

It appears that the root cause of this issue is that the MissingRefDelayProcessor and the MegabusRefResolver have the same client id. This PR fixes this by appending a processor specific suffix to each application client id.

## How to Test and Verify

Manual Code Inspection should be enough here.

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

This is extremely low risk. All we are doing is modifying a string.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
