### PR TITLE
Fix accuracy of databus replaySince

### DIFF
--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusChannelConfiguration.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DatabusChannelConfiguration.java
@@ -13,7 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class DatabusChannelConfiguration implements ChannelConfiguration {
     private static final Duration FANOUT_TTL = Duration.ofDays(365);  // Basically forever
     public static final Duration CANARY_TTL = Duration.ofDays(365);  // Basically forever
-    public static final Duration REPLAY_TTL = Duration.ofHours(50); // 2 days + 2 hours
+    public static final Duration REPLAY_TTL = Duration.ofHours(52); // 2 days + 4 hours
 
     private final SubscriptionDAO _subscriptionDao;
 

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/DefaultDatabus.java
@@ -120,9 +120,6 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
     /* This is how long we submit tasks to drain the queue for each subscription from one poll request */
     private static final Duration MAX_QUEUE_DRAIN_TIME_FOR_A_SUBSCRIPTION = Duration.ofMinutes(1);
 
-    /* This is how far extra we should scan the replay subscription to alleviate the effects of race conditions */
-    private static final Duration REPLAY_SINCE_PADDING = Duration.ofMinutes(30);
-
     private final DatabusEventWriterRegistry _eventWriterRegistry;
     private final SubscriptionDAO _subscriptionDao;
     private final DatabusEventStore _eventStore;
@@ -838,11 +835,9 @@ public class DefaultDatabus implements OwnerAwareDatabus, DatabusEventWriter, Ma
         String source = ChannelNames.getMasterReplayChannel();
         final OwnedSubscription destination = getSubscriptionByName(subscription);
 
-        Date sinceWithPadding = since != null ? Date.from(since.toInstant().minus(REPLAY_SINCE_PADDING)) : null;
-
         _eventStore.copy(source, subscription,
                 (eventDataBytes) -> _subscriptionEvaluator.matches(destination, eventDataBytes, since),
-                sinceWithPadding);
+                since);
     }
 
     @Override

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluator.java
@@ -47,7 +47,7 @@ public class SubscriptionEvaluator {
                 .filter(subscription -> matches(subscription, eventData));
     }
 
-    public boolean matches(OwnedSubscription subscription, ByteBuffer eventData) {
+    public boolean matches(OwnedSubscription subscription, ByteBuffer eventData, Date since) {
         MatchEventData matchEventData;
         try {
             matchEventData = getMatchEventData(eventData);
@@ -55,7 +55,8 @@ public class SubscriptionEvaluator {
             return false;
         }
 
-        return matches(subscription, matchEventData);
+        return matches(subscription, matchEventData)
+                && (since == null || !matchEventData.getEventTime().before(since));
     }
 
     public boolean matches(OwnedSubscription subscription, MatchEventData eventData) {

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluatorTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/core/SubscriptionEvaluatorTest.java
@@ -43,23 +43,23 @@ public class SubscriptionEvaluatorTest {
         Condition skipIgnoreEvents = Conditions.not(Conditions.mapBuilder().matches(UpdateRef.TAGS_NAME, Conditions.containsAny("ignore")).build());
         OwnedSubscription skipIgnoreSubscription = new DefaultOwnedSubscription("test-tags", skipIgnoreEvents,
                 Date.from(Instant.now().plus(Duration.ofDays(1))), Duration.ofHours(1), "id");
-        assertFalse(subscriptionEvaluator.matches(skipIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef)));
+        assertFalse(subscriptionEvaluator.matches(skipIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef), null));
         // The following databus event should match, as it doesn't have "ignore" tag
         UpdateRef updateRef2 = new UpdateRef("table1", "some-key", TimeUUIDs.newUUID(), ImmutableSet.of("ETL"));
-        assertTrue(subscriptionEvaluator.matches(skipIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef2)));
+        assertTrue(subscriptionEvaluator.matches(skipIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef2), null));
         UpdateRef updateRef3 = new UpdateRef("table1", "some-key", TimeUUIDs.newUUID(), ImmutableSet.<String>of());
-        assertTrue(subscriptionEvaluator.matches(skipIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef3)));
+        assertTrue(subscriptionEvaluator.matches(skipIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef3), null));
 
         // Subscription that explicitly asks for "ignore" events
         Condition getIgnoreEvents = Conditions.mapBuilder().matches(UpdateRef.TAGS_NAME, Conditions.containsAny("ignore")).build();
         OwnedSubscription getIgnoreSubscription = new DefaultOwnedSubscription("test-tags", getIgnoreEvents,
                 Date.from(Instant.now().plus(Duration.ofDays(1))), Duration.ofHours(1), "id");
-        assertTrue(subscriptionEvaluator.matches(getIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef)));
+        assertTrue(subscriptionEvaluator.matches(getIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef), null));
         // The following databus event should *not* match, as it doesn't have "ignore" tag
         updateRef2 = new UpdateRef("table1", "some-key", TimeUUIDs.newUUID(), ImmutableSet.of("ETL"));
-        assertFalse(subscriptionEvaluator.matches(getIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef2)));
+        assertFalse(subscriptionEvaluator.matches(getIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef2), null));
         updateRef3 = new UpdateRef("table1", "some-key", TimeUUIDs.newUUID(), ImmutableSet.<String>of());
-        assertFalse(subscriptionEvaluator.matches(getIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef3)));
+        assertFalse(subscriptionEvaluator.matches(getIgnoreSubscription, UpdateRefSerializer.toByteBuffer(updateRef3), null));
     }
 
     @Test
@@ -74,6 +74,65 @@ public class SubscriptionEvaluatorTest {
         // No condition, even alwaysTrue(), matches when the authorizer doesn't have permission
         OwnedSubscription allSubscription = new DefaultOwnedSubscription("all", Conditions.alwaysTrue(),
                 Date.from(Instant.now().plus(Duration.ofDays(1))), Duration.ofHours(1), "id");
-        assertFalse(subscriptionEvaluator.matches(allSubscription, UpdateRefSerializer.toByteBuffer(updateRef)));
+        assertFalse(subscriptionEvaluator.matches(allSubscription, UpdateRefSerializer.toByteBuffer(updateRef), null));
+    }
+
+    @Test
+    public void testSince() {
+        DataProvider dataProvider = mock(DataProvider.class);
+        when(dataProvider.getTable(anyString())).thenReturn(new InMemoryTable("table1",
+                new TableOptionsBuilder().setPlacement("app_global:ugc").build(), Maps.<String, Object>newHashMap()));
+        SubscriptionEvaluator subscriptionEvaluator = new SubscriptionEvaluator(dataProvider,
+                ConstantDatabusAuthorizer.ALLOW_ALL, mock(RateLimitedLogFactory.class));
+
+        Date date = new Date();
+
+        UpdateRef updateRef = new UpdateRef("table1", "some-key",
+                TimeUUIDs.uuidForTimestamp(Date.from(date.toInstant().minus(Duration.ofSeconds(1)))),
+                ImmutableSet.of("ignore", "ETL"));
+        // No condition, even alwaysTrue(), matches when the the "since" timestamp is after the timestamp of the event
+        OwnedSubscription subscription = new DefaultOwnedSubscription("all", Conditions.alwaysTrue(),
+                Date.from(Instant.now().plus(Duration.ofDays(1))), Duration.ofHours(1), "id");
+        assertFalse(subscriptionEvaluator.matches(subscription, UpdateRefSerializer.toByteBuffer(updateRef), date));
+
+        updateRef = new UpdateRef("table1", "some-key",
+                TimeUUIDs.uuidForTimestamp(Date.from(date.toInstant().plus(Duration.ofSeconds(1)))),
+                ImmutableSet.of("ignore", "ETL"));
+        // A matching condition matches when the the "since" timestamp is before the timestamp of the event
+        subscription = new DefaultOwnedSubscription("all", Conditions.alwaysTrue(),
+                Date.from(Instant.now().plus(Duration.ofDays(1))), Duration.ofHours(1), "id");
+        assertTrue(subscriptionEvaluator.matches(subscription, UpdateRefSerializer.toByteBuffer(updateRef), date));
+
+        updateRef = new UpdateRef("table1", "some-key",
+                TimeUUIDs.uuidForTimestamp(date),
+                ImmutableSet.of("ignore", "ETL"));
+        // A matching condition matches when the the "since" timestamp is the same as the timestamp of the event
+        subscription = new DefaultOwnedSubscription("all", Conditions.alwaysTrue(),
+                Date.from(Instant.now().plus(Duration.ofDays(1))), Duration.ofHours(1), "id");
+        assertTrue(subscriptionEvaluator.matches(subscription, UpdateRefSerializer.toByteBuffer(updateRef), date));
+
+        updateRef = new UpdateRef("table1", "some-key",
+                TimeUUIDs.uuidForTimestamp(date),
+                ImmutableSet.of("ignore", "ETL"));
+        // A non-matching condition does not match when the the "since" timestamp is the same as the timestamp of the event
+        subscription = new DefaultOwnedSubscription("all", Conditions.alwaysFalse(),
+                Date.from(Instant.now().plus(Duration.ofDays(1))), Duration.ofHours(1), "id");
+        assertFalse(subscriptionEvaluator.matches(subscription, UpdateRefSerializer.toByteBuffer(updateRef), date));
+
+        new UpdateRef("table1", "some-key",
+                TimeUUIDs.uuidForTimestamp(Date.from(date.toInstant().minus(Duration.ofSeconds(1)))),
+                ImmutableSet.of("ignore", "ETL"));
+        // A non-matching condition does not match when the the "since" timestamp is after the timestamp of the event
+        subscription = new DefaultOwnedSubscription("all", Conditions.alwaysFalse(),
+                Date.from(Instant.now().plus(Duration.ofDays(1))), Duration.ofHours(1), "id");
+        assertFalse(subscriptionEvaluator.matches(subscription, UpdateRefSerializer.toByteBuffer(updateRef), date));
+
+        updateRef = new UpdateRef("table1", "some-key",
+                TimeUUIDs.uuidForTimestamp(Date.from(date.toInstant().plus(Duration.ofSeconds(1)))),
+                ImmutableSet.of("ignore", "ETL"));
+        // A non-matching condition does not match when the the "since" timestamp is before the timestamp of the event
+        subscription = new DefaultOwnedSubscription("all", Conditions.alwaysFalse(),
+                Date.from(Instant.now().plus(Duration.ofDays(1))), Duration.ofHours(1), "id");
+        assertFalse(subscriptionEvaluator.matches(subscription, UpdateRefSerializer.toByteBuffer(updateRef), date));
     }
 }

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -566,7 +566,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
     protected SlabFilter getSlabFilterSince(final Date since, final String channel) {
         return new SlabFilter() {
             boolean foundStartingSlab = false;
-            final UUID sinceUUID = TimeUUIDs.uuidForTimestamp(since);
+            final UUID sinceUUID = TimeUUIDs.uuidForTimestamp(Date.from(since.toInstant().minus(Constants.SLAB_ROTATE_TTL)));
             @Override
             public boolean accept(ByteBuffer slabId, boolean open, ByteBuffer nextSlabId) {
                 UUID nextSlabUUID = !foundStartingSlab && nextSlabId != null ?

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -566,7 +566,9 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
     protected SlabFilter getSlabFilterSince(final Date since, final String channel) {
         return new SlabFilter() {
             boolean foundStartingSlab = false;
-            final UUID sinceUUID = TimeUUIDs.uuidForTimestamp(Date.from(since.toInstant().minus(Constants.SLAB_ROTATE_TTL)));
+            final UUID sinceUUID = TimeUUIDs.uuidForTimestamp(Date.from(since.toInstant()
+                    .minus(Constants.SLAB_ROTATE_TTL)
+                    .minus(Constants.REPLAY_PADDING_TIME)));
             @Override
             public boolean accept(ByteBuffer slabId, boolean open, ByteBuffer nextSlabId) {
                 UUID nextSlabUUID = !foundStartingSlab && nextSlabId != null ?

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxManifestPersister.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxManifestPersister.java
@@ -116,7 +116,7 @@ public class AstyanaxManifestPersister implements ManifestPersister {
     }
 
     private Duration getTtl(String channel, boolean open) {
-        // When a slab is open set its TTL for an extra day to make sure the manifest entry doesn't expire before the
+        // When a slab is open set its TTL for an extra hour to make sure the manifest entry doesn't expire before the
         // events it points to.  When a slab is closed, set it to the regular event TTL.  There's no point in it
         // outliving the events it contains.
         Duration eventTtl = _channelConfiguration.getEventTtl(channel);

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/Constants.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/Constants.java
@@ -19,8 +19,13 @@ interface Constants {
     /** A server is expected to update a slab at least this often or else close it. */
     static final Duration OPEN_SLAB_MARKER_TTL = Duration.ofMinutes(20);
 
-    /** Don't keep slabs open for too long.  Rotate them periodically. */
+    /** Don't keep slabs open for too long.  Rotate them periodically.
+     * This used to be one day, instead of one hour, but it was lowered to make databus replay more efficient.
+     */
     static final Duration SLAB_ROTATE_TTL = Duration.ofHours(1);
+
+    /** Add some extra padding to databus replay time to avoid any unknown race conditions */
+    static final Duration REPLAY_PADDING_TIME = Duration.ofMinutes(5);
 
     /** Cap the size of updates. */
     static final int MUTATION_MAX_ROWS = 10;

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/Constants.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/Constants.java
@@ -20,7 +20,7 @@ interface Constants {
     static final Duration OPEN_SLAB_MARKER_TTL = Duration.ofMinutes(20);
 
     /** Don't keep slabs open for too long.  Rotate them periodically. */
-    static final Duration SLAB_ROTATE_TTL = Duration.ofDays(1);
+    static final Duration SLAB_ROTATE_TTL = Duration.ofHours(1);
 
     /** Cap the size of updates. */
     static final int MUTATION_MAX_ROWS = 10;

--- a/event/src/test/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAOTest.java
+++ b/event/src/test/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAOTest.java
@@ -137,8 +137,8 @@ public class AstyanaxEventReaderDAOTest {
                     : null;
             boolean actual = slabFilterSince.accept(slabId, false, nextSlabId);
             // Slabs slabId4 and slabId5 are the only interesting ones for us
-            boolean expected = currSlabId.equals(slabId4) || currSlabId.equals(slabId5);
-            assertEquals(actual, expected, "slabId4 and slabId5 are the only ones we care about.");
+            boolean expected = currSlabId.equals(slabId3) || currSlabId.equals(slabId4) || currSlabId.equals(slabId5);
+            assertEquals(actual, expected, "slabId3, slabId4, and slabId5 are the only ones we care about.");
         }
     }
 }


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Emo's databus replay feature currently uses the following code block for determining which slab to begin replaying from when given a "since" timestamp for replay:

```
protected SlabFilter getSlabFilterSince(final Date since, final String channel) {
    return new SlabFilter() {
        boolean foundStartingSlab = false;
        final UUID sinceUUID = TimeUUIDs.uuidForTimestamp(since);
        @Override
        public boolean accept(ByteBuffer slabId, boolean open, ByteBuffer nextSlabId) {
            UUID nextSlabUUID = !foundStartingSlab && nextSlabId != null ?
                    TimeUUIDSerializer.get().fromByteBuffer(nextSlabId.duplicate())
                    : null;
            // If the nextSlab's UUID is less than the desired timestamp, then skip reading events from this slab
            if (nextSlabUUID != null && TimeUUIDs.compareTimestamps(nextSlabUUID, sinceUUID) < 0) {
                return false;
            }
            if (!foundStartingSlab) {
                // Log the slab that we start reading from
                foundStartingSlab = true;
                _log.info("Starting to replay {} from slabid {}, for since timestamp of {}", channel,
                        UUIDSerializer.get().fromByteBuffer(slabId),  ISO_FORMATTER.format(since.toInstant()));
            }
            return true;
        }
    };
}
```

This function thinks it is being defensive by picking the the last slab timestamped before the since time. However, this is actually not correct. In a distributed system, where there are multiple Emo app servers, slabs are not perfectly chronological. They can overlap due to multiple servers writing slabs (which is indeed the case with partitioned fanout).

## How to Test and Verify

This is extremely difficult to test locally, as it requires multiple app servers to exacerbate the existing issue. We should test in a CI environment before moving further.

## Risk

### Level 

`Medium`

### Required Testing

`Regression`

### Risk Summary

I had to modify the slab rotation time in order to make this possible. As far as i can tell, the risk on this is mimimal, but the implementation of manifests and slabs is extremely complicated, so I could have missed something.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
