### PR TITLE
Serializing the zoneddatetime for UnPublishedDatabusEvents delta so t…

### DIFF
--- a/sor/src/test/java/com/bazaarvoice/emodb/table/db/astyanax/TableLifeCycleTest.java
+++ b/sor/src/test/java/com/bazaarvoice/emodb/table/db/astyanax/TableLifeCycleTest.java
@@ -48,6 +48,10 @@ import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -1988,6 +1992,19 @@ public class TableLifeCycleTest {
         Assertions.assertThat(expectedTables).containsOnly(TABLE1, TABLE2);
         assertTrue(expectedDates.contains(nowInstant.toEpochMilli()));
         assertTrue(expectedDates.contains(nextDayInstant.toEpochMilli()));
+    }
+
+    @Test
+    public void testMillisecondPrecisionZonedDateTime()
+            throws Exception {
+        ZonedDateTime zeroSecondDateTime = ZonedDateTime.of(LocalDate.parse("2017-01-01"), LocalTime.parse("07:01"), ZoneOffset.UTC);
+        ZonedDateTime zeroMilliSecondDateTime = ZonedDateTime.of(LocalDate.parse("2017-01-01"), LocalTime.parse("07:01:01"), ZoneOffset.UTC);
+
+        assertEquals(zeroSecondDateTime.toString(), "2017-01-01T07:01Z");
+        assertEquals(zeroMilliSecondDateTime.toString(), "2017-01-01T07:01:01Z");
+
+        assertEquals(AstyanaxTableDAO.getMillisecondPrecisionZonedDateTime(zeroSecondDateTime), "2017-01-01T07:01:00.000Z");
+        assertEquals(AstyanaxTableDAO.getMillisecondPrecisionZonedDateTime(zeroMilliSecondDateTime), "2017-01-01T07:01:01.000Z");
     }
 
     //


### PR DESCRIPTION
…hat it always include seconds and milliseconds so as to not encounter any parsing errors.

## Github Issue #

## What Are We Doing Here?

Stash Generator failed randomly on one day as it failed to read unpublished databus events. It turns out that it was because one databus event has a delta with date time value with no seconds as it happened at zeroth second and zeroth millisecond, and this lead to a parsing error. The standard ISO-8601 format omits some time components  where the omitted parts are implied to be zero. 
This PR would serialize the DateTime string to put back those zeros so that we do not encounter any parsing issues when deserializing. 
   
## How to Test and Verify

1. Run the commands mentioned in the ticket to understand the current behavior.
2. Run the added tests to verify the change. 
3. Run the existing UnPublishedDatabusEvents tests in TableLifeCycleTest to make sure there is no regression, and it works with all cases. 

## Risk


### Level 

`Low`, `Medium`, or `High`. Give an indication of what you think is the level of change introduced by this PR. `High` means a massive change to a core functionality. 
`Low` means a really minor change that shouldn't have any regression effect. 

### Required Testing

`Smoke`, `Regression`, or `Manual`. (All changes except documentation need smoke
testing at a minimum).

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
