### PR TITLE
Send null tombstones to kafka

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -33,5 +33,10 @@
             <artifactId>kafka-streams</artifactId>
             <version>2.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/JsonPOJOSerde.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/JsonPOJOSerde.java
@@ -46,6 +46,9 @@ public class JsonPOJOSerde<T> implements Serde<T> {
 
             @Override
             public byte[] serialize(String topic, T data) {
+                if (data == null) {
+                    return null;
+                }
                 try {
                     return mapper.writeValueAsBytes(data);
                 } catch (Exception e) {
@@ -71,6 +74,11 @@ public class JsonPOJOSerde<T> implements Serde<T> {
 
             @Override
             public T deserialize(String topic, byte[] data) {
+
+                if (data == null) {
+                    return null;
+                }
+
                 T result;
                 try {
                     result = typeReference != null ? mapper.readValue(data, typeReference) : mapper.readValue(data, cls);

--- a/kafka/src/test/java/com/bazaarvoice/emodb/kafka/JsonPOJOSerdeTest.java
+++ b/kafka/src/test/java/com/bazaarvoice/emodb/kafka/JsonPOJOSerdeTest.java
@@ -1,0 +1,80 @@
+package com.bazaarvoice.emodb.kafka;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class JsonPOJOSerdeTest {
+
+    @Test
+    public void testPOJO() {
+        JsonPOJOSerde<TestPOJO> jsonPOJOSerde = new JsonPOJOSerde<>(TestPOJO.class);
+
+        TestPOJO testPOJO = new TestPOJO(1, "hello");
+
+        byte[] serializedResult = jsonPOJOSerde.serializer().serialize("", testPOJO);
+        TestPOJO deserializedResult = jsonPOJOSerde.deserializer().deserialize("", serializedResult);
+
+        assertEquals(new String(serializedResult), "{\"val1\":1,\"val2\":\"hello\"}");
+        assertEquals(deserializedResult, testPOJO);
+    }
+
+    @Test
+    public void testList() {
+        JsonPOJOSerde<List<TestPOJO>> jsonPOJOSerde = new JsonPOJOSerde<>(new TypeReference<List<TestPOJO>>() {});
+        List<TestPOJO> testPOJOList = Collections.singletonList(new TestPOJO(1, "hello"));
+        byte[] serializedResult = jsonPOJOSerde.serializer().serialize("", testPOJOList);
+        List<TestPOJO> deserializedResult = jsonPOJOSerde.deserializer().deserialize("", serializedResult);
+        assertEquals(new String(serializedResult), "[{\"val1\":1,\"val2\":\"hello\"}]");
+        assertEquals(deserializedResult, testPOJOList);
+    }
+
+    @Test
+    public void testNull() {
+        JsonPOJOSerde<TestPOJO> jsonPOJOSerde = new JsonPOJOSerde<>(TestPOJO.class);
+        TestPOJO nullTestPOJO = null;
+
+        byte[] serializedResult = jsonPOJOSerde.serializer().serialize("", null);
+        TestPOJO deserializedResult = jsonPOJOSerde.deserializer().deserialize("", serializedResult);
+
+        assertNull(serializedResult);
+        assertNull(deserializedResult);
+        assertEquals(serializedResult, deserializedResult);
+    }
+
+    private static class TestPOJO {
+
+        private int val1;
+        private String val2;
+
+        public TestPOJO(int val1, String val2) {
+            this.val1 = val1;
+            this.val2 = val2;
+        }
+
+        public TestPOJO() {
+        }
+
+        public int getVal1() {
+            return val1;
+        }
+
+        public String getVal2() {
+            return val2;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof TestPOJO)) return false;
+            TestPOJO testPOJO = (TestPOJO) o;
+            return getVal1() == testPOJO.getVal1() &&
+                    Objects.equals(getVal2(), testPOJO.getVal2());
+        }
+    }
+}


### PR DESCRIPTION
## Github Issue #

[1234](https://github.com/bazaarvoice/emodb/issues/11)

## What Are We Doing Here?

The megabus is currently writing tombstones as the string "null" and instead of the value null due to a bug in the `JsonPOJOSerde`. This PR fixes this issue and adds a test.

## How to Test and Verify

1. Check out this PR
2. Run Kafka and Zookeeper locally
3. Build emo and run the megabus with `mvn clean verify -P init-cassandra,start-emodb-megabus-role
4. create a table and delete a document
5. check the megabus topic for null

**Note**: The above verification instructions doesn't really verify that we are sending `null` and not `"null"`, as they will be printed the same by the console consumer (which is why this bug got past me the first time). For this reason, I added an explicit unit test, and we will also do testing via Legion and the Megabus Stash.

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The risk on this is low, as the code change is small, and the megabus service is not even in production yet.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
