### PR TITLE
Upgrade Kafka libraries to 2.3.0

### DIFF
--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -26,12 +26,10 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>

--- a/megabus/pom.xml
+++ b/megabus/pom.xml
@@ -42,12 +42,10 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.12</artifactId>
-            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -44,6 +44,7 @@
         <jersey.version>1.18.1</jersey.version>
         <jacoco.version>0.7.2.201409121644</jacoco.version>
         <cassandra.driver.version>3.1.1</cassandra.driver.version>
+        <kafka.version>2.3.0</kafka.version>
         <dependency-check-maven.version>1.4.2</dependency-check-maven.version>
         <skipCC>true</skipCC>
         <nexus.autoReleaseAfterClose>true</nexus.autoReleaseAfterClose>
@@ -350,6 +351,18 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>1.11</version>
+            </dependency>
+
+            <!-- Megabus dependencies -->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_2.12</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-streams</artifactId>
+                <version>${kafka.version}</version>
             </dependency>
 
             <!-- Test dependencies -->


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

While testing the megabus, we see the following log mesage:
```
INFO  [2019-08-26 18:45:37,012] org.apache.kafka.clients.FetchSessionHandler: [Consumer clientId=10.110.68.92:8080-resolver-StreamThread-4-consumer, groupId=anon-megabus-us-resolver] Node 3 was unable to process the fetch request with (sessionId=81741431, epoch=72901): INVALID_FETCH_SESSION_EPOCH.
```
According to https://issues.apache.org/jira/browse/KAFKA-8052, this is fixed in 2.3.0.

This PR updates our Kafka libraries to 2.3.0

## How to Test and Verify

There is no great way to test this locally other than booting up the megabus and making sure everything works as expected.

## Risk

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

The risk here is that there is some incompatibility with the most recent version that we are unaware of.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
