### PR TITLE
Megabus boot should scan all data, not just live tables

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/megabus/StashMegabusBootDAO.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/megabus/StashMegabusBootDAO.java
@@ -27,6 +27,7 @@ public class StashMegabusBootDAO implements MegabusBootDAO {
     public void initiateBoot(String applicationId, Topic topic) {
         ScanOptions scanOptions = new ScanOptions(_dataTools.getTablePlacements(false, true));
         scanOptions.setTemporalEnabled(false);
+        scanOptions.setOnlyScanLiveRanges(false);
         scanOptions.addDestination(ScanDestination.to(URI.create("kafka://" + topic.getName())));
 
         _scanUploader.scanAndUpload(applicationId, scanOptions).start();

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
@@ -42,6 +42,8 @@ public class ScanOptions {
     private boolean _compactionEnabled = false;
     // Whether or not to stash temporally
     private boolean _temporalEnabled = true;
+    // Whether or not to only scan live ranges according to StashTableDAO
+    private boolean _onlyScanLiveRanges = true;
 
     public ScanOptions(String placement) {
         this(ImmutableSortedSet.of(placement));
@@ -60,7 +62,8 @@ public class ScanOptions {
                         @JsonProperty ("rangeScanSplitSize") Integer rangeScanSplitSize,
                         @JsonProperty ("maxRangeScanTime") Long maxRangeScanTime,
                         @JsonProperty ("compactionEnabled") Boolean compactionEnabled,
-                        @JsonProperty ("temporalEnabled") Boolean temporalEnabled) {
+                        @JsonProperty ("temporalEnabled") Boolean temporalEnabled,
+                        @JsonProperty ("onlyScanLiveRanges") Boolean onlyScanLiveRanges) {
         this(placements);
         if (destinations != null) {
             addDestinations(destinations);
@@ -82,6 +85,9 @@ public class ScanOptions {
         }
         if (temporalEnabled != null) {
             _temporalEnabled = temporalEnabled;
+        }
+        if (onlyScanLiveRanges != null) {
+            _onlyScanLiveRanges = onlyScanLiveRanges;
         }
     }
 
@@ -167,6 +173,14 @@ public class ScanOptions {
 
     public void setTemporalEnabled(boolean temporalEnabled) {
         _temporalEnabled = temporalEnabled;
+    }
+
+    public boolean isOnlyScanLiveRanges() {
+        return _onlyScanLiveRanges;
+    }
+
+    public void setOnlyScanLiveRanges(boolean onlyScanLiveRanges) {
+        _onlyScanLiveRanges = onlyScanLiveRanges;
     }
 
     @Override

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/LocalScanUploadMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/LocalScanUploadMonitor.java
@@ -235,8 +235,10 @@ public class LocalScanUploadMonitor extends AbstractService {
         }
 
         // Before going any further ensure the stash table snapshot has been created and, if not, do so now.
-        // This should only happen prior to the first scan range being processed.
-        if (!status.isTableSnapshotCreated() && status.getOptions().isTemporalEnabled()) {
+        // This should only happen if both
+        // 1. it is prior to the first scan range being processed.
+        // 2. the scan being processed is configured to only scan live table ranges
+        if (!status.isTableSnapshotCreated() && status.getOptions().isOnlyScanLiveRanges()) {
             _dataTools.createStashTokenRangeSnapshot(id, status.getOptions().getPlacements());
             _scanStatusDAO.setTableSnapshotCreated(id);
         }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/LocalScanUploadMonitor.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/control/LocalScanUploadMonitor.java
@@ -236,7 +236,7 @@ public class LocalScanUploadMonitor extends AbstractService {
 
         // Before going any further ensure the stash table snapshot has been created and, if not, do so now.
         // This should only happen prior to the first scan range being processed.
-        if (!status.isTableSnapshotCreated()) {
+        if (!status.isTableSnapshotCreated() && status.getOptions().isTemporalEnabled()) {
             _dataTools.createStashTokenRangeSnapshot(id, status.getOptions().getPlacements());
             _scanStatusDAO.setTableSnapshotCreated(id);
         }
@@ -402,7 +402,7 @@ public class LocalScanUploadMonitor extends AbstractService {
     private void scanCanceled(ScanStatus status) {
         // Send notification that the scan has been canceled
         _stashStateListener.stashCanceled(status.asPluginStashMetadata(), new Date());
-        cleanupScan(status.getScanId());
+        cleanupScan(status.getScanId(), status.getOptions().isOnlyScanLiveRanges());
     }
 
     private void completeScan(ScanStatus status)
@@ -430,21 +430,23 @@ public class LocalScanUploadMonitor extends AbstractService {
             status.setCompleteTime(completeTime);
             _stashStateListener.stashCompleted(status.asPluginStashMetadata(), status.getCompleteTime());
         } finally {
-            cleanupScan(id);
+            cleanupScan(id, status.getOptions().isOnlyScanLiveRanges());
         }
     }
 
-    private void cleanupScan(String id) {
+    private void cleanupScan(String id, boolean isOnlyLiveRanges) {
         // Remove this scan from the active set
         if (_activeScans.remove(id)) {
             notifyActiveScanCountChanged();
         }
 
-        try {
-            // Remove the table snapshots set for this scan
-            _dataTools.clearStashTokenRangeSnapshot(id);
-        } catch (Exception e) {
-            _log.error("Failed to clean up table set for scan {}", id, e);
+        if (isOnlyLiveRanges) {
+            try {
+                // Remove the table snapshots set for this scan
+                _dataTools.clearStashTokenRangeSnapshot(id);
+            } catch (Exception e) {
+                _log.error("Failed to clean up table set for scan {}", id, e);
+            }
         }
 
         try {


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

During testing, we have seen some discrepancies between the megabus and stash. We have theorized that this discrepancy is caused by a bug in `CQLStashTableDAO` that we have yet to explicitly identify. This PR configures the megabus to not use `CQLStashTableDAO`, which will hopefully resolve our discrepancy

## How to Test and Verify

1. Check out this PR 
2. Run the megabus
3. After boot, ensure that the `stash_token_range` table does not exist in Cassandra


## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

This PR does not affect the operation of traditional stash, and is therefore low risk. There **is** risk that we will hurt performance of the megabus boot. I am not worried about this currently, as boot speed doesn't really matter, and this feature is likely a temporary solution until we figure what is ailing stash.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
