### PR TITLE
Prevent internal tables from being written to the megabus

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/rangescan/LocalRangeScanUploader.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/rangescan/LocalRangeScanUploader.java
@@ -272,8 +272,10 @@ public class LocalRangeScanUploader implements RangeScanUploader, Managed {
             Iterator<MultiTableScanResult> allResults = _dataTools.stashMultiTableScan(scanId, placement, scanRange,
                     LimitCounter.max(), ReadConsistency.STRONG, cutoffTime);
 
+            Iterator<MultiTableScanResult> nonInternalResults = Iterators.filter(allResults, result -> !result.getTable().isInternal());
+
             // Enforce a maximum number of results based on the scan options
-            Iterator<MultiTableScanResult> results = Iterators.limit(allResults, getResplitRowCount(options));
+            Iterator<MultiTableScanResult> results = Iterators.limit(nonInternalResults, getResplitRowCount(options));
 
             while (results.hasNext() && !timeout.isTimedOut()) {
                 MultiTableScanResult result = results.next();


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?
During the last megabus boot, I observed documents from `__system_migrate` on the megabus. Because this table starts with `__`, it is technically internal and should not be on the megabus. 

This PR modifies stash to ignore internal tables in order to fix this issue. Previously, stash never scanned internal tables, as its placement list did not include any placements which contained internal tables.

## How to Test and Verify

1. Boot Emo locally
2. Create a table that starts with `__` and add some documents to it
3. run the megabus and ensure that its boot does not produce any documents from tables that begin with `__`

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The risk here is extremely low, as the changeset is small, and no tables in traditional stash will match the filter put in place.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
