### PR TITLE
Reduce flush calls during megabus boot

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
@@ -69,7 +69,7 @@ public class KafkaScanDestinationWriter implements ScanDestinationWriter {
                     coordinate = coordinateAndFuture.getCoordinate();
                     RecordMetadata recordMetadata = coordinateAndFuture.getFuture().get();
                     _bytesTransferred += recordMetadata.serializedKeySize() + recordMetadata.serializedValueSize();
-                } else if (_futureGettingService.isShutdown()) {
+                } else if (_futureGettingService.isShutdown() && _futureQueue.isEmpty()) {
                     break;
                 }
             } catch (Exception e) {
@@ -112,7 +112,6 @@ public class KafkaScanDestinationWriter implements ScanDestinationWriter {
     @Override
     public void closeAndTransferAsync(Optional<Integer> finalPartCount) throws IOException {
         _closed = true;
-        _producer.flush();
         _futureGettingService.shutdown();
     }
 


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Currently megabus boot experiences many timeout failures due to the frequency that is calls `flush` on its Kafka Producer. This PR removes an unnecessary flush call. 

## How to Test and Verify

This one is pretty hard to verify, as it is purely a performance modification, and it will only reveal it self at high scale. Static code analysis will have to do here.

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

This change does not really add any risk by itself. The main things to think about here are:
1. this fix may or may not be a fix to our missing documents issue
2. this may or may not actually increase performance
3. it is theoretically possible that this could make the missing documents issue worse

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
