### PR TITLE
EMO-7116 revert nexus-staging-maven-plugin version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -452,6 +452,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.2</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Release to oss sonatype nexus fails with new plugin version.
This PR reverts nexus-staging-maven-plugin.

## How to Test and Verify

1. Check out this PR
2. Release new emodb version
3. Profit

## Risk

### Level 

`Low`
### Required Testing

`Manual`

### Risk Summary

Add one or a few complete sentences about the possible risks or concerns for
this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
