### PR TITLE
Make megabus kafka producer configurable

### DIFF
--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaConfiguration.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaConfiguration.java
@@ -20,7 +20,7 @@ public class KafkaConfiguration {
         return _kafkaBootstrapServers;
     }
 
-    public String getKafkaBootstrapServers() {
-        return _kafkaBootstrapServers;
+    public KafkaProducerConfiguration getKafkaProducerConfiguration() {
+        return _kafkaProducerConfiguration;
     }
 }

--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaConfiguration.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaConfiguration.java
@@ -11,7 +11,16 @@ public class KafkaConfiguration {
     @JsonProperty("bootstrapServers")
     private String _kafkaBootstrapServers;
 
+    @Valid
+    @NotNull
+    @JsonProperty("producer")
+    private KafkaProducerConfiguration _kafkaProducerConfiguration = new KafkaProducerConfiguration();
+
     public String getBootstrapServers() {
+        return _kafkaBootstrapServers;
+    }
+
+    public String getKafkaBootstrapServers() {
         return _kafkaBootstrapServers;
     }
 }

--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaModule.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaModule.java
@@ -17,8 +17,8 @@ public class KafkaModule extends PrivateModule {
     @Provides
     @Singleton
     @BootstrapServers
-    String provideBootstrapServers(KafkaConfiguration megabusConfiguration) {
-        return megabusConfiguration.getBootstrapServers();
+    String provideBootstrapServers(KafkaConfiguration kafkaConfiguration) {
+        return kafkaConfiguration.getBootstrapServers();
     }
 
 
@@ -28,6 +28,12 @@ public class KafkaModule extends PrivateModule {
         Properties properties = new Properties();
         properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         return AdminClient.create(properties);
+    }
+
+    @Provides
+    @Singleton
+    KafkaProducerConfiguration provideKafkaProducerConfiguration(KafkaConfiguration kafkaConfiguration) {
+        return kafkaConfiguration.getKafkaProducerConfiguration();
     }
 
 }

--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaProducerConfiguration.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaProducerConfiguration.java
@@ -1,0 +1,35 @@
+package com.bazaarvoice.emodb.kafka;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Optional;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class KafkaProducerConfiguration {
+    @Valid
+    @NotNull
+    @JsonProperty("bufferMemory")
+    private Optional<Long> _bufferMemory = Optional.empty();
+
+    @Valid
+    @NotNull
+    @JsonProperty("batchSize")
+    private Optional<Integer> _batchsize = Optional.empty();
+
+    @Valid
+    @NotNull
+    @JsonProperty("lingerMs")
+    private Optional<Long> _lingerMs = Optional.empty();
+
+    public Optional<Long> getBufferMemory() {
+        return _bufferMemory;
+    }
+
+    public Optional<Integer> getBatchsize() {
+        return _batchsize;
+    }
+
+    public Optional<Long> getLingerMs() {
+        return _lingerMs;
+    }
+}

--- a/web-local/config-megabus.yaml
+++ b/web-local/config-megabus.yaml
@@ -56,6 +56,8 @@ dataCenter:
 
 kafka:
   bootstrapServers: localhost:9092
+  producer:
+    lingerMs: 5
 
 megabus:
   applicationId: megabus-local


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

Currently the megabus's Kafka producer uses static config as defined in `DefaultKafkaCluster.java`. The configuration of `linger.ms`, `batch.size`, and `buffer.memory` do not affect data correctness, but can greatly impact performance. This PR makes these configurable so that we can tinker and maximize throughput during boot.

## How to Test and Verify

1. Check out this PR
2. Configure the producer the way you want it in `config-megabus.yaml`
3. Run the megabus
4. check the logs for the producer configuration  that you set and ensure that it as intended 

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

The code changes here are very straightforward and contained. The only risk here is that there may be different optimal configurations for boot time and normal operating time, which may mean that we will have to remember to configure the megabus differently in certain situations.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
