### PR TITLE
Fix possible race condition in megabus boot

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
@@ -21,6 +21,11 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This class writes documents to Kafka asynchronously, then cleans up the futures using the future service. Access to
+ * this class is multi-threaded. A single thread is responsible for calling {@link #writeDocument(Map)},
+ * {@link #closeAndCancel()}, and {@link #closeAndTransferAsync(Optional)}. A separate threads calls {@link #isFinishedUploading()}
+ */
 public class KafkaScanDestinationWriter implements ScanDestinationWriter {
 
     private static Logger _log = LoggerFactory.getLogger(KafkaScanDestinationWriter.class);

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
@@ -105,8 +105,8 @@ public class KafkaScanDestinationWriter implements ScanDestinationWriter {
     @Override
     public void closeAndCancel() {
         _closed = true;
-        _futureGettingService.shutdownNow();
         _error.compareAndSet(null, new RuntimeException("Kafka upload canceled."));
+        _futureGettingService.shutdownNow();
     }
 
     @Override

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
@@ -104,8 +104,8 @@ public class KafkaScanDestinationWriter implements ScanDestinationWriter {
 
     @Override
     public void closeAndCancel() {
+        _error.compareAndSet(null, new RuntimeException("Kafka upload canceled.")); 
         _closed = true;
-        _error.compareAndSet(null, new RuntimeException("Kafka upload canceled."));
         _futureGettingService.shutdownNow();
     }
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/writer/KafkaScanDestinationWriter.java
@@ -31,7 +31,7 @@ public class KafkaScanDestinationWriter implements ScanDestinationWriter {
     private final BlockingQueue<CoordinateAndFuture> _futureQueue;
     private final ExecutorService _futureGettingService;
     private final AtomicReference<Throwable> _error = new AtomicReference<>();
-    private boolean _closed;
+    private volatile boolean _closed;
     private int _bytesTransferred;
     private int _bytesAdded;
 


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

There is a race condition in the failure handling the megabus boot. It currently _may_ be possible for a call to `isFinishedUploading` to return true before the error is set within `closeAndCancel`. This PR modifies `closeAndCancel` to set the error before shutting down the `_futureGettingService`. 

Additionally, I have marked `_closed` as volatile to avoid any possibility of it being read incorrectly from CPU cache.

In regards to both of these changes above, all interaction with this class is from a single thread as far as I know, but this gives us some protection if we're wrong.

## How to Test and Verify

The code change here is extremely small and likely completely non-consequential. There isn't really any verification that can be done.

## Risk

### Level 

`Low`

### Required Testing

`Regression`

### Risk Summary

I can't think of any legitimate risk here.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
