### PR TITLE
Configure stream threads on Kafka Streams

### DIFF
--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -62,7 +62,8 @@ public class MegabusRefResolver extends KafkaStreamsService {
                               HostAndPort hostAndPort,
                               String refResolverConsumerGroup,
                               MetricRegistry metricRegistry) {
-        super(SERVICE_NAME, kafkaCluster.getBootstrapServers(), hostAndPort.toString(), refResolverConsumerGroup, metricRegistry);
+        super(SERVICE_NAME, kafkaCluster.getBootstrapServers(), hostAndPort.toString(),
+                refResolverConsumerGroup, megabusRefTopic.getPartitions(), metricRegistry);
         _dataProvider = checkNotNull(dataProvider, "dataProvider");
         _megabusRefTopic = checkNotNull(megabusRefTopic, "megabusRefTopic");
         _megabusResolvedTopic = checkNotNull(megabusResolvedTopic, "megabusResolvedTopic");

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MissingRefDelayProcessor.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MissingRefDelayProcessor.java
@@ -38,7 +38,8 @@ public class MissingRefDelayProcessor extends KafkaStreamsService {
                                     HostAndPort hostAndPort,
                                     String delayProcessorConsumerGroup,
                                     MetricRegistry metricRegistry) {
-        super(SERVICE_NAME, kafkaCluster.getBootstrapServers(), hostAndPort.toString(), delayProcessorConsumerGroup, metricRegistry);
+        super(SERVICE_NAME, kafkaCluster.getBootstrapServers(), hostAndPort.toString(),
+                delayProcessorConsumerGroup, 1, metricRegistry);
 
         _retryRefTopic = checkNotNull(retryRefTopic, "retryRefTopic");
         _missingRefTopic = checkNotNull(missingRefTopic, "missingRefTopic");

--- a/megabus/src/main/java/com/bazaarvoice/megabus/service/KafkaStreamsService.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/service/KafkaStreamsService.java
@@ -26,6 +26,7 @@ public abstract class KafkaStreamsService extends AbstractService implements Kaf
                                String bootstrapServers,
                                String instanceId,
                                String consumerGroupName,
+                               int streamThreads,
                                MetricRegistry metricRegistry) {
         _uncaughtException = new AtomicReference<>();
         _fatalErrorEncountered = new AtomicBoolean(false);
@@ -39,6 +40,8 @@ public abstract class KafkaStreamsService extends AbstractService implements Kaf
         _streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 
         _streamsConfiguration.put(StreamsConfig.METRIC_REPORTER_CLASSES_CONFIG, DropwizardMetricsReporter.class.getName());
+
+        _streamsConfiguration.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, streamThreads);
 
         _streamsConfiguration.put(StreamsConfig.producerPrefix(ProducerConfig.ACKS_CONFIG), "all");
 


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

In #264, I accidentally removed our stream thread configuration from Kafka Streams. This PR adds the config back, as it is critical to throughput.

## How to Test and Verify

Not much testing really needed here. If you want to be thorough, check the logs when the megabus is running locally and look at the number of stream threads.

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

I have no concerns about this change.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
