### PR TITLE
Temporary make table operations (except createTable) admin only

### DIFF
--- a/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
+++ b/quality/integration/src/test/java/test/integration/sor/DataStoreJerseyTest.java
@@ -115,6 +115,7 @@ public class DataStoreJerseyTest extends ResourceTest {
     private static final String APIKEY_REVIEWS_ONLY = "reviews-only-key";
     private static final String APIKEY_STANDARD = "standard-key";
     private static final String APIKEY_STANDARD_UPDATE = "standard-update";
+    private static final String APIKEY_ADMIN = "standard-admin";
 
     private DataStore _server = mock(DataStore.class);
     private DataCenters _dataCenters = mock(DataCenters.class);
@@ -131,6 +132,7 @@ public class DataStoreJerseyTest extends ResourceTest {
         authIdentityManager.createIdentity(APIKEY_REVIEWS_ONLY, new ApiKeyModification().addRoles("reviews-only-role"));
         authIdentityManager.createIdentity(APIKEY_STANDARD, new ApiKeyModification().addRoles("standard"));
         authIdentityManager.createIdentity(APIKEY_STANDARD_UPDATE, new ApiKeyModification().addRoles("update-with-events"));
+        authIdentityManager.createIdentity(APIKEY_ADMIN, new ApiKeyModification().addRoles("admin-role"));
 
         EmoPermissionResolver permissionResolver = new EmoPermissionResolver(_server, mock(BlobStore.class));
         InMemoryPermissionManager permissionManager = new InMemoryPermissionManager(permissionResolver);
@@ -143,6 +145,7 @@ public class DataStoreJerseyTest extends ResourceTest {
         createRole(roleManager, null, "reviews-only-role", ImmutableSet.of("sor|*|if({..,\"type\":\"review\"})"));
         createRole(roleManager, null, "standard", DefaultRoles.standard.getPermissions());
         createRole(roleManager, null, "update-with-events", ImmutableSet.of("sor|update|*"));
+        createRole(roleManager, null, "admin-role", ImmutableSet.of("*"));
 
         return setupResourceTestRule(Collections.<Object>singletonList(
                 new DataStoreResource1(_server, mock(DataStoreAsync.class), new InMemoryCompactionControlSource(), new UnlimitedDataStoreUpdateThrottler())),
@@ -560,10 +563,28 @@ public class DataStoreJerseyTest extends ResourceTest {
         when(dataCenter.isSystem()).thenReturn(true);
 
         Audit audit = new AuditBuilder().setLocalHost().build();
-        sorClient(APIKEY_TABLE).dropTable("table-name", audit);
+        sorClient(APIKEY_ADMIN).dropTable("table-name", audit);
 
         verify(_server).dropTable("table-name", audit);
         verify(_dataCenters, never()).getSelf();
+        verifyNoMoreInteractions(_server, _dataCenters);
+    }
+
+    @Test
+    public void testDropTableForbiddenIfNotAdmin() {
+        DataCenter dataCenter = mock(DataCenter.class);
+        when(dataCenter.getName()).thenReturn("mock-datacenter");
+        when(_dataCenters.getSelf()).thenReturn(dataCenter);
+        when(dataCenter.isSystem()).thenReturn(true);
+
+        Audit audit = new AuditBuilder().setLocalHost().build();
+        try {
+            sorClient(APIKEY_TABLE).dropTable("table-name", audit);
+            fail();
+        } catch (Exception e) {
+            assertTrue(e instanceof UnauthorizedException);
+        }
+
         verifyNoMoreInteractions(_server, _dataCenters);
     }
 
@@ -772,7 +793,7 @@ public class DataStoreJerseyTest extends ResourceTest {
     @Test
     public void testSetTableTemplate() {
         Audit audit = new AuditBuilder().setLocalHost().build();
-        sorClient(APIKEY_TABLE).setTableTemplate("table-name", ImmutableMap.<String, Object>of("key", "value"), audit);
+        sorClient(APIKEY_ADMIN).setTableTemplate("table-name", ImmutableMap.<String, Object>of("key", "value"), audit);
 
         verify(_server).setTableTemplate("table-name", ImmutableMap.<String, Object>of("key", "value"), audit);
         verifyNoMoreInteractions(_server);

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
@@ -105,6 +105,9 @@ import static java.lang.String.format;
 public class DataStoreResource1 {
     private static final Logger _log = LoggerFactory.getLogger(DataStoreResource1.class);
 
+    private static final String TEMPORARY_UNAUTHORIZED_MESSAGE =
+            "Modifying the metadata of existing tables is temporarily disabled for EmoDB users. Contact the database administrator for assistance";
+
     /**
      * To distinguish between UUID and timestamps, assume anything that looks like "hex-hex-hex-hex-hex" is a UUID.
      */
@@ -211,8 +214,14 @@ public class DataStoreResource1 {
     )
     public SuccessResponse dropTable(@PathParam ("table") String table,
                                      @QueryParam ("audit") AuditParam auditParam,
-                                     @Context UriInfo uriInfo) {
+                                     @Context UriInfo uriInfo,
+                                     @Authenticated Subject subject) {
         Audit audit = getRequired(auditParam, "audit");
+
+        if (!subject.hasPermission(Permissions.unlimited())) {
+            throw new UnauthorizedException(TEMPORARY_UNAUTHORIZED_MESSAGE);
+        }
+
         _dataStore.dropTable(table, audit);
         return SuccessResponse.instance();
     }
@@ -247,9 +256,15 @@ public class DataStoreResource1 {
     public SuccessResponse dropFacade(@PathParam ("table") String table,
                                       @QueryParam ("audit") AuditParam auditParam,
                                       @QueryParam ("placement") String placement,
-                                      @Context UriInfo uriInfo) {
+                                      @Context UriInfo uriInfo,
+                                      @Authenticated Subject subject) {
         checkArgument(!Strings.isNullOrEmpty(placement), "Missing required placement.");
         Audit audit = getRequired(auditParam, "audit");
+
+        if (!subject.hasPermission(Permissions.unlimited())) {
+            throw new UnauthorizedException(TEMPORARY_UNAUTHORIZED_MESSAGE);
+        }
+
         _dataStore.dropFacade(table, placement, audit);
         return SuccessResponse.instance();
     }
@@ -264,8 +279,14 @@ public class DataStoreResource1 {
             response = SuccessResponse.class
     )
     public Map<String, Object> purgeTableAsync(@PathParam ("table") String table,
-                                               @QueryParam ("audit") AuditParam auditParam) {
+                                               @QueryParam ("audit") AuditParam auditParam,
+                                               @Authenticated Subject subject) {
         Audit audit = getRequired(auditParam, "audit");
+
+        if (!subject.hasPermission(Permissions.unlimited())) {
+            throw new UnauthorizedException(TEMPORARY_UNAUTHORIZED_MESSAGE);
+        }
+
         String jobID = _dataStoreAsync.purgeTableAsync(table, audit);
         return ImmutableMap.<String, Object>of("id", jobID);
     }
@@ -308,8 +329,14 @@ public class DataStoreResource1 {
     public SuccessResponse setTableTemplate(@PathParam ("table") String table,
                                             Map<String, Object> template,
                                             @QueryParam ("audit") AuditParam auditParam,
-                                            @Context UriInfo uriInfo) {
+                                            @Context UriInfo uriInfo,
+                                            @Authenticated Subject subject) {
         Audit audit = getRequired(auditParam, "audit");
+
+        if (!subject.hasPermission(Permissions.unlimited())) {
+            throw new UnauthorizedException(TEMPORARY_UNAUTHORIZED_MESSAGE);
+        }
+
         _dataStore.setTableTemplate(table, template, audit);
         return SuccessResponse.instance();
     }

--- a/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
@@ -1,5 +1,6 @@
 package com.bazaarvoice.emodb.web.purge;
 
+import com.bazaarvoice.emodb.auth.jersey.Subject;
 import com.bazaarvoice.emodb.common.dropwizard.lifecycle.LifeCycleRegistry;
 import com.bazaarvoice.emodb.common.uuid.TimeUUIDs;
 import com.bazaarvoice.emodb.job.api.JobIdentifier;
@@ -24,6 +25,7 @@ import com.bazaarvoice.emodb.sor.core.PurgeRequest;
 import com.bazaarvoice.emodb.sor.core.PurgeResult;
 import com.bazaarvoice.emodb.sor.core.test.InMemoryDataStore;
 import com.bazaarvoice.emodb.sor.delta.Deltas;
+import com.bazaarvoice.emodb.web.auth.Permissions;
 import com.bazaarvoice.emodb.web.resources.sor.AuditParam;
 import com.bazaarvoice.emodb.web.resources.sor.DataStoreResource1;
 import com.bazaarvoice.emodb.web.throttling.UnlimitedDataStoreUpdateThrottler;
@@ -45,6 +47,7 @@ import java.util.Objects;
 import static com.bazaarvoice.emodb.job.api.JobIdentifier.createNew;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
 
 
@@ -141,7 +144,9 @@ public class PurgeTest {
         assertTrue(purgeStatus.get("status").toString().equals("IN_PROGRESS"));
 
         // calling job directly via calling purgeTableAsync on DataStoreResource1
-        Map<String, Object> jobID3Map = _dataStoreResource.purgeTableAsync(TABLE3, new AuditParam("audit=comment:'purgetest+comment'"));
+        Subject subject = mock(Subject.class);
+        when(subject.hasPermission(Permissions.unlimited())).thenReturn(true);
+        Map<String, Object> jobID3Map = _dataStoreResource.purgeTableAsync(TABLE3, new AuditParam("audit=comment:'purgetest+comment'"), subject);
         Map<String, Object> purgeStatus3 = _dataStoreResource.getPurgeStatus(TABLE3, jobID3Map.get("id").toString());
         assertTrue(purgeStatus3.get("status").toString().equals("IN_PROGRESS"));
     }


### PR DESCRIPTION
## Github Issue #

`None`

## What Are We Doing Here?

In order to hit a deadline for megabus, we decided to avoid dealing with problems related to table state changes – specifically, table template updates and table deletions – for the short-term. In order to avoid dealing with these problems, we have to disable the API's that allow customers to delete tables or update table templates.

This implementation basically amounts to requiring an admin api key only for these particular API endpoints, thereby unauthorizing any customers from actually using it. Then when these API's are needed, we can manage the data on the megabus or whatever by hand, and then perform the API invocations ourselves.

Note: I specifically did not modify the permissions previously specified for the calls we are locking down here. Instead, I added an additionally admin check in implementation. I implemented it this way so that users that previously did not have access to these endpoints will experience the same response that they did before. Only users who are legitimately blocked by this change will receive the `TEMPORARY_UNAUTHORIZED_MESSAGE`.  

## How to Test and Verify

1. Check out this PR
2. Build and run emo
3. create an api key with `sor|*|*` permissions
4. create a table
5. try deleting the table with api created above
6. confirm that you receive the `TEMPORARY_UNAUTHORIZED_MESSAGE`.
7. try deleting the table with `local_admin`
8. confirm that the table was deleted successfully.

## Risk

### Level 

`Medium`

### Required Testing

`Manual`

### Risk Summary

The risk here is much more in the overall idea than the implementation. It is definitely possible that locking down table events could cause trouble.
 
## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
