### PR TITLE
EMO-7131 add kafka SSL support

### DIFF
--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/DefaultKafkaCluster.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/DefaultKafkaCluster.java
@@ -7,19 +7,22 @@ import com.google.common.base.Suppliers;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Futures;
 import com.google.inject.Inject;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ExecutionException;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.connect.json.JsonSerializer;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -31,9 +34,12 @@ public class DefaultKafkaCluster implements KafkaCluster {
     private final String _instanceIdentifier;
     private final KafkaProducerConfiguration _kafkaProducerConfiguration;
     private final Supplier<Producer<String, JsonNode>> _producerSupplier;
+    private final SslConfiguration _sslConfiguration;
 
     @Inject
-    public DefaultKafkaCluster(AdminClient adminClient, @BootstrapServers String bootstrapServers,
+    public DefaultKafkaCluster(AdminClient adminClient,
+                               @BootstrapServers String bootstrapServers,
+                               SslConfiguration sslConfiguration,
                                @SelfHostAndPort HostAndPort hostAndPort,
                                KafkaProducerConfiguration producerConfiguration) {
         _adminClient = requireNonNull(adminClient);
@@ -41,6 +47,7 @@ public class DefaultKafkaCluster implements KafkaCluster {
         _instanceIdentifier = requireNonNull(hostAndPort).toString();
         _kafkaProducerConfiguration = requireNonNull(producerConfiguration);
         _producerSupplier = Suppliers.memoize(this::createProducer);
+        _sslConfiguration = sslConfiguration;
     }
 
     @Override
@@ -59,12 +66,12 @@ public class DefaultKafkaCluster implements KafkaCluster {
     }
 
     private void checkTopicPropertiesMatching(Topic topic) {
-            TopicDescription topicDescription = Futures.getUnchecked(
-                    _adminClient.describeTopics(Collections.singleton(topic.getName())).all()).get(topic.getName());
+        TopicDescription topicDescription = Futures.getUnchecked(
+                _adminClient.describeTopics(Collections.singleton(topic.getName())).all()).get(topic.getName());
 
-            checkArgument(topicDescription.partitions().size() == topic.getPartitions());
-            topicDescription.partitions().forEach(topicPartitionInfo ->
-                    checkArgument(topicPartitionInfo.replicas().size() == topic.getReplicationFactor()));
+        checkArgument(topicDescription.partitions().size() == topic.getPartitions());
+        topicDescription.partitions().forEach(topicPartitionInfo ->
+                checkArgument(topicPartitionInfo.replicas().size() == topic.getReplicationFactor()));
     }
 
     private Producer<String, JsonNode> createProducer() {
@@ -92,6 +99,17 @@ public class DefaultKafkaCluster implements KafkaCluster {
             props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, _kafkaProducerConfiguration.getBufferMemory().get());
         }
 
+        if (null != _sslConfiguration) {
+            props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SslConfiguration.PROTOCOL);
+
+            props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, _sslConfiguration.getTrustStoreLocation());
+            props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, _sslConfiguration.getTrustStorePassword());
+
+            props.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, _sslConfiguration.getKeyStoreLocation());
+            props.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, _sslConfiguration.getKeyStorePassword());
+            props.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, _sslConfiguration.getKeyPassword());
+        }
+
         return new KafkaProducer<>(props);
     }
 
@@ -102,5 +120,10 @@ public class DefaultKafkaCluster implements KafkaCluster {
     @Override
     public String getBootstrapServers() {
         return _bootstrapServers;
+    }
+
+    @Override
+    public SslConfiguration getSSLConfiguration() {
+        return _sslConfiguration;
     }
 }

--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaCluster.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaCluster.java
@@ -2,8 +2,9 @@ package com.bazaarvoice.emodb.kafka;
 
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.Map;
 import org.apache.kafka.clients.producer.Producer;
+
+import java.util.Map;
 
 public interface KafkaCluster {
 
@@ -12,5 +13,7 @@ public interface KafkaCluster {
     Producer<String, JsonNode> producer();
 
     String getBootstrapServers();
+
+    SslConfiguration getSSLConfiguration();
 
 }

--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaConfiguration.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/KafkaConfiguration.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.emodb.kafka;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
@@ -10,6 +11,10 @@ public class KafkaConfiguration {
     @NotNull
     @JsonProperty("bootstrapServers")
     private String _kafkaBootstrapServers;
+
+    @Valid
+    @JsonProperty("ssl")
+    private SslConfiguration _sslConfiguration;
 
     @Valid
     @NotNull
@@ -22,5 +27,13 @@ public class KafkaConfiguration {
 
     public KafkaProducerConfiguration getKafkaProducerConfiguration() {
         return _kafkaProducerConfiguration;
+    }
+
+    public SslConfiguration getSslConfiguration() {
+        return _sslConfiguration;
+    }
+
+    public void setSslConfiguration(final SslConfiguration sslConfiguration) {
+        _sslConfiguration = sslConfiguration;
     }
 }

--- a/kafka/src/main/java/com/bazaarvoice/emodb/kafka/SslConfiguration.java
+++ b/kafka/src/main/java/com/bazaarvoice/emodb/kafka/SslConfiguration.java
@@ -1,0 +1,76 @@
+package com.bazaarvoice.emodb.kafka;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class SslConfiguration {
+
+    public final static String PROTOCOL = "SSL";
+
+    @Valid
+    @NotNull
+    @JsonProperty("trustStoreLocation")
+    private String _trustStoreLocation;
+
+    @Valid
+    @NotNull
+    @JsonProperty("trustStorePassword")
+    private String _trustStorePassword;
+
+    @Valid
+    @NotNull
+    @JsonProperty("keyStoreLocation")
+    private String _keyStoreLocation;
+
+    @Valid
+    @NotNull
+    @JsonProperty("keyStorePassword")
+    private String _keyStorePassword;
+
+    @Valid
+    @NotNull
+    @JsonProperty("keyPassword")
+    private String _keyPassword;
+
+    public String getTrustStoreLocation() {
+        return _trustStoreLocation;
+    }
+
+    public void setTrustStoreLocation(String trustStoreLocation) {
+        this._trustStoreLocation = trustStoreLocation;
+    }
+
+    public String getTrustStorePassword() {
+        return _trustStorePassword;
+    }
+
+    public void setTrustStorePassword(String trustStorePassword) {
+        this._trustStorePassword = trustStorePassword;
+    }
+
+    public String getKeyStoreLocation() {
+        return _keyStoreLocation;
+    }
+
+    public void setKeyStoreLocation(String keyStoreLocation) {
+        this._keyStoreLocation = keyStoreLocation;
+    }
+
+    public String getKeyStorePassword() {
+        return _keyStorePassword;
+    }
+
+    public void setKeyStorePassword(String keyStorePassword) {
+        this._keyStorePassword = keyStorePassword;
+    }
+
+    public String getKeyPassword() {
+        return _keyPassword;
+    }
+
+    public void setKeyPassword(String keyPassword) {
+        this._keyPassword = keyPassword;
+    }
+}

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -15,10 +15,17 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Table;
 import com.google.common.net.HostAndPort;
 import com.google.inject.Inject;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Date;
@@ -28,13 +35,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.Produced;
+
 import static java.util.Objects.requireNonNull;
 
 public class MegabusRefResolver extends KafkaStreamsService {
@@ -63,7 +64,7 @@ public class MegabusRefResolver extends KafkaStreamsService {
                               HostAndPort hostAndPort,
                               String refResolverConsumerGroup,
                               MetricRegistry metricRegistry) {
-        super(SERVICE_NAME, kafkaCluster.getBootstrapServers(), hostAndPort.toString(),
+        super(SERVICE_NAME, kafkaCluster, hostAndPort.toString(),
                 refResolverConsumerGroup, megabusRefTopic.getPartitions(), metricRegistry);
         _dataProvider = requireNonNull(dataProvider, "dataProvider");
         _megabusRefTopic = requireNonNull(megabusRefTopic, "megabusRefTopic");

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MissingRefDelayProcessor.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MissingRefDelayProcessor.java
@@ -3,15 +3,11 @@ package com.bazaarvoice.megabus.resolver;
 import com.bazaarvoice.emodb.kafka.JsonPOJOSerde;
 import com.bazaarvoice.emodb.kafka.KafkaCluster;
 import com.bazaarvoice.emodb.kafka.Topic;
-import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.megabus.MegabusRef;
 import com.bazaarvoice.megabus.service.KafkaStreamsService;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.net.HostAndPort;
-import java.time.Clock;
-import java.time.Instant;
-import java.util.List;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
@@ -19,6 +15,11 @@ import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
 import static java.util.Objects.requireNonNull;
 
 public class MissingRefDelayProcessor extends KafkaStreamsService {
@@ -31,14 +32,14 @@ public class MissingRefDelayProcessor extends KafkaStreamsService {
     private Clock _clock;
 
 
-    public MissingRefDelayProcessor(DataProvider dataProvider,
-                                    Topic retryRefTopic,
+    public MissingRefDelayProcessor(Topic retryRefTopic,
                                     Topic missingRefTopic,
-                                    KafkaCluster kafkaCluster, Clock clock,
+                                    KafkaCluster kafkaCluster,
+                                    Clock clock,
                                     HostAndPort hostAndPort,
                                     String delayProcessorConsumerGroup,
                                     MetricRegistry metricRegistry) {
-        super(SERVICE_NAME, kafkaCluster.getBootstrapServers(), hostAndPort.toString(),
+        super(SERVICE_NAME, kafkaCluster, hostAndPort.toString(),
                 delayProcessorConsumerGroup, 1, metricRegistry);
 
         _retryRefTopic = requireNonNull(retryRefTopic, "retryRefTopic");

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/ResilientMissingRefDelayProcessor.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/ResilientMissingRefDelayProcessor.java
@@ -3,7 +3,6 @@ package com.bazaarvoice.megabus.resolver;
 import com.bazaarvoice.emodb.common.dropwizard.guice.SelfHostAndPort;
 import com.bazaarvoice.emodb.kafka.KafkaCluster;
 import com.bazaarvoice.emodb.kafka.Topic;
-import com.bazaarvoice.emodb.sor.core.DataProvider;
 import com.bazaarvoice.megabus.guice.DelayProcessorConsumerGroup;
 import com.bazaarvoice.megabus.guice.MissingRefTopic;
 import com.bazaarvoice.megabus.guice.RetryRefTopic;
@@ -11,6 +10,7 @@ import com.bazaarvoice.megabus.service.ResilientService;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.net.HostAndPort;
 import com.google.inject.Inject;
+
 import java.time.Clock;
 import java.time.Duration;
 
@@ -20,15 +20,14 @@ public class ResilientMissingRefDelayProcessor extends ResilientService {
     private static Duration RESTART_DELAY = Duration.ofSeconds(30);
 
     @Inject
-    public ResilientMissingRefDelayProcessor(DataProvider dataProvider,
-                                             @RetryRefTopic Topic retryRefTopic,
+    public ResilientMissingRefDelayProcessor(@RetryRefTopic Topic retryRefTopic,
                                              @MissingRefTopic Topic missingRefTopic,
                                              KafkaCluster kafkaCluster, Clock clock,
                                              @SelfHostAndPort HostAndPort hostAndPort,
                                              @DelayProcessorConsumerGroup String delayProcessorConsumerGroup,
                                              MetricRegistry metricRegistry) {
         super(SERVICE_NAME,
-                () -> new MissingRefDelayProcessor(dataProvider, retryRefTopic, missingRefTopic,
+                () -> new MissingRefDelayProcessor(retryRefTopic, missingRefTopic,
                         kafkaCluster, clock, hostAndPort, delayProcessorConsumerGroup, metricRegistry),
                 RESTART_DELAY, false);
     }


### PR DESCRIPTION
## Github Issue #

`No`

## What Are We Doing Here?

Add TLS for megabus kafka connections.

## How to Test and Verify

1. Check out this PR
2. Setup SSL on kafka broker
3. Set/update `kafka.ssl` section in config
4. Start megabus service against Kafka broker

## Risk

### Level 

`Medium`

### Required Testing

`Manual`

### Risk Summary

As ssl config is optional, previous configuration will still work. However, if ssl config section is specified, it requires to be synced with Kafka broker config values.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
