### PR TITLE
Make MegabusRef POJO backward compatible with 6.0.7 schema

### DIFF
--- a/megabus/src/main/java/com/bazaarvoice/megabus/MegabusRef.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/MegabusRef.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 
+import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.UUID;
 
@@ -25,11 +26,11 @@ public class MegabusRef {
 
     @JsonCreator
     public MegabusRef(@JsonProperty("table") String table, @JsonProperty("key") String key,
-                     @JsonProperty("changeId") UUID changeId, @JsonProperty("readTime") Instant readTime) {
+                     @JsonProperty("changeId") UUID changeId, @JsonProperty("readTime") @Nullable Instant readTime) {
         _table = requireNonNull(table, "table");
         _key = requireNonNull(key, "key");
         _changeId = requireNonNull(changeId, "changeId");
-        _readTime = requireNonNull(readTime, "readTime");
+        _readTime = readTime;
     }
 
     public String getTable() {
@@ -44,6 +45,7 @@ public class MegabusRef {
         return _changeId;
     }
 
+    @Nullable
     public Instant getReadTime() {
         return _readTime;
     }

--- a/megabus/src/main/java/com/bazaarvoice/megabus/MegabusRef.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/MegabusRef.java
@@ -15,6 +15,9 @@ import static java.util.Objects.requireNonNull;
 /**
  * Reference to a System of Record update. Designed to be similar to {@link com.bazaarvoice.emodb.sor.core.UpdateRef},
  * but with more flexibility to add new fields without breaking serialization.
+ *
+ * Note that changes do need to be backward-compatible, as the outgoing Megabus will have inevitably written
+ * some records as the new Megabus release is coming online.
  */
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -188,7 +188,7 @@ public class MegabusRefResolver extends KafkaStreamsService {
                 triggerEvent.set(true);
 
                 final Instant mark = _clock.instant();
-                final Instant readAt = ref.getReadTime();
+                final Instant readAt = ref.getReadTime() != null ? ref.getReadTime() : mark;
                 _log.debug("doc[{}], readAt[{}], age[{}ms]", ref.getKey(), readAt, mark.toEpochMilli() - readAt.toEpochMilli());
                 _processingLatencyHisto.update(mark.toEpochMilli() - readAt.toEpochMilli());
             });

--- a/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/resolver/MegabusRefResolver.java
@@ -188,9 +188,11 @@ public class MegabusRefResolver extends KafkaStreamsService {
                 triggerEvent.set(true);
 
                 final Instant mark = _clock.instant();
-                final Instant readAt = ref.getReadTime() != null ? ref.getReadTime() : mark;
-                _log.debug("doc[{}], readAt[{}], age[{}ms]", ref.getKey(), readAt, mark.toEpochMilli() - readAt.toEpochMilli());
-                _processingLatencyHisto.update(mark.toEpochMilli() - readAt.toEpochMilli());
+                final Instant readAt = ref.getReadTime();
+                if (readAt != null) {
+                    _log.debug("doc[{}], readAt[{}], age[{}ms]", ref.getKey(), readAt, mark.toEpochMilli() - readAt.toEpochMilli());
+                    _processingLatencyHisto.update(mark.toEpochMilli() - readAt.toEpochMilli());
+                }
             });
 
             if (triggerEvent.get()) {


### PR DESCRIPTION
In #281 , I added the `readTime` property to the `MegabusRef` POJO. Well, I required a non-null property for instance instantiation, which failed spectacularly on any databus events that the previous release wrote to our internal topic during deployment. In short, I made a backward-incompatible schema change, something that, in spite of our not setting any schema ahead-of-time, I should remember to bear in mind.

So this basically just doesn't report the metric if there was no recorded `readTime`.

And this is the part where I advocate for schemas, since simpletons like myself easily forget they exist and go and make a change like this. :D 

Also, this situation reminded me that we need to add unit tests to this whole thing. I can't decide if I should just add the one here, for maybe put a little more thought into it and tackle the actual EMO ticket for adding unit tests the the Megabus.