### PR TITLE
Adding Temporal and LiveRangeScan switches to the StashResource.

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanOptions.java
@@ -171,16 +171,18 @@ public class ScanOptions {
         return _temporalEnabled;
     }
 
-    public void setTemporalEnabled(boolean temporalEnabled) {
+    public ScanOptions setTemporalEnabled(boolean temporalEnabled) {
         _temporalEnabled = temporalEnabled;
+        return this;
     }
 
     public boolean isOnlyScanLiveRanges() {
         return _onlyScanLiveRanges;
     }
 
-    public void setOnlyScanLiveRanges(boolean onlyScanLiveRanges) {
+    public ScanOptions setOnlyScanLiveRanges(boolean onlyScanLiveRanges) {
         _onlyScanLiveRanges = onlyScanLiveRanges;
+        return this;
     }
 
     @Override

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/resource/StashResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/resource/StashResource1.java
@@ -60,6 +60,8 @@ public class StashResource1 {
                                 @QueryParam ("byAZ") @DefaultValue ("true") Boolean byAZ,
                                 @QueryParam ("maxConcurrency") @DefaultValue ("4") Integer maxConcurrency,
                                 @QueryParam ("compactionEnabled") @DefaultValue ("false") Boolean compactionEnabled,
+                                @QueryParam ("temporalEnabled") @DefaultValue ("true") Boolean temporalEnabled,
+                                @QueryParam ("onlyScanLiveRanges") @DefaultValue ("true") Boolean onlyScanLiveRanges,
                                 @QueryParam ("rangeScanSplitSize") @DefaultValue("1000000") Integer rangeScanSplitSize,
                                 @QueryParam ("maxRangeScanTime") @DefaultValue("PT10M") String maxRangeScanTime,
                                 @QueryParam ("usePlanFrom") String usePlanFromStashId,
@@ -91,6 +93,8 @@ public class StashResource1 {
                 .setScanByAZ(byAZ)
                 .setMaxConcurrentSubRangeScans(maxConcurrency)
                 .setCompactionEnabled(compactionEnabled)
+                .setTemporalEnabled(temporalEnabled)
+                .setOnlyScanLiveRanges(onlyScanLiveRanges)
                 .setRangeScanSplitSize(rangeScanSplitSize)
                 .setMaxRangeScanTime(Duration.parse(maxRangeScanTime));
 


### PR DESCRIPTION
## What Are We Doing Here?

This PR adds the Temporal and LiveRangeScan enabling and disabling in the StashResource.
Defaults are still true for both as today.

The plan right now is to disable them only in certain testing cases (current purpose is to compare the stash data to Megabus data)  

## How to Test and Verify

These parameters will be used to generate a validation stash in Anon with the two values disabled. 

