### PR TITLE
EMO-7191 cache blob s3 healthchecks

### DIFF
--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/BlobStoreModule.java
@@ -20,6 +20,7 @@ import com.bazaarvoice.emodb.blob.db.s3.S3BucketNamesToS3Clients;
 import com.bazaarvoice.emodb.blob.db.s3.S3ClientConfiguration;
 import com.bazaarvoice.emodb.blob.db.s3.S3Configuration;
 import com.bazaarvoice.emodb.blob.db.s3.S3HealthCheck;
+import com.bazaarvoice.emodb.blob.db.s3.S3HealthCheckConfiguration;
 import com.bazaarvoice.emodb.cachemgr.api.CacheRegistry;
 import com.bazaarvoice.emodb.common.cassandra.CassandraConfiguration;
 import com.bazaarvoice.emodb.common.cassandra.CassandraFactory;
@@ -382,6 +383,17 @@ public class BlobStoreModule extends PrivateModule {
     ConsistencyLevel provideBlobReadConsistency(BlobStoreConfiguration configuration) {
         // By default use local quorum
         return Optional.fromNullable(configuration.getReadConsistency()).or(ConsistencyLevel.CL_LOCAL_QUORUM);
+    }
+
+    @Provides @Singleton
+    S3HealthCheckConfiguration provideS3BucketConfiguration(BlobStoreConfiguration configuration) {
+        S3Configuration s3Configuration = configuration.getS3Configuration();
+
+        if (null != s3Configuration && null != s3Configuration.getS3BucketConfigurations()) {
+            return s3Configuration.getS3HealthCheckConfiguration();
+        } else {
+            return new S3HealthCheckConfiguration();
+        }
     }
 
     @Provides @Singleton @S3BucketNamesToS3Clients

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/db/s3/S3Configuration.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/db/s3/S3Configuration.java
@@ -17,6 +17,10 @@ public class S3Configuration {
     @JsonProperty("client")
     private S3ClientConfiguration _s3ClientConfiguration;
 
+    @Valid
+    @JsonProperty("healthcheck")
+    private S3HealthCheckConfiguration _s3HealthCheckConfiguration = new S3HealthCheckConfiguration();
+
     public List<S3BucketConfiguration> getS3BucketConfigurations() {
         return _s3BucketConfigurations;
     }
@@ -32,5 +36,13 @@ public class S3Configuration {
 
     public void setS3ClientConfiguration(final S3ClientConfiguration s3ClientConfiguration) {
         _s3ClientConfiguration = s3ClientConfiguration;
+    }
+
+    public S3HealthCheckConfiguration getS3HealthCheckConfiguration() {
+        return _s3HealthCheckConfiguration;
+    }
+
+    public void setS3HealthCheckConfiguration(final S3HealthCheckConfiguration s3HealthCheckConfiguration) {
+        this._s3HealthCheckConfiguration = _s3HealthCheckConfiguration;
     }
 }

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/db/s3/S3HealthCheck.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/db/s3/S3HealthCheck.java
@@ -4,23 +4,44 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.bazaarvoice.emodb.common.dropwizard.healthcheck.HealthCheckRegistry;
 import com.codahale.metrics.health.HealthCheck;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 
 import javax.inject.Inject;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 public class S3HealthCheck extends HealthCheck {
     private final Map<String, AmazonS3> _bucketNamesToS3Clients;
+    private final S3HealthCheckConfiguration _healthCheckConfiguration;
+    private final LoadingCache<String, Result> _healthCheckCache;
 
     @Inject
     public S3HealthCheck(@S3BucketNamesToS3Clients Map<String, AmazonS3> bucketNamesToS3Clients,
+                         S3HealthCheckConfiguration s3HealthCheckConfiguration,
                          HealthCheckRegistry healthCheckRegistry) {
         _bucketNamesToS3Clients = Objects.requireNonNull(bucketNamesToS3Clients);
-        healthCheckRegistry.addHealthCheck("blob-s3", this);
+        _healthCheckConfiguration = Objects.requireNonNull(s3HealthCheckConfiguration);
+        _healthCheckCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(_healthCheckConfiguration.getDuration().getSeconds(), TimeUnit.SECONDS)
+                .build(new CacheLoader<String, Result>() {
+                    @Override
+                    public Result load(String key) throws Exception {
+                        return getResult();
+                    }
+                });
+
+        healthCheckRegistry.addHealthCheck(_healthCheckConfiguration.getName(), this);
     }
 
     @Override
     protected Result check() throws Exception {
+        return _healthCheckCache.getUnchecked(_healthCheckConfiguration.getName());
+    }
+
+    private Result getResult() {
         return _bucketNamesToS3Clients.entrySet().parallelStream()
                 .map(entry -> {
                     try {
@@ -31,9 +52,9 @@ public class S3HealthCheck extends HealthCheck {
                     } catch (Exception e) {
                         return Result.unhealthy("Bucket " + entry.getKey() + " is unhealthy: " + e.getMessage());
                     }
-                }).reduce((result, result2) -> {
-                    String message = result.getMessage() + ", " + result2.getMessage();
-                    if (result.isHealthy() && result2.isHealthy()) {
+                }).reduce((result1, result2) -> {
+                    String message = result1.getMessage() + ", " + result2.getMessage();
+                    if (result1.isHealthy() && result2.isHealthy()) {
                         return Result.healthy(message);
                     } else {
                         return Result.unhealthy(message);

--- a/blob/src/main/java/com/bazaarvoice/emodb/blob/db/s3/S3HealthCheckConfiguration.java
+++ b/blob/src/main/java/com/bazaarvoice/emodb/blob/db/s3/S3HealthCheckConfiguration.java
@@ -1,0 +1,32 @@
+package com.bazaarvoice.emodb.blob.db.s3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+public class S3HealthCheckConfiguration {
+
+    private final static String DEFAULT_NAME = "blob-s3";
+    private final static Duration DEFAULT_DURATION = Duration.of(60, ChronoUnit.SECONDS);
+    /**
+     * Name for the health check as registered in DropWizard.
+     */
+
+    @JsonProperty("name")
+    private String _name = DEFAULT_NAME;
+
+
+    @JsonProperty("duration")
+    private String _duration = DEFAULT_DURATION.toString();
+
+
+    public String getName() {
+        return _name;
+    }
+
+    public Duration getDuration() {
+        return Duration.parse(_duration);
+    }
+
+}


### PR DESCRIPTION
## Github Issue #

*

## What Are We Doing Here?
Cache blob s3 healthcheck result to reduce costs.

## How to Test and Verify

1. Check out this PR
2. Run `mvn clean verify`
3. Run emodb-web locally
4. Run `curl localhost:8081/healthcheck` few times and make sure that service is healthy
5.  Update config with:
```
  s3:
    buckets:
      - name: <BUCKET_NAME1>
        region: <REGION1>
        roleArn: <ROLE_ARN1>
      - name: <BUCKET_NAME2>
        region: <REGION2>
        roleArn: <ROLE_ARN2>
    healthcheck:
      name: blob-s3
      duration: PT10S
```
6. Repeat steps 3 and 4
7. Verify that response is cached after first attempt
8. Profit

## Risk

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

App could start improper way due to misconfiguration.
Healthcheck endpoint could be broken.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
