### PR TITLE
Updated Cordinate class to not have tildes for the input

### DIFF
--- a/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Coordinate.java
+++ b/sor-api/src/main/java/com/bazaarvoice/emodb/sor/api/Coordinate.java
@@ -43,7 +43,7 @@ public final class Coordinate {
     }
 
     @JsonCreator
-    private Coordinate(@JsonProperty(Intrinsic.TABLE) String table, @JsonProperty(Intrinsic.ID) String id) {
+    private Coordinate(@JsonProperty("table") String table, @JsonProperty("id") String id) {
         _table = checkNotNull(table, "table");
         _id = checkNotNull(id, "id");
     }


### PR DESCRIPTION
Updated Coordinate class to accept input without tildes for the table and the id fields. This way the JSON serialization of the Coordinate object match its deserialization.

Also, this means that the Megabus Touch input for the Stream endpoint should not have tildes in the JSON input. 

