### PR TITLE
Make table template updates possible in all datacenters

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreProviderProxy.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/core/DataStoreProviderProxy.java
@@ -94,7 +94,7 @@ public class DataStoreProviderProxy implements DataStore {
 
     @Override
     public void setTableTemplate(String table, Map<String, ?> template, Audit audit) throws UnknownTableException {
-        _local.get().setTableTemplate(table, template, audit);
+        _system.get().setTableTemplate(table, template, audit);
     }
 
     @Override


### PR DESCRIPTION
Table template updates currently fail when made in the non-system datacenter. They fail with the error: It fails with the message:
```"The table metadata mutex is unavailable from this data center. Make sure that the `systemDataCenter` property points to the right system datacenter. If this is a new data center and not the system datacenter, then try repairing the new Cassandra cluster as it may not have all the system tables replicated yet."```

This PR fixes this issue by forwarding table template updates the system data center.