### PR TITLE
Enabling Drop, Move and other operations.

### DIFF
--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/sor/DataStoreResource1.java
@@ -105,9 +105,6 @@ import static java.lang.String.format;
 public class DataStoreResource1 {
     private static final Logger _log = LoggerFactory.getLogger(DataStoreResource1.class);
 
-    private static final String TEMPORARY_UNAUTHORIZED_MESSAGE =
-            "Modifying the metadata of existing tables is temporarily disabled for EmoDB users. Contact the database administrator for assistance";
-
     /**
      * To distinguish between UUID and timestamps, assume anything that looks like "hex-hex-hex-hex-hex" is a UUID.
      */
@@ -214,13 +211,8 @@ public class DataStoreResource1 {
     )
     public SuccessResponse dropTable(@PathParam ("table") String table,
                                      @QueryParam ("audit") AuditParam auditParam,
-                                     @Context UriInfo uriInfo,
-                                     @Authenticated Subject subject) {
+                                     @Context UriInfo uriInfo) {
         Audit audit = getRequired(auditParam, "audit");
-
-        if (!subject.hasPermission(Permissions.unlimited())) {
-            throw new UnauthorizedException(TEMPORARY_UNAUTHORIZED_MESSAGE);
-        }
 
         _dataStore.dropTable(table, audit);
         return SuccessResponse.instance();
@@ -256,14 +248,9 @@ public class DataStoreResource1 {
     public SuccessResponse dropFacade(@PathParam ("table") String table,
                                       @QueryParam ("audit") AuditParam auditParam,
                                       @QueryParam ("placement") String placement,
-                                      @Context UriInfo uriInfo,
-                                      @Authenticated Subject subject) {
+                                      @Context UriInfo uriInfo) {
         checkArgument(!Strings.isNullOrEmpty(placement), "Missing required placement.");
         Audit audit = getRequired(auditParam, "audit");
-
-        if (!subject.hasPermission(Permissions.unlimited())) {
-            throw new UnauthorizedException(TEMPORARY_UNAUTHORIZED_MESSAGE);
-        }
 
         _dataStore.dropFacade(table, placement, audit);
         return SuccessResponse.instance();
@@ -279,13 +266,8 @@ public class DataStoreResource1 {
             response = SuccessResponse.class
     )
     public Map<String, Object> purgeTableAsync(@PathParam ("table") String table,
-                                               @QueryParam ("audit") AuditParam auditParam,
-                                               @Authenticated Subject subject) {
+                                               @QueryParam ("audit") AuditParam auditParam) {
         Audit audit = getRequired(auditParam, "audit");
-
-        if (!subject.hasPermission(Permissions.unlimited())) {
-            throw new UnauthorizedException(TEMPORARY_UNAUTHORIZED_MESSAGE);
-        }
 
         String jobID = _dataStoreAsync.purgeTableAsync(table, audit);
         return ImmutableMap.<String, Object>of("id", jobID);
@@ -329,13 +311,8 @@ public class DataStoreResource1 {
     public SuccessResponse setTableTemplate(@PathParam ("table") String table,
                                             Map<String, Object> template,
                                             @QueryParam ("audit") AuditParam auditParam,
-                                            @Context UriInfo uriInfo,
-                                            @Authenticated Subject subject) {
+                                            @Context UriInfo uriInfo) {
         Audit audit = getRequired(auditParam, "audit");
-
-        if (!subject.hasPermission(Permissions.unlimited())) {
-            throw new UnauthorizedException(TEMPORARY_UNAUTHORIZED_MESSAGE);
-        }
 
         _dataStore.setTableTemplate(table, template, audit);
         return SuccessResponse.instance();

--- a/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/purge/PurgeTest.java
@@ -144,9 +144,7 @@ public class PurgeTest {
         assertTrue(purgeStatus.get("status").toString().equals("IN_PROGRESS"));
 
         // calling job directly via calling purgeTableAsync on DataStoreResource1
-        Subject subject = mock(Subject.class);
-        when(subject.hasPermission(Permissions.unlimited())).thenReturn(true);
-        Map<String, Object> jobID3Map = _dataStoreResource.purgeTableAsync(TABLE3, new AuditParam("audit=comment:'purgetest+comment'"), subject);
+        Map<String, Object> jobID3Map = _dataStoreResource.purgeTableAsync(TABLE3, new AuditParam("audit=comment:'purgetest+comment'"));
         Map<String, Object> purgeStatus3 = _dataStoreResource.getPurgeStatus(TABLE3, jobID3Map.get("id").toString());
         assertTrue(purgeStatus3.get("status").toString().equals("IN_PROGRESS"));
     }


### PR DESCRIPTION
We recently made changes to make sure all table operations would include an extra task of updating Megabus. 

This PR includes enabling all Table Operations(Delete, Move, Purge, Update Table template etc.) back to the Public with supported API keys.
I also updated the relevant Tests which were changed before to accommodate Admin-Only case.

 
