### PR TITLE
Add Postman tests  for all endpoints under /sor/1/_table/{table}

### DIFF
--- a/quality/postman/emodb_tests.postman_collection.json
+++ b/quality/postman/emodb_tests.postman_collection.json
@@ -1,0 +1,21851 @@
+{
+	"info": {
+		"_postman_id": "da2ac7fe-038e-4359-8ab1-a644fa922457",
+		"name": "EmoDB_Tests",
+		"description": "Postman tests that are meant to cover most of positive and negative scenarios",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "sor/1 test cases",
+			"item": [
+				{
+					"name": " table",
+					"item": [
+						{
+							"name": "{table}",
+							"item": [
+								{
+									"name": "Returns a table template GET /sor/1/_table/:table",
+									"item": [
+										{
+											"name": "TC: Request without api-key",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table1', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"auth": {
+															"type": "apikey"
+														},
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"type\":\"create_test_table\",\n    \"client\":\"postman_customer\",\n    \"test_field\":\"postman\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table1}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table1}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns a table template",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+																	"});",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-Api-Key",
+																"value": "{{api_key_no_rights}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table1}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table1}}"
+															],
+															"query": [
+																{
+																	"key": "debug",
+																	"value": "<string>",
+																	"disabled": true
+																}
+															]
+														},
+														"description": "Returns a Map"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "debug",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table1}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table1}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Returns 10 tables (default value) where limit parameter is not defined",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Get table with undefined template",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table2', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body is correct\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"auth": {
+															"type": "apikey"
+														},
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table2}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table2}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns a table template",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(\"{}\"));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table2}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table2}}"
+															],
+															"query": [
+																{
+																	"key": "debug",
+																	"value": "<string>",
+																	"disabled": true
+																}
+															]
+														},
+														"description": "Returns a Map"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "debug",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table2}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table2}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table2}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table2}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with correct api-key which has sor|read|{table} permission to get table template where template is not defined returns: empty body {}",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Get table template when it is defined, debug is not set",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table3', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"auth": {
+															"type": "apikey"
+														},
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"type\":\"create_test_table\",\n    \"client\":\"postman_customer\",\n    \"test_field\":\"postman\",\n    \"test\":\"get_table_template\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table3}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table3}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns a table template",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"test_field\":\"postman\",\"client\":\"postman_customer\",\"test\":\"get_table_template\",\"type\":\"create_test_table\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table3}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table3}}"
+															]
+														},
+														"description": "Returns a Map"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "debug",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table3}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table3}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table3}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table3}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with correct api-key which has sor|read|{table} permission and debug param is not set to get table template where template is defined returns: unsorted table template",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Get table template when it is defined, debug: true",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table4', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"auth": {
+															"type": "apikey"
+														},
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"type\":\"create_test_table\",\n    \"client\":\"postman_customer\",\n    \"test_field\":\"postman\",\n    \"test\":\"get_table_template\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table4}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table4}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns a table template",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"client\":\"postman_customer\",\"test\":\"get_table_template\",\"test_field\":\"postman\",\"type\":\"create_test_table\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table4}}?debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table4}}"
+															],
+															"query": [
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "Returns a Map"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "debug",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table4}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table4}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table4}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table4}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with correct api-key which has sor|read|{table} permission and debug param is set to true to get table template where template is defined returns: sorted table template",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Get table template when it is defined, debug: false",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table5', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"auth": {
+															"type": "apikey"
+														},
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"type\":\"create_test_table\",\n    \"client\":\"postman_customer\",\n    \"test_field\":\"postman\",\n    \"test\":\"get_table_template\",\n    \"unsorted\":\"table_template\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table5}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table5}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns a table template",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"unsorted\":\"table_template\",\"test_field\":\"postman\",\"client\":\"postman_customer\",\"test\":\"get_table_template\",\"type\":\"create_test_table\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table5}}?debug=false",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table5}}"
+															],
+															"query": [
+																{
+																	"key": "debug",
+																	"value": "false"
+																}
+															]
+														},
+														"description": "Returns a Map"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "debug",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table5}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table5}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table5}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table5}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with correct api-key which has sor|read|{table} permission and debug param is set to false to get table template where template is defined returns: unsorted table template",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Get table template for not existing table",
+											"item": [
+												{
+													"name": "Returns a table template",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(404);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"message\":\"Unknown table: doesnt_exist\",\"table\":\"doesnt_exist\",\"suppressed\":[]}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/doesnt_exist?debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"doesnt_exist"
+															],
+															"query": [
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "Returns a Map"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "debug",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{}"
+														}
+													]
+												}
+											],
+											"description": "\"Request with correct api-key which has sor|read|{table} permission and debug param is set true to get table template for the table that doesn't exists returns: \"\"message\"\": \"\"Unknown table: %table name%\"\",\n    \"\"table\"\": \"\"%table name%\"\",\n    \"\"suppressed\"\": []\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Returns a table template",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 403\", function () {",
+															"    pm.response.to.have.status(403);",
+															"});",
+															"",
+															"pm.test(\"Body matches string\", function () {",
+															"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-BV-Api-Key",
+														"value": "{{api_key_no_rights}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table",
+														":table"
+													],
+													"query": [
+														{
+															"key": "debug",
+															"value": "<string>"
+														}
+													],
+													"variable": [
+														{
+															"key": "table",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												},
+												"description": "Returns a Map"
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table"
+															],
+															"query": [
+																{
+																	"key": "debug",
+																	"value": "<string>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "table"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												}
+											]
+										}
+									],
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										}
+									]
+								},
+								{
+									"name": "Creates a table PUT /sor/1/_table/:table",
+									"item": [
+										{
+											"name": "TC: Request without parameters",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table6', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('Missing required query parameter: options'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-Api-Key",
+																"value": "{{api_key_no_rights}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table6}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table6}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "<string>",
+																	"disabled": true
+																},
+																{
+																	"key": "audit",
+																	"value": "<string>",
+																	"disabled": true
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with no parameters and body set as {} returns  \"Missing required query parameter: options\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request with body type set to text instead of json",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table7', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"message\":\"Unrecognized token \\'test\\': was expecting \\'null\\', \\'true\\', \\'false\\' or NaN\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "test",
+															"options": {
+																"raw": {
+																	"language": "text"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table7}}?options=placement:'ugc_global:ugc'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table7}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "<string>",
+																	"disabled": true
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with body which is not json (e.g. text) returns: code 400 Bad Request",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request with json body type, correct options without audit parameter ",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table8', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('Missing required query parameter: audit'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table8}}?options=placement:'ugc_global:ugc'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table8}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request body of json type, options with correct o-rison value, with no audit parameter returns: \"Missing required query parameter: audit\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request without api-key",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table9', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-Api-Key",
+																"value": "{{api_key_no_rights}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table9}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table9}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request body of json type, options with correct o-rison value, with correct audit parameter and without authentication key returns: \"\"reason\": \"not authorized\"\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Create new table ",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table10', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table10}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table10}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table10}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table10}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table10}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table10}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table10}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request body of json type, options with correct o-rison value, with correct audit parameter and authentication key which has sor | create_table permission returns: \"\"success\": true\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Create new table with existing table name",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table11', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table11}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table11}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table11}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table with existing table name",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 409\", function () {",
+																	"    pm.response.to.have.status(409);",
+																	"});",
+																	"",
+																	"var stringToReplace = '{\"message\":\"Cannot create table that already exists: postman_table_name\",\"table\":\"postman_table_name\",\"suppressed\":[]}';",
+																	"const expectedResponseBody = stringToReplace.replace(/postman_table_name/g, pm.environment.get(\"table11\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n     \"new_attribute\": \"some_value\",\n    \"test_table\":\"{{table11}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table11}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table11}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table11}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table11}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request body of json type, options with correct o-rison value, with correct audit parameter and authentication key which has sor | create_table permission creates table with name that is already used returns: TableExistsException thrown and no table with the same name has been created",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Create new table with template",
+											"item": [
+												{
+													"name": "Returns a table template for table before its created",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 404\", function () {",
+																	"    pm.response.to.have.status(404);",
+																	"});",
+																	"",
+																	"const stringToReplace = '{\"message\":\"Unknown table: postman_test_table\",\"table\":\"postman_test_table\",\"suppressed\":[]}';",
+																	"const expectedResponseBody = stringToReplace.replace(/postman_test_table/g, pm.environment.get(\"table12\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table12', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table12}}?debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table12}}"
+															],
+															"query": [
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "Returns a Map"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "debug",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table12}}\",\n        \"options\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facades\": []\n        },\n        \"template\": {},\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n}\n",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table12}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table12}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns a table template after table is created",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"const stringToReplace = '{\"availability\":{\"facade\":false,\"placement\":\"ugc_global:ugc\"},\"name\":\"postman_test_table\",\"options\":{\"facades\":[],\"placement\":\"ugc_global:ugc\"},\"template\":{}}';",
+																	"const expectedResponceBody = stringToReplace.replace(/postman_test_table/, pm.environment.get(\"table12\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponceBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table12}}?debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table12}}"
+															],
+															"query": [
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "Returns a Map"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?debug=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "debug",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table12}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table12}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table12}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table12}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request body of json type, options with correct o-rison value, with correct audit parameter and authentication key which has sor | create_table permission creates table: e.g. \n[\n    {\n        \"name\": \"postman_test_table\",\n        \"options\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facades\": []\n        },\n        \"template\": {},\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }\n] ",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Creates a table",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 400\", function () {",
+															"    pm.response.to.have.status(400);",
+															"});",
+															"",
+															"pm.test(\"Body matches string\", function () {",
+															"    pm.expect(pm.response.to.have.body('Missing required query parameter: audit'));",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table/{{table8}}?options=placement:'ugc_global:ugc'",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table",
+														"{{table8}}"
+													],
+													"query": [
+														{
+															"key": "options",
+															"value": "placement:'ugc_global:ugc'"
+														},
+														{
+															"key": "audit",
+															"value": "",
+															"disabled": true
+														}
+													]
+												},
+												"description": "Returns a SuccessResponse if table is created"
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "<string>"
+																},
+																{
+																	"key": "audit",
+																	"value": "<string>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "table"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "Drops a table DELETE /sor/1/_table/:table",
+									"item": [
+										{
+											"name": "TC: Request without api-key",
+											"item": [
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-Api-Key",
+																"value": "{{api_key_no_rights}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/some_table_name?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"some_table_name"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request without api-key returns: \"\"reason\": \"not authorized\"\""
+										},
+										{
+											"name": "TC: Request without audit param when api-key is correct",
+											"item": [
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('Missing required query parameter: audit'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/some_table_name",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"some_table_name"
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request without audit parameter, with correct api-key which has sor|drop_table|{table} permission returns: \"Missing required query parameter: audit\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request remove table",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table20', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table20}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table20}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table20}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table20}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table20}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"const stringToReplace = 'This table name is currently undergoing maintenance and therefore cannot be modified: postman_table_name';",
+																	"const expectedResponseBody = stringToReplace.replace(/postman_table_name/g, pm.environment.get(\"table20\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table20}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table20}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table metadata",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 404\", function () {",
+																	"    pm.response.to.have.status(404);",
+																	"});",
+																	"",
+																	"const stringToReplace = '{\"message\":\"Unknown table: postman_table_name\",\"table\":\"postman_table_name\",\"suppressed\":[]}';",
+																	"const expectedResponseBody = stringToReplace.replace(/postman_table_name/g, pm.environment.get(\"table20\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table20}}/metadata",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table20}}",
+																"metadata"
+															]
+														},
+														"description": "Returns a Table object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/metadata",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"metadata"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with audit parameter, with correct api-key returns: \"\"success\": true\" and table removed",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request UnknownTableException",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table13', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table13}}\",\n        \"options\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facades\": []\n        },\n        \"template\": {},\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n}\n",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table13}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table13}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table metadata",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"const stringToReplace = '{\"name\":\"postman_table_name\",\"options\":{\"placement\":\"ugc_global:ugc\",\"facades\":[]},\"template\":{\"template\":{},\"name\":\"postman_table_name\",\"options\":{\"facades\":[],\"placement\":\"ugc_global:ugc\"},\"availability\":{\"facade\":false,\"placement\":\"ugc_global:ugc\"}},\"availability\":{\"placement\":\"ugc_global:ugc\",\"facade\":false}}';",
+																	"const expectedResponseBody = stringToReplace.replace(/postman_table_name/g, pm.environment.get(\"table13\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table13}}/metadata",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table13}}",
+																"metadata"
+															]
+														},
+														"description": "Returns a Table object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/metadata",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"metadata"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table13}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table13}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table metadata",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 404\", function () {",
+																	"    pm.response.to.have.status(404);",
+																	"});",
+																	"",
+																	"const stringToReplace = '{\"message\":\"Unknown table: postman_table_name\",\"table\":\"postman_table_name\",\"suppressed\":[]}';",
+																	"const expectedResponseBody = stringToReplace.replace(/postman_table_name/g, pm.environment.get(\"table13\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table13}}/metadata",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table13}}",
+																"metadata"
+															]
+														},
+														"description": "Returns a Table object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/metadata",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"metadata"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with audit parameter, with correct api-key for the table that doesn't exist returns: UnknownTableException",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Drops a table",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 403\", function () {",
+															"    pm.response.to.have.status(403);",
+															"});",
+															"",
+															"pm.test(\"Body matches string\", function () {",
+															"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table",
+														":table"
+													],
+													"query": [
+														{
+															"key": "audit",
+															"value": "<string>"
+														}
+													],
+													"variable": [
+														{
+															"key": "table",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												},
+												"description": "Returns a SuccessResponse if table is dropped"
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "<string>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "table"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "Returns Table metadata GET /sor/1/_table/:table/metadata",
+									"item": [
+										{
+											"name": "TC: Request without api-key",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table14', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table14}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table14}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table14}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														}
+													},
+													"response": []
+												},
+												{
+													"name": "Returns Table metadata",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-Api-Key",
+																"value": "{{api_key_no_rights}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table14}}/metadata",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table14}}",
+																"metadata"
+															]
+														}
+													},
+													"response": []
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table14}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table14}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table14}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table14}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request without api-key returns: \"\"reason\": \"not authorized\"\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request get table metadata",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table15', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table15}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table15}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table15}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table metadata",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"const stringToReplace = '{\"name\":\"postman_table_name\",\"options\":{\"placement\":\"ugc_global:ugc\",\"facades\":[]},\"template\":{\"test_table\":\"postman_table_name\",\"customer\":\"postman\"},\"availability\":{\"placement\":\"ugc_global:ugc\",\"facade\":false}}';",
+																	"const expectedResponseBody = stringToReplace.replace(/postman_table_name/g, pm.environment.get(\"table15\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table15}}/metadata",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table15}}",
+																"metadata"
+															]
+														},
+														"description": "Returns a Table object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/metadata",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"metadata"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table15}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table15}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table15}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table15}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api-key with sor|read|{table} permission returns table metadata",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request get table metada for not existing table",
+											"item": [
+												{
+													"name": "Returns Table metadata",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 404\", function () {",
+																	"    pm.response.to.have.status(404);",
+																	"});",
+																	" ",
+																	"const expectedResponseBody = '{\"message\":\"Unknown table: not_existing_table\",\"table\":\"not_existing_table\",\"suppressed\":[]}';",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/not_existing_table/metadata",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"not_existing_table",
+																"metadata"
+															]
+														},
+														"description": "Returns a Table object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/metadata",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"metadata"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api-key with sor|read|{table} permission for the table that doesn't exist returns \"message\": \"Unknown table: %table name%\",\n    \"table\": \"%table name%\",\n    \"suppressed\": []",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Returns Table metadata",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 403\", function () {",
+															"    pm.response.to.have.status(403);",
+															"});",
+															"",
+															"pm.test(\"Body matches string\", function () {",
+															"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-BV-Api-Key",
+														"value": "{{api_key_no_rights}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table/:table/metadata",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table",
+														":table",
+														"metadata"
+													],
+													"variable": [
+														{
+															"key": "table",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												},
+												"description": "Returns a Table object"
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table/metadata",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table",
+																"metadata"
+															],
+															"variable": [
+																{
+																	"key": "table"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+												}
+											]
+										}
+									],
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										}
+									]
+								},
+								{
+									"name": "Returns Table options GET /sor/1/_table/:table/options",
+									"item": [
+										{
+											"name": "TC: Request without api-key returns",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table40', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table40}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table40}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table40}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table options",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-Api-Key",
+																"value": "{{api_key_no_rights}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table40}}/options",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table40}}",
+																"options"
+															]
+														},
+														"description": "Returns a TableOptions object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/options",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"options"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"placement\": \"do\",\n \"facades\": [\n  {\n   \"placement\": \"cillum laborum ut\"\n  },\n  {\n   \"placement\": \"dolore dolor\"\n  }\n ]\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table40}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table40}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request without api-key returns: \"reason\": \"not authorized\""
+										},
+										{
+											"name": "TC: Request gets table options",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table16', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table16}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table16}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table16}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table options",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"const expectedResponseBody = '{\"placement\":\"ugc_global:ugc\",\"facades\":[]}';",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table16}}/options",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table16}}",
+																"options"
+															]
+														},
+														"description": "Returns a TableOptions object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/options",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"options"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"placement\": \"do\",\n \"facades\": [\n  {\n   \"placement\": \"cillum laborum ut\"\n  },\n  {\n   \"placement\": \"dolore dolor\"\n  }\n ]\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table16}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table16}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with correct api-key which has sor|read|{table} permissions for the existing table returns: e.g. \"placement\": \"ugc_global:ugc\",\n    \"facades\": []",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request gets table options of NotExisting table",
+											"item": [
+												{
+													"name": "Returns Table options",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 404\", function () {",
+																	"    pm.response.to.have.status(404);",
+																	"});",
+																	"",
+																	"const expectedResponseBody = '{\"message\":\"Unknown table: not_exiting_table\",\"table\":\"not_exiting_table\",\"suppressed\":[]}';",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/not_exiting_table/options",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"not_exiting_table",
+																"options"
+															]
+														},
+														"description": "Returns a TableOptions object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/options",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"options"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"placement\": \"do\",\n \"facades\": [\n  {\n   \"placement\": \"cillum laborum ut\"\n  },\n  {\n   \"placement\": \"dolore dolor\"\n  }\n ]\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with correct api-key which has sor|read|{table} permission for the table which doesn't exists returns: \"message\": \"Unknown table: %table name%\",\n    \"table\": \"%table name%\",\n    \"suppressed\": []",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Returns Table options",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 403\", function () {",
+															"    pm.response.to.have.status(403);",
+															"});",
+															"",
+															"pm.test(\"Body matches string\", function () {",
+															"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-BV-Api-Key",
+														"value": "{{api_key_no_rights}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table/:table/options",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table",
+														":table",
+														"options"
+													],
+													"variable": [
+														{
+															"key": "table",
+															"value": "some_notexisiting_table",
+															"description": "(Required) "
+														}
+													]
+												},
+												"description": "Returns a TableOptions object"
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table/options",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table",
+																"options"
+															],
+															"variable": [
+																{
+																	"key": "table"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"placement\": \"do\",\n \"facades\": [\n  {\n   \"placement\": \"cillum laborum ut\"\n  },\n  {\n   \"placement\": \"dolore dolor\"\n  }\n ]\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "Purges a table POST /sor/1/_table/:table/purge",
+									"item": [
+										{
+											"name": "TC: Request without api-key",
+											"item": [
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-Api-Key",
+																"value": "{{api_key_no_rights}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "<string>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "table",
+																	"value": "<string>",
+																	"description": "(Required) "
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request without api-key returns: \"reason\": \"not authorized to update table %table%\""
+										},
+										{
+											"name": "TC: Request Missing required query parameter: audit",
+											"item": [
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('Missing required query parameter: audit'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "<string>",
+																	"disabled": true
+																}
+															],
+															"variable": [
+																{
+																	"key": "table",
+																	"value": "<string>",
+																	"description": "(Required) "
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api-key and correct table, without audit parameter returns: Missing required query parameter: audit",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request table purge",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table17', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table17}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table17}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table17}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table options",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"const expectedResponseBody = '{\"placement\":\"ugc_global:ugc\",\"facades\":[]}';",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table17}}/options",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table17}}",
+																"options"
+															]
+														},
+														"description": "Returns a TableOptions object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/options",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"options"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"placement\": \"do\",\n \"facades\": [\n  {\n   \"placement\": \"cillum laborum ut\"\n  },\n  {\n   \"placement\": \"dolore dolor\"\n  }\n ]\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"success\":true,\"debug\":{\"changeId\":\"');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('uuid', uuid.v4());",
+																	"postman.setEnvironmentVariable('document_id2', 'document_id2_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table17}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table17}}/{{document_id2}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table17}}",
+																"{{document_id2}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"success\":true,\"debug\":{\"changeId\":\"');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('uuid', uuid.v4());",
+																	"postman.setEnvironmentVariable('document_id2', 'document_id2_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table17}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table17}}/{{document_id2}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table17}}",
+																"{{document_id2}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"success\":true,\"debug\":{\"changeId\":\"');",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('uuid', uuid.v4());",
+																	"postman.setEnvironmentVariable('document_id2', 'document_id2_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table17}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table17}}/{{document_id2}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table17}}",
+																"{{document_id2}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});",
+																	"",
+																	"const purgeId = JSON.parse(responseBody);",
+																	"postman.setEnvironmentVariable('purgeStatus', purgeId.id);",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table17}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table17}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Get Purge Status",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.be.oneOf(['{\"status\":\"IN_PROGRESS\"}','{\"status\":\"COMPLETE\"}']);",
+																	"});",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table17}}/purgestatus?id={{purgeStatus}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table17}}",
+																"purgestatus"
+															],
+															"query": [
+																{
+																	"key": "id",
+																	"value": "{{purgeStatus}}"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table17}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table17}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api-key and correct table, with audit parameter returns: id: \"%id of purge%\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Purge not existing table",
+											"item": [
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":\"');",
+																	"});",
+																	"",
+																	"const purgeId = JSON.parse(responseBody);",
+																	"postman.setEnvironmentVariable('purgeStatus1', purgeId.id);"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/not_existing_table/purge?audit=comment:'table_purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"not_existing_table",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Get Purge Status",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"status\":\"IN_PROGRESS\"}'));",
+																	"});",
+																	"",
+																	"const response = pm.response.json().status;",
+																	"if (response !== \"ERROR\") {",
+																	"    pm.test(\"Body matches string after some delay\", async function () {",
+																	"        await waitUntil(async () => {",
+																	"            const status = await retryRequest();",
+																	"            return status === 'ERROR';",
+																	"        });",
+																	"        pm.expect(response.json().status === 'ERROR');",
+																	"    });",
+																	"}",
+																	"",
+																	"const retryRequest = () => {",
+																	"    return new Promise((resolve, reject) => {",
+																	"        pm.sendRequest({",
+																	"            url: `${pm.environment.get(\"baseurl_dc1\")}/sor/1/_table/not_existing_table/purgestatus?id=${pm.environment.get(\"purgeStatus1\")}`,",
+																	"            method: 'POST',",
+																	"            header: {",
+																	"                \"X-BV-API-Key\": pm.environment.get(\"api-key\"),",
+																	"            }",
+																	"        }, (error, response) => {",
+																	"            if (error) {",
+																	"                reject(error);",
+																	"            }",
+																	"            resolve(response.json().status);",
+																	"        });",
+																	"    });",
+																	"};"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/not_existing_table/purgestatus?id={{purgeStatus1}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"not_existing_table",
+																"purgestatus"
+															],
+															"query": [
+																{
+																	"key": "id",
+																	"value": "{{purgeStatus1}}"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api-key which has sor|purge|{table}  and  table that doesn't exist, with audit parameter.",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Purges a table",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 403\", function () {",
+															"    pm.response.to.have.status(403);",
+															"});",
+															"",
+															"pm.test(\"Body matches string\", function () {",
+															"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "X-BV-Api-Key",
+														"value": "{{api_key_no_rights}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table",
+														":table",
+														"purge"
+													],
+													"query": [
+														{
+															"key": "audit",
+															"value": "<string>"
+														}
+													],
+													"variable": [
+														{
+															"key": "table",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												},
+												"description": "Returns a SuccessResponse if table is purged"
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "<string>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "table"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "Returns Purge Status POST /sor/1/_table/:table/purgestatus",
+									"item": [
+										{
+											"name": "TC: Request without api-key ",
+											"item": [
+												{
+													"name": "Get Purge Status",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+																	"});",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/not_existing_table/purgestatus",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"not_existing_table",
+																"purgestatus"
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request without api-key returns: \"reason\": \"not authorized\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request table purge without purge id",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table18', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table18}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table18}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table18}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table options",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"const expectedResponseBody = '{\"placement\":\"ugc_global:ugc\",\"facades\":[]}';",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table18}}/options",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table18}}",
+																"options"
+															]
+														},
+														"description": "Returns a TableOptions object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/options",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"options"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"placement\": \"do\",\n \"facades\": [\n  {\n   \"placement\": \"cillum laborum ut\"\n  },\n  {\n   \"placement\": \"dolore dolor\"\n  }\n ]\n}"
+														}
+													]
+												},
+												{
+													"name": "Get Purge Status",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 500\", function () {",
+																	"    pm.response.to.have.status(500);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"message\":\"There was an error processing your request. It has been logged (ID ');",
+																	"});",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table18}}/purgestatus?id=some_id",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table18}}",
+																"purgestatus"
+															],
+															"query": [
+																{
+																	"key": "id",
+																	"value": "some_id"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});",
+																	"",
+																	"const purgeId = JSON.parse(responseBody);",
+																	"postman.setEnvironmentVariable('purgeStatus', purgeId.id);",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table18}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table18}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table18}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table18}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api which has sor|purge|{table} for the table that exists without id query parameter returns: \"message\": \"There was an error processing your request. It has been logged (e.g. %ID 4134846f7b131e01%).\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request table purge to get Different Statuses",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table19', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table19}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table19}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table19}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table options",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"const expectedResponseBody = '{\"placement\":\"ugc_global:ugc\",\"facades\":[]}';",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table19}}/options",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table19}}",
+																"options"
+															]
+														},
+														"description": "Returns a TableOptions object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/options",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"options"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"placement\": \"do\",\n \"facades\": [\n  {\n   \"placement\": \"cillum laborum ut\"\n  },\n  {\n   \"placement\": \"dolore dolor\"\n  }\n ]\n}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});",
+																	"",
+																	"const purgeId = JSON.parse(responseBody);",
+																	"postman.setEnvironmentVariable('purgeStatus', purgeId.id);",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table19}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table19}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Get Purge Status In_Progress => Complete",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"const retryRequest = () => {",
+																	"    return new Promise((resolve, reject) => {",
+																	"        pm.sendRequest({",
+																	"            url: `${pm.environment.get(\"baseurl_dc1\")}/sor/1/_table/${pm.environment.get(\"table19\")}/purgestatus?id=${pm.environment.get(\"purgeStatus\")}`,",
+																	"            method: 'POST',",
+																	"            header: {",
+																	"                \"X-BV-API-Key\": pm.environment.get(\"api_key\"),",
+																	"            }",
+																	"        }, (error, response) => {",
+																	"            if (error) {",
+																	"                reject(error);",
+																	"            }",
+																	"            resolve(response.json().status);",
+																	"        });",
+																	"    });",
+																	"};",
+																	"",
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.be.oneOf(['{\"status\":\"IN_PROGRESS\"}','{\"status\":\"COMPLETE\"}']);",
+																	"});",
+																	"",
+																	"const response = pm.response.json().status;",
+																	"if (response !== \"COMPLETE\") {",
+																	"    pm.test(\"Body matches string after some delay\", async function () {",
+																	"        await waitUntil(async () => {",
+																	"            const status = await retryRequest();",
+																	"            return status === 'COMPLETE';",
+																	"        });",
+																	"        pm.expect(response.json().status === 'COMPLETE');",
+																	"    });",
+																	"}",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table19}}/purgestatus?id={{purgeStatus}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table19}}",
+																"purgestatus"
+															],
+															"query": [
+																{
+																	"key": "id",
+																	"value": "{{purgeStatus}}"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table19}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table19}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table19', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table19}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table19}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table19}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table19}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table19}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Purges a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.text()).to.include('{\"id\":');",
+																	"});",
+																	"",
+																	"const purgeId = JSON.parse(responseBody);",
+																	"postman.setEnvironmentVariable('purgeStatus', purgeId.id);",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table19}}/purge?audit=comment:'table purge'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table19}}",
+																"purge"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table purge'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Get Purge Status Error",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"",
+																	"const response = pm.response.json().status;",
+																	"if (response !== \"ERROR\") {",
+																	"    pm.test(\"Body matches string after some delay\", async function () {",
+																	"        await waitUntil(async () => {",
+																	"            const status = await retryRequest();",
+																	"            return status === 'ERROR';",
+																	"        });",
+																	"        pm.expect(response.json().status === 'ERROR');",
+																	"    });",
+																	"}",
+																	"",
+																	"",
+																	"const retryRequest = () => {",
+																	"    return new Promise((resolve, reject) => {",
+																	"        pm.sendRequest({",
+																	"            url: `${pm.environment.get(\"baseurl_dc1\")}/sor/1/_table/${pm.environment.get(\"table19\")}/purgestatus?id=${pm.environment.get(\"purgeStatus\")}`,",
+																	"            method: 'POST',",
+																	"            header: {",
+																	"                \"X-BV-API-Key\": pm.environment.get(\"api_key\"),",
+																	"            }",
+																	"        }, (error, response) => {",
+																	"            if (error) {",
+																	"                reject(error);",
+																	"            }",
+																	"            resolve(response.json().status);",
+																	"        });",
+																	"    });",
+																	"};"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table19}}/purgestatus?id={{purgeStatus}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table19}}",
+																"purgestatus"
+															],
+															"query": [
+																{
+																	"key": "id",
+																	"value": "{{purgeStatus}}"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is purged"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purge?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"purge"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api which has sor|purge|{table} for the table that exists with id query parameter set to correct purge job returns: job status e.g.  \"status\": \"COMPLETE\" (Available job statuses to test: in progress, complete, error)",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "get Purge Status",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 403\", function () {",
+															"    pm.response.to.have.status(403);",
+															"});",
+															"",
+															"pm.test(\"Body matches string\", function () {",
+															"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+															"});",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "X-BV-Api-Key",
+														"value": "{{api_key_no_rights}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purgestatus?id=<string>",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table",
+														":table",
+														"purgestatus"
+													],
+													"query": [
+														{
+															"key": "id",
+															"value": "<string>"
+														}
+													],
+													"variable": [
+														{
+															"key": "table",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table/purgestatus?id=<string>",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table",
+																"purgestatus"
+															],
+															"query": [
+																{
+																	"key": "id",
+																	"value": "<string>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "table"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{}"
+												}
+											]
+										}
+									],
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										}
+									]
+								},
+								{
+									"name": "Returns Table Size GET /sor/1/_table/:table/size",
+									"item": [
+										{
+											"name": "Request without api-key",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table21', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table21}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table21}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table21}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table Size",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-Api-Key",
+																"value": "{{api_key_no_rights}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table21}}/size?limit=10",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table21}}",
+																"size"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "10"
+																}
+															]
+														},
+														"description": "Returns a long"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/size?limit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"size"
+																	],
+																	"query": [
+																		{
+																			"key": "limit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "43857864"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table21}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table21}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request without api-key returns: \"reason\": \"not authorized\""
+										},
+										{
+											"name": "Request table size",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table22', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table22}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table22}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table22}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table Size",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('0'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table22}}/size?limit=10",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table22}}",
+																"size"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "10"
+																}
+															]
+														},
+														"description": "Returns a long"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/size?limit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"size"
+																	],
+																	"query": [
+																		{
+																			"key": "limit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "43857864"
+														}
+													]
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id1', 'document_id1_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table22}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table22}}/{{document_id1}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table22}}",
+																"{{document_id1}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Returns Table Size",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('1'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table22}}/size?limit=10",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table22}}",
+																"size"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "10"
+																}
+															]
+														},
+														"description": "Returns a long"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/size?limit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"size"
+																	],
+																	"query": [
+																		{
+																			"key": "limit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "43857864"
+														}
+													]
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id1', 'document_id1_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table22}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table22}}/{{document_id1}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table22}}",
+																"{{document_id1}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id1', 'document_id1_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table22}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table22}}/{{document_id1}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table22}}",
+																"{{document_id1}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id1', 'document_id1_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table22}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table22}}/{{document_id1}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table22}}",
+																"{{document_id1}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id1', 'document_id1_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table22}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table22}}/{{document_id1}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table22}}",
+																"{{document_id1}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Returns Table Size",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('5'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table22}}/size?limit=10",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table22}}",
+																"size"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "10"
+																}
+															]
+														},
+														"description": "Returns a long"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/size?limit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"size"
+																	],
+																	"query": [
+																		{
+																			"key": "limit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "43857864"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table22}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table22}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api-key which has sor|read|{table} permission for the table that exists returns: number of documents in  the table",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Request table size without limit parameter",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table24', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table24}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table24}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table24}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id3', 'document_id3_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table24}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table24}}/{{document_id3}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table24}}",
+																"{{document_id3}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id3', 'document_id3_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table24}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table24}}/{{document_id3}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table24}}",
+																"{{document_id3}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id3', 'document_id3_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table24}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table24}}/{{document_id3}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table24}}",
+																"{{document_id3}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id3', 'document_id3_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table24}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table24}}/{{document_id3}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table24}}",
+																"{{document_id3}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id3', 'document_id3_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table24}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table24}}/{{document_id3}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table24}}",
+																"{{document_id3}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Creates/Updates content in datastore /sor/1/{table}/{key}",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('document_id3', 'document_id3_' + uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n        \"name\": \"{{table24}}\",\n        \"id\": 1,\n        \"template\": {\n            \"test_field\": \"test_value_of_field\"\n        },\n        \"availability\": {\n            \"placement\": \"ugc_global:ugc\",\n            \"facade\": false\n        }\n    }",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/{{table24}}/{{document_id3}}?audit=comment:'adding+document'&consistency={{write_consistency_weak}}&tag=postman&debug=true",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"{{table24}}",
+																"{{document_id3}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'adding+document'"
+																},
+																{
+																	"key": "consistency",
+																	"value": "{{write_consistency_weak}}"
+																},
+																{
+																	"key": "tag",
+																	"value": "postman"
+																},
+																{
+																	"key": "debug",
+																	"value": "true"
+																}
+															]
+														},
+														"description": "\"Creates or replaces a piece of content in the data store.  Overwrites the old\\n\" +\n                    \" version of the content, if it exists.  Expects a literal JSON representation\\n\" +\n                    \" of the object.\""
+													},
+													"response": []
+												},
+												{
+													"name": "Returns Table Size",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('6'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table24}}/size",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table24}}",
+																"size"
+															]
+														},
+														"description": "Returns a long"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/size?limit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"size"
+																	],
+																	"query": [
+																		{
+																			"key": "limit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "43857864"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table24}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table24}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api-key which has sor|read|{table} permission for the table that exists, limit value is set returns: number of documents in the table but no more then number in limit",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Request table size for not existing table",
+											"item": [
+												{
+													"name": "Returns Table Size",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 404\", function () {",
+																	"    pm.response.to.have.status(404);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"message\":\"Unknown table: not_existing_table\",\"table\":\"not_existing_table\",\"suppressed\":[]}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/not_existing_table/size?limit=10",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"not_existing_table",
+																"size"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "10"
+																}
+															]
+														},
+														"description": "Returns a long"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/size?limit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"size"
+																	],
+																	"query": [
+																		{
+																			"key": "limit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "43857864"
+														}
+													]
+												}
+											],
+											"description": "Request with api-key which has sor|read|{table} permission for the table that doesn't exist returns: \"message\": \"Unknown table: %table name%\",\n    \"table\": \"%table name%\",\n    \"suppressed\": []",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Request table size with limit set to 0",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table23', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table23}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table23}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table23}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table Size",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('limit must be greater than 0'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table23}}/size?limit=0",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table23}}",
+																"size"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "0"
+																}
+															]
+														},
+														"description": "Returns a long"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/size?limit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"size"
+																	],
+																	"query": [
+																		{
+																			"key": "limit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "43857864"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table23}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table23}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with api-key which has sor|read|{table} permission for the table that exists when limit param is set to 0 returns: limit must be greater than 0",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Returns Table Size",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 403\", function () {",
+															"    pm.response.to.have.status(403);",
+															"});",
+															"",
+															"pm.test(\"Body matches string\", function () {",
+															"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "X-BV-Api-Key",
+														"value": "{{api_key_no_rights}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table/:table/size?limit=<string>",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table",
+														":table",
+														"size"
+													],
+													"query": [
+														{
+															"key": "limit",
+															"value": "<string>"
+														}
+													],
+													"variable": [
+														{
+															"key": "table",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												},
+												"description": "Returns a long"
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table/size?limit=<string>",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table",
+																"size"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "<string>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "table"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "43857864"
+												}
+											]
+										}
+									],
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										}
+									]
+								},
+								{
+									"name": "Sets table template PUT /sor/1/_table/:table/template",
+									"item": [
+										{
+											"name": "TC: Request sets table template",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table41', 'postman_'+uuid.v4());",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table41}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table41}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table41}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table metadata",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"const stringToReplace = '{\"name\":\"postman_table_name\",\"options\":{\"placement\":\"ugc_global:ugc\",\"facades\":[]},\"template\":{\"test_table\":\"postman_table_name\",\"customer\":\"postman\"},\"availability\":{\"placement\":\"ugc_global:ugc\",\"facade\":false}}';",
+																	"const expectedResponseBody = stringToReplace.replace(/postman_table_name/g, pm.environment.get(\"table41\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table41}}/metadata",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table41}}",
+																"metadata"
+															]
+														},
+														"description": "Returns a Table object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/metadata",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"metadata"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												},
+												{
+													"name": "Sets table template",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"table_name\": \"some_table\",\n    \"test_value\": \"some_table_filed\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table41}}/template?audit=comment:'set+template'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table41}}",
+																"template"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'set+template'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table template is set"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "\"<object>\""
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/template?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"template"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns Table metadata",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"const stringToReplace = '{\"name\":\"postman_table_name\",\"options\":{\"placement\":\"ugc_global:ugc\",\"facades\":[]},\"template\":{\"table_name\":\"some_table\",\"test_value\":\"some_table_filed\"},\"availability\":{\"placement\":\"ugc_global:ugc\",\"facade\":false}}';",
+																	"const expectedResponseBody = stringToReplace.replace(/postman_table_name/g, pm.environment.get(\"table41\"));",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body(expectedResponseBody));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table41}}/metadata",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table41}}",
+																"metadata"
+															]
+														},
+														"description": "Returns a Table object"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/metadata",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"metadata"
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with correct api-key (has sor|set_table_attributes|{table} permissions) and with json body type, with populated audit param returns: \"\"success\": true\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request without api key",
+											"item": [
+												{
+													"name": "Sets table template",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"reason\":\"not authorized\"}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-Api-Key",
+																"value": "{{api_key_no_rights}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/some_table/template?audit=comment:'set+template'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"some_table",
+																"template"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'set+template'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table template is set"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "\"<object>\""
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/template?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"template"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request without api key returns: \"\"reason\": \"not authorized\"\""
+										},
+										{
+											"name": "TC: Request table template without audit",
+											"item": [
+												{
+													"name": "Sets table template",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('Missing required query parameter: audit'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/some_table/template",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"some_table",
+																"template"
+															]
+														},
+														"description": "Returns a SuccessResponse if table template is set"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "\"<object>\""
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table/template?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table",
+																		"template"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request with correct api-key and with json body type and without audit returns: \"Missing required query parameter: audit\"",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Sets table template",
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"key": "X-BV-Api-Key",
+														"value": "{{api_key_no_rights}}",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "\"<object>\""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table/:table/template?audit=<string>",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table",
+														":table",
+														"template"
+													],
+													"query": [
+														{
+															"key": "audit",
+															"value": "<string>"
+														}
+													],
+													"variable": [
+														{
+															"key": "table",
+															"value": "<string>",
+															"description": "(Required) "
+														}
+													]
+												},
+												"description": "Returns a SuccessResponse if table template is set"
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "PUT",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": "\"<object>\""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/:table/template?audit=<string>",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																":table",
+																"template"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "<string>"
+																}
+															],
+															"variable": [
+																{
+																	"key": "table"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "Returns all the existing tables GET /sor/1/_table",
+									"item": [
+										{
+											"name": "TC: Request without api-key",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table28', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table28}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table28}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table28}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns all the existing tables",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    console.log(pm.response.text())",
+																	"    pm.expect(pm.response.text()).to.include(JSON.parse('[]'));",
+																	"});",
+																	"",
+																	"pm.test(\"Response Content-Type is json\", function () {",
+																	"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key_no_rights}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table?limit=100",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "100"
+																}
+															]
+														},
+														"description": "Returns a Iterator of Table"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table?from=<string>&limit=10",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table"
+																	],
+																	"query": [
+																		{
+																			"key": "from",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "limit",
+																			"value": "10"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table28}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table28}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Request without api-key returns empty body response",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request all tables when limit parameter is not defined",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table29', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table29}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table29}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table29}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table30', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table30}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table30}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table30}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table31', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table31}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table31}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table31}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table32', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table32}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table32}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table32}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table33', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table33}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table33}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table33}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table34', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table34}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table34}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table34}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table35', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table35}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table35}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table35}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table36', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table36}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table36}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table36}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table37', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table37}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table37}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table37}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table38', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table38}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table38}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table38}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table39', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table39}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table39}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table39}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns all the existing tables",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Your test name\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    pm.expect(jsonData.length).to.be.greaterThan(10);",
+																	"});",
+																	"",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table?limit=100",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table"
+															],
+															"query": [
+																{
+																	"key": "from",
+																	"value": "{{table11}}",
+																	"disabled": true
+																},
+																{
+																	"key": "limit",
+																	"value": "100"
+																}
+															]
+														},
+														"description": "Returns a Iterator of Table"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table?from=<string>&limit=10",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table"
+																	],
+																	"query": [
+																		{
+																			"key": "from",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "limit",
+																			"value": "10"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns all the existing tables",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Your test name\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    pm.expect(jsonData.length).to.be.equal(10);",
+																	"});",
+																	"",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table"
+															],
+															"query": [
+																{
+																	"key": "from",
+																	"value": "{{table11}}",
+																	"disabled": true
+																},
+																{
+																	"key": "limit",
+																	"value": "100",
+																	"disabled": true
+																}
+															]
+														},
+														"description": "Returns a Iterator of Table"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table?from=<string>&limit=10",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table"
+																	],
+																	"query": [
+																		{
+																			"key": "from",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "limit",
+																			"value": "10"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table29}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table29}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table30}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table30}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table31}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table31}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table32}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table32}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table33}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table33}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table34}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table34}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table35}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table35}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table36}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table36}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table37}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table37}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table38}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table38}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table39}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table39}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Returns 10 tables (default value) where limit and from  parameter is not defined",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request all tables when limit parameter is defined",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table29', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table29}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table29}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table29}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table30', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table30}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table30}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table30}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table31', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table31}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table31}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table31}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table32', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table32}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table32}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table32}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table33', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table33}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table33}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table33}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table34', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table34}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table34}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table34}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table35', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table35}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table35}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table35}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table36', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table36}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table36}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table36}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table37', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table37}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table37}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table37}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table38', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table38}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table38}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table38}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table39', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table39}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table39}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table39}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns all the existing tables",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Your test name\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    pm.expect(jsonData.length).to.be.greaterThan(10);",
+																	"});",
+																	"",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table?limit=100",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "100"
+																}
+															]
+														},
+														"description": "Returns a Iterator of Table"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table?from=<string>&limit=10",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table"
+																	],
+																	"query": [
+																		{
+																			"key": "from",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "limit",
+																			"value": "10"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table29}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table29}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table30}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table30}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table31}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table31}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table32}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table32}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table33}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table33}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table34}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table34}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table35}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table35}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table36}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table36}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table37}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table37}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table38}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table38}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table39}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table39}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Returns number of tables which is less or equel to number defined in Limit parameter",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "TC: Request all tables when limit and from parameters defined",
+											"item": [
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table29', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table29}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table29}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table29}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table30', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table30}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table30}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table30}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table31', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table31}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table31}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table31}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table32', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table32}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table32}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table32}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table33', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table33}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table33}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table33}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table34', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table34}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table34}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table34}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table35', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table35}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table35}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table35}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table36', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table36}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table36}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table36}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table37', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table37}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table37}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table37}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table38', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table38}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table38}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table38}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Creates a table",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"var uuid = require('uuid');",
+																	"postman.setEnvironmentVariable('table39', 'postman_'+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "PUT",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table39}}\"\n}",
+															"options": {
+																"raw": {
+																	"language": "json"
+																}
+															}
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table39}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table39}}"
+															],
+															"query": [
+																{
+																	"key": "options",
+																	"value": "placement:'ugc_global:ugc'"
+																},
+																{
+																	"key": "audit",
+																	"value": "comment:'initial+provisioning'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is created"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "PUT",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "options",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns all the existing tables without from",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Table name is in the returned result\", function () {",
+																	"    pm.expect(Boolean(pm.response.json().find(tableAttributes => tableAttributes.name.includes('postman_')))).to.be.true;",
+																	"});",
+																	"",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table?limit=10000",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "10000"
+																}
+															]
+														},
+														"description": "Returns a Iterator of Table"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table?from=<string>&limit=10",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table"
+																	],
+																	"query": [
+																		{
+																			"key": "from",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "limit",
+																			"value": "10"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												},
+												{
+													"name": "Returns all the existing tables",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Table name is in the returned result\", function () {",
+																	"    pm.expect(Boolean(pm.response.json().find(tableAttributes => tableAttributes.name.includes(pm.environment.get('table29'))))).to.be.false;",
+																	"});",
+																	"",
+																	"",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															},
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table?limit=100&from={{table29}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table"
+															],
+															"query": [
+																{
+																	"key": "limit",
+																	"value": "100"
+																},
+																{
+																	"key": "from",
+																	"value": "{{table29}}"
+																}
+															]
+														},
+														"description": "Returns a Iterator of Table"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table?from=<string>&limit=10",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table"
+																	],
+																	"query": [
+																		{
+																			"key": "from",
+																			"value": "<string>"
+																		},
+																		{
+																			"key": "limit",
+																			"value": "10"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"value": "{{api_key}}",
+																"type": "text"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table29}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table29}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table30}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table30}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table31}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table31}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table32}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table32}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table33}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table33}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table34}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table34}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table35}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table35}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table36}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table36}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table37}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table37}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table38}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table38}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "Drops a table",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Body matches string\", function () {",
+																	"    pm.expect(pm.response.to.have.body('{\"success\":true}'));",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "X-BV-API-Key",
+																"type": "text",
+																"value": "{{api_key}}"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table/{{table39}}?audit=comment:'table_removal'",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table",
+																"{{table39}}"
+															],
+															"query": [
+																{
+																	"key": "audit",
+																	"value": "comment:'table_removal'"
+																}
+															]
+														},
+														"description": "Returns a SuccessResponse if table is dropped"
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+																	"host": [
+																		"{{baseurl_dc1}}"
+																	],
+																	"path": [
+																		"sor",
+																		"1",
+																		"_table",
+																		":table"
+																	],
+																	"query": [
+																		{
+																			"key": "audit",
+																			"value": "<string>"
+																		}
+																	],
+																	"variable": [
+																		{
+																			"key": "table"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											],
+											"description": "Returns number of tables which is less or equel to number defined in Limit parameter",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"type": "text/javascript",
+														"exec": [
+															""
+														]
+													}
+												}
+											]
+										},
+										{
+											"name": "Returns all the existing tables",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Body matches string\", function () {",
+															"    pm.expect(pm.response.text()).to.include(JSON.parse('[]'));",
+															"});",
+															"",
+															"pm.test(\"Response Content-Type is json\", function () {",
+															"    pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													},
+													{
+														"key": "X-BV-API-Key",
+														"value": "{{api_key_no_rights}}",
+														"type": "text"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/sor/1/_table?limit=100",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"sor",
+														"1",
+														"_table"
+													],
+													"query": [
+														{
+															"key": "limit",
+															"value": "100"
+														}
+													]
+												},
+												"description": "Returns a Iterator of Table"
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/sor/1/_table?from=<string>&limit=10",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"sor",
+																"1",
+																"_table"
+															],
+															"query": [
+																{
+																	"key": "from",
+																	"value": "<string>"
+																},
+																{
+																	"key": "limit",
+																	"value": "10"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"options\": {\n  \"placement\": \"cupidatat dolor Excepteur\",\n  \"facades\": [\n   {\n    \"placement\": \"laboris magna s\"\n   },\n   {\n    \"placement\": \"minim deserunt\"\n   }\n  ]\n },\n \"template\": {},\n \"name\": \"eiusmod\",\n \"availability\": {\n  \"placement\": \"quis\",\n  \"facade\": false\n }\n}"
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"/**",
+					" * Waits until the given predicate returns a truthy value. Calls and awaits the predicate",
+					" * function at the given interval time. Can be used to poll until a certain condition is true.",
+					" *",
+					" * @example",
+					" * ```js",
+					" * import { fixture, waitUntil } from '@open-wc/testing-helpers';",
+					" *",
+					" * const element = await fixture(html`<my-element></my-element>`);",
+					" *",
+					" * await waitUntil(() => element.someAsyncProperty, 'element should become ready');",
+					" *",
+					"",
+					" *",
+					" * @param {() => boolean | Promise<boolean>} predicate - predicate function which is called each poll interval.",
+					" *   The predicate is awaited, so it can return a promise.",
+					" * @param {string} [message] an optional message to display when the condition timed out",
+					" * @param {{ interval?: number, timeout?: number }} [options] timeout and polling interval",
+					" */",
+					"waitUntil = (predicate, message, options = {}) => {",
+					"  const { interval = 1000, timeout = 5000 } = options;",
+					"",
+					"  return new Promise((resolve, reject) => {",
+					"    let timeoutId;",
+					"",
+					"    setTimeout(() => {",
+					"      clearTimeout(timeoutId);",
+					"      reject(new Error(message ? `Timeout: ${message}` : `waitUntil timed out after ${timeout}ms`));",
+					"    }, timeout);",
+					"",
+					"    async function nextInterval() {",
+					"      try {",
+					"        if (await predicate()) {",
+					"          resolve();",
+					"        } else {",
+					"          timeoutId = setTimeout(() => {",
+					"            nextInterval();",
+					"          }, interval);",
+					"        }",
+					"      } catch (error) {",
+					"        reject(error);",
+					"      }",
+					"    }",
+					"    nextInterval();",
+					"  });",
+					"};",
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
+}

--- a/quality/postman/sor-1-_table-table.postman_environment.json
+++ b/quality/postman/sor-1-_table-table.postman_environment.json
@@ -1,0 +1,44 @@
+{
+	"id": "29d85e3c-308d-44f2-b24d-79e3c72f2751",
+	"name": "/sor/1/_table/:table",
+	"values": [
+		{
+			"key": "api_key",
+			"value": "local_admin",
+			"enabled": true
+		},
+		{
+			"key": "api_key_no_rights",
+			"value": "should be passed as param in command line",
+			"enabled": true
+		},
+		{
+			"key": "baseurl_dc1",
+			"value": "localhost:8080",
+			"enabled": true
+		},
+		{
+			"key": "baseurl_dc2",
+			"value": "localhost:8080",
+			"enabled": true
+		},
+		{
+			"key": "write_consistency_weak",
+			"value": "WEAK",
+			"enabled": true
+		},
+		{
+			"key": "write_consistency_strong",
+			"value": "STRONG",
+			"enabled": true
+		},
+		{
+			"key": "write_consistency_nodurable",
+			"value": "NO_DURABLE",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2021-02-02T09:35:23.091Z",
+	"_postman_exported_using": "Postman/7.36.1"
+}


### PR DESCRIPTION
## Github Issue #315 

-

## What Are We Doing Here?
We are extending automation testing coverage by adding postman tests. This commit is covering all kind of checks for all endpoints under  /sor/1/_table/{table} api path. 

Feature coverage is additionally updated in our (for now internal) testing artefacts.


## How to Test and Verify

1. Check out this PR
2. Start emodb on local
3. Add api-key with "permissions":["*|read|__"]}' 

curl -s -XPOST 'http://localhost:8080/uac/1/role/reserved/postman_without_permissions' \
      -H "Content-Type: application/x.json-create-role" -H "X-BV-Api-Key:local_admin"\
      -d '{"name":"Postman without permissions","description":"Postman without permissions","permissions":["*|read|__"]}'

curl -s -XPOST "http://localhost:8080/uac/1/api-key" \
    -H "Content-Type: application/x.json-create-api-key" -H "X-BV-Api-Key:local_admin" \
    -d '{"owner":"emodb-dev@bazaarvoice.com","description":"Postman Without Permissions API key","roles":[{"group":"reserved","id":"postman_without_permissions"}]}' | jq .

4. Open postman 
5. Import "EmoDB Tests.postman_collection.json" as a collection
5. Import "sor-1-_table.postman_environment.json" as environment variables
6. Set 'api-key-no-rights' environment variable to value of the key that has been generated in step 3
7. Use runner for executing postman collection

Expected result: All tests are successfully executed on local environment

## Risk

`Low`
There are no changes to application code base

### Required Testing

All newly added postman tests should be executed without failures.

### Risk Summary

-

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
