### PR TITLE
Add postman test precondition setup script

### DIFF
--- a/quality/postman/tests_preconditions.postman_collection.json
+++ b/quality/postman/tests_preconditions.postman_collection.json
@@ -1,0 +1,161 @@
+{
+	"info": {
+		"_postman_id": "fb76faff-5ac9-425e-a44f-a7da90600140",
+		"name": "Tests_Preconditions",
+		"description": "Operrations that should be done before tests are run",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Setup api keys",
+			"item": [
+				{
+					"name": "Get api key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"if (pm.response.code == 200) {",
+									"    postman.setNextRequest(null);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-BV-Api-Key",
+								"value": "{{api_key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key/_key/{{api_key_no_rights}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key",
+								"_key",
+								"{{api_key_no_rights}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add user role",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x.json-create-role",
+								"type": "text"
+							},
+							{
+								"key": "X-BV-Api-Key",
+								"value": "{{api_key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\":\"Postman without permissions\",\n    \"description\":\"Postman without permissions\",\n    \"permissions\":[\"sor|read|__\"]\n}",
+							"options": {
+								"raw": {
+									"language": "text"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/role/reserved/postman_without_permissions1",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"role",
+								"reserved",
+								"postman_without_permissions1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Add api key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"const api_key_no_rights = pm.response.json().key",
+									"",
+									"pm.environment.set(\"api_key_no_rights\", api_key_no_rights);",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x.json-create-api-key",
+								"type": "text"
+							},
+							{
+								"key": "X-BV-Api-Key",
+								"value": "{{api_key}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"owner\":\"emodb-dev@bazaarvoice.com\",\n    \"description\":\"Postman Without Permissions API key\",\n    \"roles\":\n    [\n        {\"group\":\"reserved\",\"id\":\"postman_without_permissions\"}\n    ]\n}"
+						},
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "api keys are setup here for using them inside of the postman tests"
+		}
+	]
+}


### PR DESCRIPTION
## What Are We Doing Here?

Test precondition setup script has been added in order to test if api key has been created on test environment and setup it if it is not there.

## How to Test and Verify

1. Check out this PR
2. Start emodb on local
3. Open postman
4. Import "tests_preconditions.postman_collection.json" as a collection
5. Import "sor-1-_table.postman_environment.json" as environment variables
6. Use runner for executing postman collection

## Risk

`Low`
There are no changes to application code base or other tests code base

### Required Testing
Feature testing

All newly added postman tests should be executed without failures.

### Risk Summary
There are no concerns


## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
