### PR TITLE
EMO-7667 postman tests for POST /sor/1 endpoint

### DIFF
--- a/quality/postman/emodb_tests.postman_collection.json
+++ b/quality/postman/emodb_tests.postman_collection.json
@@ -52522,6 +52522,2512 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+			"item": [
+				{
+					"name": "TC: Request with api key without access",
+					"item": [
+						{
+							"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 403\", function () {",
+											"    pm.response.to.have.status(403);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"reason\":\"not authorized\"});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key_no_rights}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[\n         {\n            \"table\": \"{{table}}\",\n            \"key\": \"demo1\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\",\\\"field3\\\":\\\"value3\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n              \"comment\": \"Adding demo1 document\"\n            }\n          },\n          {\n            \"table\": \"{{table}}\",\n            \"key\": \"demo2\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1.1\\\",\\\"field5\\\":\\\"value5\\\",\\\"field32\\\":\\\"value33\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n            \"comment\": \"Update and Add\"\n        }\n      }\n]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1?audit=comment:'imports+stream+of+deltas'&consistency=STRONG&facade=false",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "<string>",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "comment:'imports+stream+of+deltas'"
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "false"
+										}
+									]
+								},
+								"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												},
+												{
+													"key": "consistency",
+													"value": "STRONG"
+												},
+												{
+													"key": "facade",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request without audit param",
+					"item": [
+						{
+							"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.text()).to.eql(\"Missing required query parameter: audit\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[\n         {\n            \"table\": \"{{table}}\",\n            \"key\": \"demo1\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\",\\\"field3\\\":\\\"value3\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n              \"comment\": \"Adding demo1 document\"\n            }\n          },\n          {\n            \"table\": \"{{table}}\",\n            \"key\": \"demo2\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1.1\\\",\\\"field5\\\":\\\"value5\\\",\\\"field32\\\":\\\"value33\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n            \"comment\": \"Update and Add\"\n        }\n      }\n]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1?consistency=STRONG&facade=false",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "<string>",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "comment:'imports+stream+of+deltas'",
+											"disabled": true
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "false"
+										}
+									]
+								},
+								"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												},
+												{
+													"key": "consistency",
+													"value": "STRONG"
+												},
+												{
+													"key": "facade",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request with wrong changeId param",
+					"item": [
+						{
+							"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.text()).to.eql(\"Invalid uuid parameter (must be a RFC 4122 version 1 time-based uuid): wrong_changeId\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[\n         {\n            \"~id\": \"1\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo1\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\",\\\"field3\\\":\\\"value3\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n              \"comment\": \"Adding demo1 document\"\n            }\n          },\n          {\n            \"~id\": \"1\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo2\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1.1\\\",\\\"field5\\\":\\\"value5\\\",\\\"field32\\\":\\\"value33\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n            \"comment\": \"Update and Add\"\n        }\n      }\n]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1?changeId=wrong_changeId&audit=comment:'imports+stream+of+deltas'&consistency=STRONG&facade=false",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "wrong_changeId"
+										},
+										{
+											"key": "audit",
+											"value": "comment:'imports+stream+of+deltas'"
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "false"
+										}
+									]
+								},
+								"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												},
+												{
+													"key": "consistency",
+													"value": "STRONG"
+												},
+												{
+													"key": "facade",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request to table without facade, with audit, consistency are set",
+					"item": [
+						{
+							"name": "Creates a table",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"postman.setEnvironmentVariable('table', 'postman_'+uuid.v4());"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "placement:'ugc_global:ugc'"
+										},
+										{
+											"key": "audit",
+											"value": "comment:'initial+provisioning'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({ success: true });",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[\n         {\n            \"~id\": \"1\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo1\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\",\\\"field3\\\":\\\"value3\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n              \"comment\": \"Adding demo1 document\"\n            }\n          },\n          {\n            \"~id\": \"2\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo2\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1.1\\\",\\\"field5\\\":\\\"value5\\\",\\\"field32\\\":\\\"value33\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n            \"comment\": \"Update and Add\"\n        }\n      }\n]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1?audit=comment:'imports+stream+of+deltas'&consistency=STRONG&facade=false",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "<string>",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "comment:'imports+stream+of+deltas'"
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "false"
+										}
+									]
+								},
+								"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												},
+												{
+													"key": "consistency",
+													"value": "STRONG"
+												},
+												{
+													"key": "facade",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Drops a table",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit=comment:'table_removal'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "audit",
+											"value": "comment:'table_removal'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is dropped"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request to table without facade, with all params without ~id and ~table",
+					"item": [
+						{
+							"name": "Creates a table",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"postman.setEnvironmentVariable('table', 'postman_'+uuid.v4());"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "placement:'ugc_global:ugc'"
+										},
+										{
+											"key": "audit",
+											"value": "comment:'initial+provisioning'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.text()).to.eql(\"Unable to cast value to String: null\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[\n         {\n            \"table\": \"{{table}}\",\n            \"key\": \"demo1\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\",\\\"field3\\\":\\\"value3\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n              \"comment\": \"Adding demo1 document\"\n            }\n          },\n          {\n            \"~id\": \"2\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo2\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1.1\\\",\\\"field5\\\":\\\"value5\\\",\\\"field32\\\":\\\"value33\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n            \"comment\": \"Update and Add\"\n        }\n      }\n]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1?audit=comment:'imports+stream+of+deltas'&consistency=STRONG&facade=false",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "<string>",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "comment:'imports+stream+of+deltas'"
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "false"
+										}
+									]
+								},
+								"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												},
+												{
+													"key": "consistency",
+													"value": "STRONG"
+												},
+												{
+													"key": "facade",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Drops a table",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit=comment:'table_removal'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "audit",
+											"value": "comment:'table_removal'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is dropped"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request to table without facade, with all params with application/x.json-deltas content",
+					"item": [
+						{
+							"name": "Creates a table",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"postman.setEnvironmentVariable('table', 'postman_'+uuid.v4());"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "placement:'ugc_global:ugc'"
+										},
+										{
+											"key": "audit",
+											"value": "comment:'initial+provisioning'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disabledSystemHeaders": {
+									"content-type": true
+								}
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-deltas",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"~id\": \"1\",\n    \"~table\": \"{{table}}\",\n    \"table\": \"{{table}}\",\n    \"key\": \"demo1\",\n    \"delta\": \"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\",\\\"field3\\\":\\\"value3\\\"}\",\n    \"consistency\": \"STRONG\",\n    \"audit\": {\n        \"comment\": \"Adding demo1 document\"\n    }\n} \n{\n    \"~id\": \"2\",\n    \"~table\": \"{{table}}\",\n    \"table\": \"{{table}}\",\n    \"key\": \"demo2\",\n    \"delta\": \"{\\\"field1\\\":\\\"value1.1\\\",\\\"field5\\\":\\\"value5\\\",\\\"field32\\\":\\\"value33\\\"}\",\n    \"consistency\": \"STRONG\",\n    \"audit\": {\n        \"comment\": \"Update and Add\"\n    }\n}\n"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1?audit=comment:'imports+stream+of+deltas'&consistency=STRONG&facade=false",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "<string>",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "comment:'imports+stream+of+deltas'"
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "false"
+										}
+									]
+								},
+								"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												},
+												{
+													"key": "consistency",
+													"value": "STRONG"
+												},
+												{
+													"key": "facade",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Drops a table",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit=comment:'table_removal'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "audit",
+											"value": "comment:'table_removal'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is dropped"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request to table with facade, with audit, consistency are set",
+					"item": [
+						{
+							"name": "Creates a table",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"postman.setEnvironmentVariable('table', 'postman_'+uuid.v4());"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options=placement:'ugc_global:ugc'&audit=comment:'initial+provisioning'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "placement:'ugc_global:ugc'"
+										},
+										{
+											"key": "audit",
+											"value": "comment:'initial+provisioning'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Creates a facade",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const isLocal = pm.environment.get(\"baseurl_dc1\").includes('localhost'); ",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-BV-Api-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc2}}/sor/1/_facade/{{table}}?options=placement:'ugc_us:ugc'&audit=audit=comment:'initial+facade+provisioning'",
+									"host": [
+										"{{baseurl_dc2}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_facade",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "placement:'ugc_us:ugc'"
+										},
+										{
+											"key": "audit",
+											"value": "audit=comment:'initial+facade+provisioning'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if facade is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/_facade/:table?options=<string>&audit=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_facade",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 403\", function () {",
+											"    pm.response.to.have.status(403);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.text()).to.eql(\"Access denied. Update intended for a facade, but the table would be updated.\");",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[\n         {\n            \"~id\": \"1\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo1\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\",\\\"field3\\\":\\\"value3\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n              \"comment\": \"Adding demo1 document\"\n            }\n          },\n          {\n            \"~id\": \"2\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo2\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1.1\\\",\\\"field5\\\":\\\"value5\\\",\\\"field32\\\":\\\"value33\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n            \"comment\": \"Update and Add\"\n        }\n      }\n]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1?audit=comment:'imports+stream+of+deltas'&consistency=STRONG&facade=true",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "<string>",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "comment:'imports+stream+of+deltas'"
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "true"
+										}
+									]
+								},
+								"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												},
+												{
+													"key": "consistency",
+													"value": "STRONG"
+												},
+												{
+													"key": "facade",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Drops a table",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit=comment:'table_removal'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "audit",
+											"value": "comment:'table_removal'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is dropped"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request to table with facade is true, with audit, consistency are set. To datacenter with facade",
+					"item": [
+						{
+							"name": "Creates a table",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"postman.setEnvironmentVariable('table', 'postman_'+uuid.v4());"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const isLocal = pm.environment.get(\"baseurl_dc1\").includes('localhost'); ",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options=placement:'ugc_eu:ugc'&audit=comment:'initial+provisioning'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "placement:'ugc_eu:ugc'"
+										},
+										{
+											"key": "audit",
+											"value": "comment:'initial+provisioning'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options=<string>&audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Creates a facade",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const isLocal = pm.environment.get(\"baseurl_dc1\").includes('localhost'); ",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "X-BV-Api-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc2}}/sor/1/_facade/{{table}}?options=placement:'ugc_us:ugc'&audit=audit=comment:'initial+facade+provisioning'",
+									"host": [
+										"{{baseurl_dc2}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_facade",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "placement:'ugc_us:ugc'"
+										},
+										{
+											"key": "audit",
+											"value": "audit=comment:'initial+facade+provisioning'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if facade is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/_facade/:table?options=<string>&audit=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_facade",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const isLocal = pm.environment.get(\"baseurl_dc1\").includes('localhost'); ",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[\n         {\n            \"~id\": \"1\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo1\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\",\\\"field3\\\":\\\"value3\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n              \"comment\": \"Adding demo1 document\"\n            }\n          },\n          {\n            \"~id\": \"2\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo2\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1.1\\\",\\\"field5\\\":\\\"value5\\\",\\\"field32\\\":\\\"value33\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n            \"comment\": \"Update and Add\"\n        }\n      }\n]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc2}}/sor/1?audit=comment:'imports+stream+of+deltas'&consistency=STRONG&facade=true",
+									"host": [
+										"{{baseurl_dc2}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "<string>",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "comment:'imports+stream+of+deltas'"
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "true"
+										}
+									]
+								},
+								"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												},
+												{
+													"key": "consistency",
+													"value": "STRONG"
+												},
+												{
+													"key": "facade",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Imports an arbitrary size stream of deltas and/or JSON objects Copy",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const isLocal = pm.environment.get(\"baseurl_dc1\").includes('localhost'); ",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({\"success\":true});",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disabledSystemHeaders": {
+									"content-type": true
+								}
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-deltas",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\"~id\": \"1\",\n\"~table\": \"{{table}}\",\n\"table\": \"{{table}}\",\n\"key\": \"demo1\",\n\"delta\": \"{\\\"field1\\\":\\\"value1\\\",\\\"field2\\\":\\\"value2\\\",\\\"field3\\\":\\\"value3\\\"}\",\n\"consistency\": \"STRONG\",\n\"audit\": {\n\"comment\": \"Adding demo1 document\"\n}} \n{\n\"~id\": \"2\",\n            \"~table\": \"{{table}}\",\n            \"table\": \"{{table}}\",\n            \"key\": \"demo2\",\n            \"delta\": \"{\\\"field1\\\":\\\"value1.1\\\",\\\"field5\\\":\\\"value5\\\",\\\"field32\\\":\\\"value33\\\"}\",\n            \"consistency\": \"STRONG\",\n            \"audit\": {\n            \"comment\": \"Update and Add\"\n        }\n      }",
+									"options": {
+										"raw": {
+											"language": "text"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc2}}/sor/1?audit=comment:'imports+stream+of+deltas'&consistency=STRONG&facade=true",
+									"host": [
+										"{{baseurl_dc2}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "<string>",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "comment:'imports+stream+of+deltas'"
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "true"
+										}
+									]
+								},
+								"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "<string>"
+												},
+												{
+													"key": "audit",
+													"value": "<string>"
+												},
+												{
+													"key": "consistency",
+													"value": "STRONG"
+												},
+												{
+													"key": "facade",
+													"value": "<string>"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Drops a table",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const isLocal = pm.environment.get(\"baseurl_dc1\").includes('localhost'); ",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"(isLocal ? pm.test.skip : pm.test)(\"Body matches string\", function () {",
+											"    pm.expect(pm.response.json()).to.eql({ \"success\": true });",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"type": "text",
+										"value": "{{api_key}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit=comment:'table_removal'",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "audit",
+											"value": "comment:'table_removal'"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is dropped"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?audit=<string>",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "audit",
+													"value": "<string>"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Imports an arbitrary size stream of deltas and/or JSON objects",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"id\": \"<string>\",\n    \"authenticationId\": \"<string>\"\n}"
+						},
+						"url": {
+							"raw": "{{baseurl_dc1}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"sor",
+								"1"
+							],
+							"query": [
+								{
+									"key": "changeId",
+									"value": "<string>"
+								},
+								{
+									"key": "audit",
+									"value": "<string>"
+								},
+								{
+									"key": "consistency",
+									"value": "STRONG"
+								},
+								{
+									"key": "facade",
+									"value": "<string>"
+								}
+							]
+						},
+						"description": "Imports an arbitrary size stream of deltas and/or JSON objects.  Two formats are supported: array syntax\n     * ('[' object ',' object ',' ... ']') and whitespace-separated objects (object whitespace object whitespace ...)\n     * Each piece of content must have top-level \"~id\" and \"~table\" attributes that determines the table and object\n     * key in the SoR."
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/sor/1?changeId=<string>&audit=<string>&consistency=STRONG&facade=<string>",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"sor",
+										"1"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "<string>"
+										},
+										{
+											"key": "audit",
+											"value": "<string>"
+										},
+										{
+											"key": "consistency",
+											"value": "STRONG"
+										},
+										{
+											"key": "facade",
+											"value": "<string>"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+						}
+					]
+				}
+			]
 		}
 	],
 	"event": [


### PR DESCRIPTION
## What Are We Doing Here?

We are extending automation testing coverage by adding postman tests. This commit is covering all kind of checks for POST /sor/1/ api endpoint.

Feature coverage is additionally updated in our (for now internal) testing artefacts.

## How to Test and Verify

1. Check out this PR
2. Start emodb on local
3. Open postman
4. Import "emodb_tests.postman_collection.json" as a collection
5. Import "sor-1-_table.postman_environment.json" as environment variables
6. Execute tests in postman
7. Profit

Expected result: All tests are successfully executed on local environment

## Risk
Low
There are no changes to application code base

### Level 

All newly added postman tests should be executed without failures.


### Required Testing

`Smoke`, `Regression`, or `Manual`. (All changes except documentation need smoke
testing at a minimum).

### Risk Summary

There are no risks to application, only tests are involved and it is about adding a new tests

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
