### PR TITLE
Pd 169591 postman tests of bus 1 subscription renew

### DIFF
--- a/quality/postman/emodb_tests_databus_renew.postman_collection.json
+++ b/quality/postman/emodb_tests_databus_renew.postman_collection.json
@@ -1,0 +1,5350 @@
+{
+	"info": {
+		"_postman_id": "89f5b563-f0fd-4828-adaf-68a9fe621c04",
+		"name": "EmoDB_Tests_databus_renew",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Renew",
+			"item": [
+				{
+					"name": "TC: Request without permission",
+					"item": [
+						{
+							"name": "Creates a table",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('table', 'postman_'+uuid.v4());",
+											"",
+											"pm.environment.set(\"options\", \"placement:'ugc_global:ugc'\");",
+											"pm.environment.set(\"audit\", \"comment:'initial+provisioning'\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Successful PUT request\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true);    ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options={{options}}&audit={{audit}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "{{options}}"
+										},
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options={{options}}&audit={{audit}}",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "{{options}}"
+												},
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Subscribe operation.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('subscription', 'postman_'+uuid.v4()+'_test_subscription');"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true);    ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-condition"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "intrinsic(\"~table\":\"{{table}}\")"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}"
+									],
+									"query": [
+										{
+											"key": "ttl",
+											"value": "{{ttl}}"
+										},
+										{
+											"key": "eventTtl",
+											"value": "{{eventTtl}}"
+										},
+										{
+											"key": "ignoreSuppressedEvents",
+											"value": "{{ignoreSuppressedEvents}}"
+										},
+										{
+											"key": "includeDefaultJoinFilter",
+											"value": "{{includeDefaultJoinFilter}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription"
+											],
+											"query": [
+												{
+													"key": "ttl",
+													"value": "{{ttl}}"
+												},
+												{
+													"key": "eventTtl",
+													"value": "{{eventTtl}}"
+												},
+												{
+													"key": "ignoreSuppressedEvents",
+													"value": "{{ignoreSuppressedEvents}}"
+												},
+												{
+													"key": "includeDefaultJoinFilter",
+													"value": "{{includeDefaultJoinFilter}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Creates, modifies or deletes a piece of content in the data store by applying a delta.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.json()).to.have.keys(\"success\", \"debug\");",
+											"    pm.expect(pm.response.json().debug).to.have.keys(\"changeId\");",
+											"    pm.expect(pm.response.json().success).to.eql(true);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('document_id', uuid.v4());",
+											"",
+											"pm.environment.set(\"audit\", \"comment:'update+data'\");",
+											"pm.environment.set(\"consistency\", \"GLOBAL\");",
+											"pm.environment.set(\"tag\", \"test_tag\");",
+											"pm.environment.set(\"debug\", \"true\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-delta"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{..,\"test_delta\":\"set\"}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/{{table}}/{{document_id}}?audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"{{table}}",
+										"{{document_id}}"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "{{change_id}}",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										},
+										{
+											"key": "consistency",
+											"value": "{{consistency}}"
+										},
+										{
+											"key": "tag",
+											"value": "{{tag}}"
+										},
+										{
+											"key": "debug",
+											"value": "{{debug}}"
+										}
+									]
+								},
+								"description": "Creates, modifies or deletes a piece of content in the data store by\n applying a delta.  Expects a delta in the format produced by the\n {@link Deltas} class and {@link Delta#toString()}."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/:table/:key?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												":table",
+												":key"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "{{change_id}}"
+												},
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												},
+												{
+													"key": "consistency",
+													"value": "{{consistency}}"
+												},
+												{
+													"key": "tag",
+													"value": "{{tag}}"
+												},
+												{
+													"key": "debug",
+													"value": "{{debug}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												},
+												{
+													"key": "key"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.to.have.body('0'));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "poll operation.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json().length < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json().length > 0;",
+											"        },\"Retrying to get events to poll\");    ",
+											"    pm.expect(response.json().length > 0);",
+											"    pm.expect(response.json()[0]).to.have.keys(\"eventKey\", \"content\");",
+											"    pm.expect(response.json()[0].content).to.have.keys(\"test_delta\",\"test_table\",\"customer\",\"~id\",\"~table\",\"~version\",\"~signature\",\"~deleted\",\"~firstUpdateAt\",\"~lastUpdateAt\",\"~lastMutateAt\");",
+											"    }",
+											"}));",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/poll`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/poll",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"poll"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}",
+											"disabled": true
+										},
+										{
+											"key": "ttl",
+											"value": "{{ttl}}",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "{{limit}}",
+											"disabled": true
+										},
+										{
+											"key": "ignoreLongPoll",
+											"value": "{{ignoreLongPoll}}",
+											"disabled": true
+										},
+										{
+											"key": "includeTags",
+											"value": "{{includeTags}}",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Returns a Response."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"poll"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												},
+												{
+													"key": "ttl",
+													"value": "{{ttl}}"
+												},
+												{
+													"key": "limit",
+													"value": "{{limit}}"
+												},
+												{
+													"key": "ignoreLongPoll",
+													"value": "{{ignoreLongPoll}}"
+												},
+												{
+													"key": "includeTags",
+													"value": "{{includeTags}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "Internal Server Error",
+									"code": 500,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json() < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json() > 0;",
+											"        }, \"Retrying request\");",
+											"    }",
+											"    pm.expect(response.json()).to.be.above(0);    ",
+											"}));",
+											" "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/claimcount?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Renew operation.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.environment.set(\"ttl\", \"300\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"var response = pm.response;",
+											"",
+											"pm.test(\"Assert response code\", function () {",
+											"    response.to.have.status(403);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(response.json().reason).to.eql(\"not authorized\"); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key_no_rights}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew?partitioned={{partitioned}}&ttl={{ttl}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"renew"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										},
+										{
+											"key": "ttl",
+											"value": "{{ttl}}"
+										}
+									]
+								},
+								"description": "Returns a SucessResponse."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"renew"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "adipisicing ea"
+												},
+												{
+													"key": "ttl",
+													"value": "30"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 3",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json() > 0) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json() == 0;",
+											"        }, \"Retrying request\");",
+											"    }",
+											"    pm.expect(response.json()).to.eql(0); ",
+											"}));",
+											" "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/claimcount?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Unsubscribe operation.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(pm.response.status !== 200) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();",
+											"            return response.code === 200;",
+											"        }, \"Error retrying unsubscribe checking status \");",
+											"    }",
+											"    pm.expect(response).to.have.status(200);",
+											"    pm.expect(response.json().success).eql(true);",
+											"}));",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"DELETE\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns an Iterator of Subscription."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Drops a table",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Successful DELETE request\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.environment.set(\"audit\", \"comment:'remove+table'\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit={{audit}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is dropped"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/_table/:table?audit={{audit}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request without parameters to subscription with polled events",
+					"item": [
+						{
+							"name": "Creates a table",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('table', 'postman_'+uuid.v4());",
+											"",
+											"pm.environment.set(\"options\", \"placement:'ugc_global:ugc'\");",
+											"pm.environment.set(\"audit\", \"comment:'initial+provisioning'\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Successful PUT request\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true);    ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options={{options}}&audit={{audit}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "{{options}}"
+										},
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options={{options}}&audit={{audit}}",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "{{options}}"
+												},
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Subscribe operation.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('subscription', 'postman_'+uuid.v4()+'_test_subscription');"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true);    ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-condition"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "intrinsic(\"~table\":\"{{table}}\")"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}"
+									],
+									"query": [
+										{
+											"key": "ttl",
+											"value": "{{ttl}}"
+										},
+										{
+											"key": "eventTtl",
+											"value": "{{eventTtl}}"
+										},
+										{
+											"key": "ignoreSuppressedEvents",
+											"value": "{{ignoreSuppressedEvents}}"
+										},
+										{
+											"key": "includeDefaultJoinFilter",
+											"value": "{{includeDefaultJoinFilter}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription"
+											],
+											"query": [
+												{
+													"key": "ttl",
+													"value": "{{ttl}}"
+												},
+												{
+													"key": "eventTtl",
+													"value": "{{eventTtl}}"
+												},
+												{
+													"key": "ignoreSuppressedEvents",
+													"value": "{{ignoreSuppressedEvents}}"
+												},
+												{
+													"key": "includeDefaultJoinFilter",
+													"value": "{{includeDefaultJoinFilter}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Creates, modifies or deletes a piece of content in the data store by applying a delta.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.json()).to.have.keys(\"success\", \"debug\");",
+											"    pm.expect(pm.response.json().debug).to.have.keys(\"changeId\");",
+											"    pm.expect(pm.response.json().success).to.eql(true);",
+											"",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('document_id1', uuid.v4());",
+											"",
+											"pm.environment.set(\"audit\", \"comment:'update+data'\");",
+											"pm.environment.set(\"consistency\", \"GLOBAL\");",
+											"pm.environment.set(\"tag\", \"test_tag\");",
+											"pm.environment.set(\"debug\", \"true\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-delta"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{..,\"test_delta\":\"set\"}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/{{table}}/{{document_id1}}?audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"{{table}}",
+										"{{document_id1}}"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "{{change_id}}",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										},
+										{
+											"key": "consistency",
+											"value": "{{consistency}}"
+										},
+										{
+											"key": "tag",
+											"value": "{{tag}}"
+										},
+										{
+											"key": "debug",
+											"value": "{{debug}}"
+										}
+									]
+								},
+								"description": "Creates, modifies or deletes a piece of content in the data store by\n applying a delta.  Expects a delta in the format produced by the\n {@link Deltas} class and {@link Delta#toString()}."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/:table/:key?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												":table",
+												":key"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "{{change_id}}"
+												},
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												},
+												{
+													"key": "consistency",
+													"value": "{{consistency}}"
+												},
+												{
+													"key": "tag",
+													"value": "{{tag}}"
+												},
+												{
+													"key": "debug",
+													"value": "{{debug}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												},
+												{
+													"key": "key"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.to.have.body('0'));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "poll operation.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json().length < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json().length > 0;",
+											"        },\"Retrying to get events to poll\");    ",
+											"    pm.expect(response.json().length > 0);",
+											"    pm.expect(response.json()[0]).to.have.keys(\"eventKey\", \"content\");",
+											"    pm.expect(response.json()[0].content).to.have.keys(\"test_delta\",\"test_table\",\"customer\",\"~id\",\"~table\",\"~version\",\"~signature\",\"~deleted\",\"~firstUpdateAt\",\"~lastUpdateAt\",\"~lastMutateAt\");",
+											"    }    ",
+											"}));",
+											"",
+											"pm.environment.set(\"eventId\", response.json()[0].eventKey);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/poll`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/poll",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"poll"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}",
+											"disabled": true
+										},
+										{
+											"key": "ttl",
+											"value": "{{ttl}}",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "{{limit}}",
+											"disabled": true
+										},
+										{
+											"key": "ignoreLongPoll",
+											"value": "{{ignoreLongPoll}}",
+											"disabled": true
+										},
+										{
+											"key": "includeTags",
+											"value": "{{includeTags}}",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Returns a Response."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"poll"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												},
+												{
+													"key": "ttl",
+													"value": "{{ttl}}"
+												},
+												{
+													"key": "limit",
+													"value": "{{limit}}"
+												},
+												{
+													"key": "ignoreLongPoll",
+													"value": "{{ignoreLongPoll}}"
+												},
+												{
+													"key": "includeTags",
+													"value": "{{includeTags}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "Internal Server Error",
+									"code": 500,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json() < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json() > 0;",
+											"        }, \"Retrying request\");",
+											"    }",
+											"    pm.expect(response.json()).to.be.above(0);    ",
+											"}));",
+											" "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/claimcount?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Renew operation.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/renew`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"POST\");",
+											"",
+											"var body = [pm.environment.get(\"eventId\")];",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"",
+											"pm.test(\"Assert response code is 200\", function () {",
+											"    response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body is true\", asyncTest(async function () {",
+											"    if((response.text()).includes(\"Invalid event ID checksum.\")) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();",
+											"            return (response.text()).includes(\"Invalid event ID checksum.\");",
+											"        }, \"Error retrying renew events\");",
+											"    }",
+											"    pm.expect(response.json().success).to.eql(true); ",
+											"}));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"renew"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}",
+											"disabled": true
+										},
+										{
+											"key": "ttl",
+											"value": "{{ttl}}",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Returns a SucessResponse."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"renew"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "adipisicing ea"
+												},
+												{
+													"key": "ttl",
+													"value": "30"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 3",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json() < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json() > 0;",
+											"        }, \"Retrying request\");",
+											"    }",
+											"    pm.expect(response.json()).to.be.above(0); ",
+											"}));",
+											" "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/claimcount?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Unsubscribe operation.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(pm.response.status !== 200) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();",
+											"            return response.code === 200;",
+											"        }, \"Error retrying unsubscribe checking status \");",
+											"    }",
+											"    pm.expect(response).to.have.status(200);",
+											"    pm.expect(response.json().success).eql(true);",
+											"}));",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"DELETE\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns an Iterator of Subscription."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Drops a table",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Successful DELETE request\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.environment.set(\"audit\", \"comment:'remove+table'\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit={{audit}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is dropped"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/_table/:table?audit={{audit}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request with ttl = 25, partitioned = false parameters to subscription with polled events",
+					"item": [
+						{
+							"name": "Creates a table",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('table', 'postman_'+uuid.v4());",
+											"",
+											"pm.environment.set(\"options\", \"placement:'ugc_global:ugc'\");",
+											"pm.environment.set(\"audit\", \"comment:'initial+provisioning'\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Successful PUT request\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true);    ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options={{options}}&audit={{audit}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "{{options}}"
+										},
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options={{options}}&audit={{audit}}",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "{{options}}"
+												},
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Subscribe operation.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('subscription', 'postman_'+uuid.v4()+'_test_subscription');"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true);    ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-condition"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "intrinsic(\"~table\":\"{{table}}\")"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}"
+									],
+									"query": [
+										{
+											"key": "ttl",
+											"value": "{{ttl}}"
+										},
+										{
+											"key": "eventTtl",
+											"value": "{{eventTtl}}"
+										},
+										{
+											"key": "ignoreSuppressedEvents",
+											"value": "{{ignoreSuppressedEvents}}"
+										},
+										{
+											"key": "includeDefaultJoinFilter",
+											"value": "{{includeDefaultJoinFilter}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription"
+											],
+											"query": [
+												{
+													"key": "ttl",
+													"value": "{{ttl}}"
+												},
+												{
+													"key": "eventTtl",
+													"value": "{{eventTtl}}"
+												},
+												{
+													"key": "ignoreSuppressedEvents",
+													"value": "{{ignoreSuppressedEvents}}"
+												},
+												{
+													"key": "includeDefaultJoinFilter",
+													"value": "{{includeDefaultJoinFilter}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Creates, modifies or deletes a piece of content in the data store by applying a delta.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.json()).to.have.keys(\"success\", \"debug\");",
+											"    pm.expect(pm.response.json().debug).to.have.keys(\"changeId\");",
+											"    pm.expect(pm.response.json().success).to.eql(true);",
+											"",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('document_id1', uuid.v4());",
+											"",
+											"pm.environment.set(\"audit\", \"comment:'update+data'\");",
+											"pm.environment.set(\"consistency\", \"GLOBAL\");",
+											"pm.environment.set(\"tag\", \"test_tag\");",
+											"pm.environment.set(\"debug\", \"true\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-delta"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{..,\"test_delta\":\"set\"}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/{{table}}/{{document_id1}}?audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"{{table}}",
+										"{{document_id1}}"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "{{change_id}}",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										},
+										{
+											"key": "consistency",
+											"value": "{{consistency}}"
+										},
+										{
+											"key": "tag",
+											"value": "{{tag}}"
+										},
+										{
+											"key": "debug",
+											"value": "{{debug}}"
+										}
+									]
+								},
+								"description": "Creates, modifies or deletes a piece of content in the data store by\n applying a delta.  Expects a delta in the format produced by the\n {@link Deltas} class and {@link Delta#toString()}."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/:table/:key?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												":table",
+												":key"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "{{change_id}}"
+												},
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												},
+												{
+													"key": "consistency",
+													"value": "{{consistency}}"
+												},
+												{
+													"key": "tag",
+													"value": "{{tag}}"
+												},
+												{
+													"key": "debug",
+													"value": "{{debug}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												},
+												{
+													"key": "key"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.to.have.body('0'));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "poll operation.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json().length < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json().length > 0;",
+											"        },\"Retrying to get events to poll\");    ",
+											"    pm.expect(response.json().length > 0);",
+											"    pm.expect(response.json()[0]).to.have.keys(\"eventKey\", \"content\");",
+											"    pm.expect(response.json()[0].content).to.have.keys(\"test_delta\",\"test_table\",\"customer\",\"~id\",\"~table\",\"~version\",\"~signature\",\"~deleted\",\"~firstUpdateAt\",\"~lastUpdateAt\",\"~lastMutateAt\");",
+											"    }    ",
+											"}));",
+											"",
+											"pm.environment.set(\"eventId\", response.json()[0].eventKey);",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/poll`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/poll",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"poll"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}",
+											"disabled": true
+										},
+										{
+											"key": "ttl",
+											"value": "{{ttl}}",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "{{limit}}",
+											"disabled": true
+										},
+										{
+											"key": "ignoreLongPoll",
+											"value": "{{ignoreLongPoll}}",
+											"disabled": true
+										},
+										{
+											"key": "includeTags",
+											"value": "{{includeTags}}",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Returns a Response."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"poll"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												},
+												{
+													"key": "ttl",
+													"value": "{{ttl}}"
+												},
+												{
+													"key": "limit",
+													"value": "{{limit}}"
+												},
+												{
+													"key": "ignoreLongPoll",
+													"value": "{{ignoreLongPoll}}"
+												},
+												{
+													"key": "includeTags",
+													"value": "{{includeTags}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "Internal Server Error",
+									"code": 500,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json() < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json() > 0;",
+											"        }, \"Retrying request\");",
+											"    }",
+											"    pm.expect(response.json()).to.be.above(0);    ",
+											"}));",
+											" "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/claimcount?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Renew operation.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.environment.set(\"partitioned\", \"false\");",
+											"pm.environment.set(\"ttl\", 25);",
+											"",
+											"var body = [pm.environment.get(\"eventId\")];",
+											"",
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/renew?partitioned=${pm.environment.get(\"partitioned\")}&ttl=${pm.environment.get(\"ttl\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"POST\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"",
+											"pm.test(\"Assert response code is 200\", function () {",
+											"    response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body is true\", asyncTest(async function () {",
+											"    if((response.text()).includes(\"Invalid event ID checksum.\")) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();",
+											"            return (response.text()).includes(\"Invalid event ID checksum.\");",
+											"        }, \"Error retrying renew events\");",
+											"    }",
+											"    pm.expect(response.json().success).to.eql(true); ",
+											"}));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew?partitioned={{partitioned}}&ttl={{ttl}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"renew"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										},
+										{
+											"key": "ttl",
+											"value": "{{ttl}}"
+										}
+									]
+								},
+								"description": "Returns a SucessResponse."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"renew"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "adipisicing ea"
+												},
+												{
+													"key": "ttl",
+													"value": "30"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 3",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json() < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json() > 0;",
+											"        }, \"Retrying request\");",
+											"    }",
+											"    pm.expect(response.json()).to.be.above(0); ",
+											"}));",
+											" "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/claimcount?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Unsubscribe operation.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(pm.response.status !== 200) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();",
+											"            return response.code === 200;",
+											"        }, \"Error retrying unsubscribe checking status \");",
+											"    }",
+											"    pm.expect(response).to.have.status(200);",
+											"    pm.expect(response.json().success).eql(true);",
+											"}));",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"DELETE\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns an Iterator of Subscription."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Drops a table",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Successful DELETE request\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.environment.set(\"audit\", \"comment:'remove+table'\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit={{audit}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is dropped"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/_table/:table?audit={{audit}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "TC: Request with ttl = 40, partitioned = true parameters to subscription with polled events",
+					"item": [
+						{
+							"name": "Creates a table",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('table', 'postman_'+uuid.v4());",
+											"",
+											"pm.environment.set(\"options\", \"placement:'ugc_global:ugc'\");",
+											"pm.environment.set(\"audit\", \"comment:'initial+provisioning'\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Successful PUT request\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true);    ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"customer\": \"postman\",\n    \"test_table\":\"{{table}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options={{options}}&audit={{audit}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "options",
+											"value": "{{options}}"
+										},
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is created"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options={{options}}&audit={{audit}}",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "options",
+													"value": "{{options}}"
+												},
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Subscribe operation.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('subscription', 'postman_'+uuid.v4()+'_test_subscription');"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true);    ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-condition"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "intrinsic(\"~table\":\"{{table}}\")"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}"
+									],
+									"query": [
+										{
+											"key": "ttl",
+											"value": "{{ttl}}"
+										},
+										{
+											"key": "eventTtl",
+											"value": "{{eventTtl}}"
+										},
+										{
+											"key": "ignoreSuppressedEvents",
+											"value": "{{ignoreSuppressedEvents}}"
+										},
+										{
+											"key": "includeDefaultJoinFilter",
+											"value": "{{includeDefaultJoinFilter}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription"
+											],
+											"query": [
+												{
+													"key": "ttl",
+													"value": "{{ttl}}"
+												},
+												{
+													"key": "eventTtl",
+													"value": "{{eventTtl}}"
+												},
+												{
+													"key": "ignoreSuppressedEvents",
+													"value": "{{ignoreSuppressedEvents}}"
+												},
+												{
+													"key": "includeDefaultJoinFilter",
+													"value": "{{includeDefaultJoinFilter}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Creates, modifies or deletes a piece of content in the data store by applying a delta.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.json()).to.have.keys(\"success\", \"debug\");",
+											"    pm.expect(pm.response.json().debug).to.have.keys(\"changeId\");",
+											"    pm.expect(pm.response.json().success).to.eql(true);",
+											"",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"var uuid = require('uuid');",
+											"pm.environment.set('document_id1', uuid.v4());",
+											"",
+											"pm.environment.set(\"audit\", \"comment:'update+data'\");",
+											"pm.environment.set(\"consistency\", \"GLOBAL\");",
+											"pm.environment.set(\"tag\", \"test_tag\");",
+											"pm.environment.set(\"debug\", \"true\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x.json-delta"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{..,\"test_delta\":\"set\"}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/{{table}}/{{document_id1}}?audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"{{table}}",
+										"{{document_id1}}"
+									],
+									"query": [
+										{
+											"key": "changeId",
+											"value": "{{change_id}}",
+											"disabled": true
+										},
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										},
+										{
+											"key": "consistency",
+											"value": "{{consistency}}"
+										},
+										{
+											"key": "tag",
+											"value": "{{tag}}"
+										},
+										{
+											"key": "debug",
+											"value": "{{debug}}"
+										}
+									]
+								},
+								"description": "Creates, modifies or deletes a piece of content in the data store by\n applying a delta.  Expects a delta in the format produced by the\n {@link Deltas} class and {@link Delta#toString()}."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/:table/:key?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												":table",
+												":key"
+											],
+											"query": [
+												{
+													"key": "changeId",
+													"value": "{{change_id}}"
+												},
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												},
+												{
+													"key": "consistency",
+													"value": "{{consistency}}"
+												},
+												{
+													"key": "tag",
+													"value": "{{tag}}"
+												},
+												{
+													"key": "debug",
+													"value": "{{debug}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												},
+												{
+													"key": "key"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", function () {",
+											"    pm.expect(pm.response.to.have.body('0'));",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "poll operation.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json().length < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json().length > 0;",
+											"        },\"Retrying to get events to poll\");    ",
+											"    }    ",
+											"",
+											"    pm.expect(response.json().length > 0);",
+											"    pm.expect(response.json()[0]).to.have.keys(\"eventKey\", \"content\");",
+											"    pm.expect(response.json()[0].content).to.have.keys(\"test_delta\",\"test_table\",\"customer\",\"~id\",\"~table\",\"~version\",\"~signature\",\"~deleted\",\"~firstUpdateAt\",\"~lastUpdateAt\",\"~lastMutateAt\");",
+											"",
+											"/*",
+											"    if(response.json().length > 0) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();",
+											"            return response.json().length == 0;",
+											"        }, \"Retrying until there no events to poll\");",
+											"    }",
+											"    pm.expect(response.json().length).to.be.eql(0);",
+											" */   ",
+											"}));",
+											"",
+											"pm.environment.set(\"eventId\", response.json()[0].eventKey);"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/poll`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/poll",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"poll"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}",
+											"disabled": true
+										},
+										{
+											"key": "ttl",
+											"value": "{{ttl}}",
+											"disabled": true
+										},
+										{
+											"key": "limit",
+											"value": "{{limit}}",
+											"disabled": true
+										},
+										{
+											"key": "ignoreLongPoll",
+											"value": "{{ignoreLongPoll}}",
+											"disabled": true
+										},
+										{
+											"key": "includeTags",
+											"value": "{{includeTags}}",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Returns a Response."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"poll"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												},
+												{
+													"key": "ttl",
+													"value": "{{ttl}}"
+												},
+												{
+													"key": "limit",
+													"value": "{{limit}}"
+												},
+												{
+													"key": "ignoreLongPoll",
+													"value": "{{ignoreLongPoll}}"
+												},
+												{
+													"key": "includeTags",
+													"value": "{{includeTags}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "Internal Server Error",
+									"code": 500,
+									"_postman_previewlanguage": "text",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "text/plain"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json() < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json() > 0;",
+											"        }, \"Retrying request\");",
+											"    }",
+											"    pm.expect(response.json()).to.be.above(0);    ",
+											"}));",
+											" "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/claimcount?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Renew operation.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.environment.set(\"partitioned\", \"true\");",
+											"pm.environment.set(\"ttl\", 40);",
+											"",
+											"var body = [pm.environment.get(\"eventId\")];",
+											"",
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/renew?partitioned=${pm.environment.get(\"partitioned\")}&ttl=${pm.environment.get(\"ttl\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"POST\");"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"",
+											"pm.test(\"Assert response code is 200\", function () {",
+											"    response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body is true\", asyncTest(async function () {",
+											"    if((response.text()).includes(\"Invalid event ID checksum.\")) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();",
+											"            return !(response.text()).includes(\"Invalid event ID checksum.\");",
+											"        }, \"Error retrying renew events\");",
+											"    }",
+											"    pm.expect(response.json().success).to.eql(true); ",
+											"}));"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "[]"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew?partitioned={{partitioned}}&ttl={{ttl}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"renew"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										},
+										{
+											"key": "ttl",
+											"value": "{{ttl}}"
+										}
+									]
+								},
+								"description": "Returns a SucessResponse."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "POST",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"renew"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "adipisicing ea"
+												},
+												{
+													"key": "ttl",
+													"value": "30"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Gets the claim count. 3",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(response.json() < 1) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();            ",
+											"            return response.json() > 0;",
+											"        }, \"Retrying request\");",
+											"    }",
+											"    pm.expect(response.json()).to.be.above(0); ",
+											"}));",
+											" "
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}/claimcount?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"GET\");",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}",
+										"claimcount"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns a long."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "GET",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription",
+												"claimcount"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": ""
+								}
+							]
+						},
+						{
+							"name": "Unsubscribe operation.",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const retryRequestCall = JSON.parse(pm.globals.get(\"retryRequestCall\"));",
+											"const retryRequest = eval(retryRequestCall.retryRequest);",
+											"",
+											"var response = pm.response;",
+											"pm.test(\"Assert response body\", asyncTest(async function () {",
+											"    if(pm.response.status !== 200) {",
+											"        await waitUntil(setTimeout, clearTimeout, async () => {",
+											"            response = await retryRequest();",
+											"            return response.code === 200;",
+											"        }, \"Error retrying unsubscribe checking status \");",
+											"    }",
+											"    pm.expect(response).to.have.status(200);",
+											"    pm.expect(response.json().success).eql(true);",
+											"}));",
+											"",
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const url = `${pm.environment.get(\"baseurl_dc1\")}/bus/1/${pm.environment.get(\"subscription\")}?partitioned=${pm.environment.get(\"partitioned\")}`;",
+											"pm.environment.set(\"url\", url);",
+											"pm.environment.set(\"method\", \"DELETE\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?partitioned={{partitioned}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										"{{subscription}}"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "{{partitioned}}"
+										}
+									]
+								},
+								"description": "Returns an Iterator of Subscription."
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/bus/1/:subscription?partitioned={{partitioned}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"bus",
+												"1",
+												":subscription"
+											],
+											"query": [
+												{
+													"key": "partitioned",
+													"value": "{{partitioned}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "subscription"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						},
+						{
+							"name": "Drops a table",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Successful DELETE request\", function () {",
+											"    pm.expect(pm.response.json().success).eql(true); ",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.environment.set(\"audit\", \"comment:'remove+table'\");"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "X-BV-API-Key",
+										"value": "{{api_key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit={{audit}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"sor",
+										"1",
+										"_table",
+										"{{table}}"
+									],
+									"query": [
+										{
+											"key": "audit",
+											"value": "{{audit}}"
+										}
+									]
+								},
+								"description": "Returns a SuccessResponse if table is dropped"
+							},
+							"response": [
+								{
+									"name": "successful operation",
+									"originalRequest": {
+										"method": "DELETE",
+										"header": [],
+										"url": {
+											"raw": "{{baseUrl}}/sor/1/_table/:table?audit={{audit}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"sor",
+												"1",
+												"_table",
+												":table"
+											],
+											"query": [
+												{
+													"key": "audit",
+													"value": "{{audit}}"
+												}
+											],
+											"variable": [
+												{
+													"key": "table"
+												}
+											]
+										}
+									},
+									"status": "OK",
+									"code": 200,
+									"_postman_previewlanguage": "json",
+									"header": [
+										{
+											"key": "Content-Type",
+											"value": "application/json"
+										}
+									],
+									"cookie": [],
+									"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Renew operation.",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "[]"
+						},
+						"url": {
+							"raw": "{{baseurl_dc1}}/bus/1/:subscription/renew?partitioned={{partitioned}}&ttl={{ttl}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"bus",
+								"1",
+								":subscription",
+								"renew"
+							],
+							"query": [
+								{
+									"key": "partitioned",
+									"value": "{{partitioned}}"
+								},
+								{
+									"key": "ttl",
+									"value": "{{ttl}}"
+								}
+							],
+							"variable": [
+								{
+									"key": "subscription",
+									"value": "{{subscription}}",
+									"description": "(Required) "
+								}
+							]
+						},
+						"description": "Returns a SucessResponse."
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"url": {
+									"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"bus",
+										"1",
+										":subscription",
+										"renew"
+									],
+									"query": [
+										{
+											"key": "partitioned",
+											"value": "adipisicing ea"
+										},
+										{
+											"key": "ttl",
+											"value": "30"
+										}
+									],
+									"variable": [
+										{
+											"key": "subscription"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"const retryRequest = () => {",
+							"    return new Promise((resolve, reject) => {",
+							"        pm.sendRequest({",
+							"            url: `${pm.environment.get(\"url\")}`,",
+							"            method: `${pm.environment.get(\"method\")}`,",
+							"            header: {",
+							"                \"X-BV-API-Key\": pm.environment.get(\"api_key\"),",
+							"                \"Content-Type\": \"application/json\"",
+							"            },",
+							"            body: pm.environment.get(\"body\")",
+							"        }, (error, response) => {",
+							"            if (error) {",
+							"                reject(error);",
+							"            }",
+							"            resolve(response);            ",
+							"        });",
+							"    });",
+							"};",
+							"",
+							"const retryRequestCall = {",
+							"    retryRequest: retryRequest.toString()",
+							"};",
+							"",
+							"pm.globals.set(\"retryRequestCall\", JSON.stringify(retryRequestCall));",
+							"",
+							"pm.environment.set(\"partitioned\", \"false\");",
+							"pm.environment.set(\"ttl\", \"86400\");",
+							"pm.environment.set(\"eventTtl\", \"86400\");",
+							"pm.environment.set(\"partitioned\", \"false\");",
+							"pm.environment.set(\"ignoreSuppressedEvents\", \"false\");",
+							"pm.environment.set(\"includeDefaultJoinFilter\", \"false\");",
+							"pm.environment.unset(\"body\");"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"/**",
+					" * Waits until the given predicate returns a truthy value. Calls and awaits the predicate",
+					" * function at the given interval time. Can be used to poll until a certain condition is true.",
+					" *",
+					" * @example",
+					" * ```js",
+					" * import { fixture, waitUntil } from '@open-wc/testing-helpers';",
+					" *",
+					" * const element = await fixture(html`<my-element></my-element>`);",
+					" *",
+					" * await waitUntil(() => element.someAsyncProperty, 'element should become ready');",
+					" *",
+					"",
+					" *",
+					" * @param {() => boolean | Promise<boolean>} predicate - predicate function which is called each poll interval.",
+					" *   The predicate is awaited, so it can return a promise.",
+					" * @param {string} [message] an optional message to display when the condition timed out",
+					" * @param {{ interval?: number, timeout?: number }} [options] timeout and polling interval",
+					" */",
+					"waitUntil = (setTimeout, clearTimeout, predicate, message, options = {}) => {",
+					"  const { interval = 1000, timeout = 120000 } = options;",
+					"",
+					"  return new Promise((resolve, reject) => {",
+					"    let timeoutId;",
+					"    let failTimeoutId;",
+					"",
+					"    failTimeoutId = setTimeout(() => {",
+					"      clearTimeout(timeoutId);",
+					"      try {",
+					"          pm.expect.fail(message ? `Timeout: ${message}` : `waitUntil timed out after ${timeout}ms`);",
+					"      } catch(err) {",
+					"          reject(err);",
+					"      }",
+					"    }, timeout);",
+					"",
+					"    async function nextInterval() {",
+					"      try {",
+					"        const result = await predicate();",
+					"        if (result) {",
+					"          clearTimeout(failTimeoutId);",
+					"          resolve();",
+					"        } else {",
+					"          timeoutId = setTimeout(function() {",
+					"            nextInterval();",
+					"          }, interval);",
+					"        }",
+					"      } catch (error) {",
+					"        clearTimeout(failTimeoutId);",
+					"        reject(error);",
+					"      }",
+					"    }",
+					"    nextInterval();",
+					"  });",
+					"};",
+					"",
+					"asyncTest = (cb) => {",
+					"    return (done) => {",
+					"        try {",
+					"            cb(done).then(() => done()).catch((err) => done(err));",
+					"        } catch (err) {",
+					"            done(err);",
+					"        }",
+					"    };",
+					"}",
+					"",
+					"delay = (setTimeout, timeInMs) => {",
+					"    return new Promise((resolve) => setTimeout(resolve, timeInMs));",
+					"}"
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "body",
+			"value": ""
+		}
+	]
+}

--- a/quality/postman/emodb_tests_databus_renew.postman_collection.json
+++ b/quality/postman/emodb_tests_databus_renew.postman_collection.json
@@ -96,7 +96,7 @@
 										"method": "PUT",
 										"header": [],
 										"url": {
-											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options={{options}}&audit={{audit}}",
+											"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options={{options}}&audit={{audit}}",
 											"host": [
 												"{{baseurl_dc1}}"
 											],
@@ -104,7 +104,7 @@
 												"sor",
 												"1",
 												"_table",
-												":table"
+												"{{table}}"
 											],
 											"query": [
 												{
@@ -225,14 +225,14 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription"
+												"{{subscription}}"
 											],
 											"query": [
 												{
@@ -370,15 +370,15 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/sor/1/:table/:key?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+											"raw": "{{baseurl_dc1}}/sor/1/{{table}}/{{key}}?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"sor",
 												"1",
-												":table",
-												":key"
+												"{{table}}",
+												"{{key}}"
 											],
 											"query": [
 												{
@@ -494,14 +494,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -635,14 +635,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"poll"
 											],
 											"query": [
@@ -770,14 +770,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -885,20 +885,20 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew?partitioned={{partitioned}}&ttl=30",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"renew"
 											],
 											"query": [
 												{
 													"key": "partitioned",
-													"value": "adipisicing ea"
+													"value": "{{partitioned}}"
 												},
 												{
 													"key": "ttl",
@@ -1008,14 +1008,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -1127,14 +1127,14 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription"
+												"{{subscription}}"
 											],
 											"query": [
 												{
@@ -1227,15 +1227,15 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/sor/1/_table/:table?audit={{audit}}",
+											"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit={{audit}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"sor",
 												"1",
 												"_table",
-												":table"
+												"{{table}}"
 											],
 											"query": [
 												{
@@ -1354,7 +1354,7 @@
 										"method": "PUT",
 										"header": [],
 										"url": {
-											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options={{options}}&audit={{audit}}",
+											"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options={{options}}&audit={{audit}}",
 											"host": [
 												"{{baseurl_dc1}}"
 											],
@@ -1362,7 +1362,7 @@
 												"sor",
 												"1",
 												"_table",
-												":table"
+												"{{table}}"
 											],
 											"query": [
 												{
@@ -1483,14 +1483,14 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription"
+												"{{subscription}}"
 											],
 											"query": [
 												{
@@ -1629,15 +1629,15 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/sor/1/:table/:key?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+											"raw": "{{baseurl_dc1}}/sor/1/{{table}}/{{key}}?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"sor",
 												"1",
-												":table",
-												":key"
+												"{{table}}",
+												"{{key}}"
 											],
 											"query": [
 												{
@@ -1753,14 +1753,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -1896,14 +1896,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"poll"
 											],
 											"query": [
@@ -2031,14 +2031,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -2162,20 +2162,20 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew?partitioned={{partitioned}}&ttl=30",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"renew"
 											],
 											"query": [
 												{
 													"key": "partitioned",
-													"value": "adipisicing ea"
+													"value": "partitioned"
 												},
 												{
 													"key": "ttl",
@@ -2285,14 +2285,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -2404,14 +2404,14 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription"
+												"{{subscription}}"
 											],
 											"query": [
 												{
@@ -2504,15 +2504,15 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/sor/1/_table/:table?audit={{audit}}",
+											"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit={{audit}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"sor",
 												"1",
 												"_table",
-												":table"
+												"{{table}}"
 											],
 											"query": [
 												{
@@ -2631,7 +2631,7 @@
 										"method": "PUT",
 										"header": [],
 										"url": {
-											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options={{options}}&audit={{audit}}",
+											"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options={{options}}&audit={{audit}}",
 											"host": [
 												"{{baseurl_dc1}}"
 											],
@@ -2639,7 +2639,7 @@
 												"sor",
 												"1",
 												"_table",
-												":table"
+												"{{table}}"
 											],
 											"query": [
 												{
@@ -2760,14 +2760,14 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription"
+												"{{subscription}}"
 											],
 											"query": [
 												{
@@ -2906,15 +2906,15 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/sor/1/:table/:key?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+											"raw": "{{baseurl_dc1}}/sor/1/{{table}}/{{key}}?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"sor",
 												"1",
-												":table",
-												":key"
+												"{{table}}",
+												"{{key}}"
 											],
 											"query": [
 												{
@@ -3030,14 +3030,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -3173,14 +3173,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"poll"
 											],
 											"query": [
@@ -3308,14 +3308,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -3439,20 +3439,20 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew?partitioned={{partitioned}}&ttl=30",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"renew"
 											],
 											"query": [
 												{
 													"key": "partitioned",
-													"value": "adipisicing ea"
+													"value": "{{partitioned}}"
 												},
 												{
 													"key": "ttl",
@@ -3562,14 +3562,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -3681,14 +3681,14 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription"
+												"{{subscription}}"
 											],
 											"query": [
 												{
@@ -3781,15 +3781,15 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/sor/1/_table/:table?audit={{audit}}",
+											"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit={{audit}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"sor",
 												"1",
 												"_table",
-												":table"
+												"{{table}}"
 											],
 											"query": [
 												{
@@ -3908,7 +3908,7 @@
 										"method": "PUT",
 										"header": [],
 										"url": {
-											"raw": "{{baseurl_dc1}}/sor/1/_table/:table?options={{options}}&audit={{audit}}",
+											"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?options={{options}}&audit={{audit}}",
 											"host": [
 												"{{baseurl_dc1}}"
 											],
@@ -3916,7 +3916,7 @@
 												"sor",
 												"1",
 												"_table",
-												":table"
+												"{{table}}"
 											],
 											"query": [
 												{
@@ -4037,14 +4037,14 @@
 											"raw": ""
 										},
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?ttl={{ttl}}&eventTtl={{eventTtl}}&ignoreSuppressedEvents={{ignoreSuppressedEvents}}&includeDefaultJoinFilter={{includeDefaultJoinFilter}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription"
+												"{{subscription}}"
 											],
 											"query": [
 												{
@@ -4183,15 +4183,15 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/sor/1/:table/:key?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
+											"raw": "{{baseurl_dc1}}/sor/1/{{table}}/{{key}}?changeId={{change_id}}&audit={{audit}}&consistency={{consistency}}&tag={{tag}}&debug={{debug}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"sor",
 												"1",
-												":table",
-												":key"
+												"{{table}}",
+												"{{key}}"
 											],
 											"query": [
 												{
@@ -4307,14 +4307,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -4460,14 +4460,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/poll?partitioned={{partitioned}}&ttl={{ttl}}&limit={{limit}}&ignoreLongPoll={{ignoreLongPoll}}&includeTags={{includeTags}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"poll"
 											],
 											"query": [
@@ -4595,14 +4595,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -4726,20 +4726,20 @@
 										"method": "POST",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew?partitioned={{partitioned}}&ttl=30",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"renew"
 											],
 											"query": [
 												{
 													"key": "partitioned",
-													"value": "adipisicing ea"
+													"value": "{{partitioned}}"
 												},
 												{
 													"key": "ttl",
@@ -4849,14 +4849,14 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription/claimcount?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/claimcount?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription",
+												"{{subscription}}",
 												"claimcount"
 											],
 											"query": [
@@ -4968,14 +4968,14 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/bus/1/:subscription?partitioned={{partitioned}}",
+											"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}?partitioned={{partitioned}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"bus",
 												"1",
-												":subscription"
+												"{{subscription}}"
 											],
 											"query": [
 												{
@@ -5068,15 +5068,15 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/sor/1/_table/:table?audit={{audit}}",
+											"raw": "{{baseurl_dc1}}/sor/1/_table/{{table}}?audit={{audit}}",
 											"host": [
-												"{{baseUrl}}"
+												"{{baseurl_dc1}}"
 											],
 											"path": [
 												"sor",
 												"1",
 												"_table",
-												":table"
+												"{{table}}"
 											],
 											"query": [
 												{
@@ -5122,14 +5122,14 @@
 							"raw": "[]"
 						},
 						"url": {
-							"raw": "{{baseurl_dc1}}/bus/1/:subscription/renew?partitioned={{partitioned}}&ttl={{ttl}}",
+							"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew?partitioned={{partitioned}}&ttl={{ttl}}",
 							"host": [
 								"{{baseurl_dc1}}"
 							],
 							"path": [
 								"bus",
 								"1",
-								":subscription",
+								"{{subscription}}",
 								"renew"
 							],
 							"query": [
@@ -5159,20 +5159,20 @@
 								"method": "POST",
 								"header": [],
 								"url": {
-									"raw": "{{baseUrl}}/bus/1/:subscription/renew?partitioned=adipisicing ea&ttl=30",
+									"raw": "{{baseurl_dc1}}/bus/1/{{subscription}}/renew?partitioned={{partitioned}}&ttl=30",
 									"host": [
-										"{{baseUrl}}"
+										"{{baseurl_dc1}}"
 									],
 									"path": [
 										"bus",
 										"1",
-										":subscription",
+										"{{subscription}}",
 										"renew"
 									],
 									"query": [
 										{
 											"key": "partitioned",
-											"value": "adipisicing ea"
+											"value": "{{partitioned}}"
 										},
 										{
 											"key": "ttl",


### PR DESCRIPTION
## Github Issue #

[1234](https://github.com/bazaarvoice/emodb/issues/11)

## What Are We Doing Here?

Postman tests have been added for /bus/1/{subscription}/renew

## How to Test and Verify

1. Run this branch on CI
2. Verify that databus renew tests have been passed 

## Risk
No issues are expected because there is no connection to existing test /application code
### Level 

`Low`
### Required Testing

`Manual`. 

### Risk Summary
No issues are expected because there is no connection to existing test /application code


## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
