### PR TITLE
PD-173478 migrate emodb base docker image to support ARM achitecture

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:8-alpine
+FROM amazoncorretto:11
 
 ARG version
 ARG APP_ROLE
@@ -19,8 +19,10 @@ ENV LOCAL_HOST=${LOCAL_HOST}
 ENV LOCAL_PORT=${LOCAL_PORT}
 ENV LOCAL_ADMIN_PORT=${LOCAL_ADMIN_PORT}
 
-RUN addgroup -S emodb -g 1000
-RUN adduser -S emodb -G emodb -u 1000
+# Create a "emodb" non-root user for the next image by updating an /etc/passwd
+# file. This is necessary since the next image is based on scratch, which doesn't have adduser.
+#COPY etc/passwd /etc/passwd
+RUN echo "emodb:x:1000:1000:EmoDB:/:" >> /etc/passwd
 
 COPY --chown=1000 maven/emodb-web-* /app/emodb-web.jar
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,9 +19,8 @@ ENV LOCAL_HOST=${LOCAL_HOST}
 ENV LOCAL_PORT=${LOCAL_PORT}
 ENV LOCAL_ADMIN_PORT=${LOCAL_ADMIN_PORT}
 
-# Create a "emodb" non-root user for the next image by updating an /etc/passwd
-# file. This is necessary since the next image is based on scratch, which doesn't have adduser.
-#COPY etc/passwd /etc/passwd
+# Create a "emodb" non-root user by updating an /etc/passwd
+# file. This is necessary since the image is based on scratch, which doesn't have adduser.
 RUN echo "emodb:x:1000:1000:EmoDB:/:" >> /etc/passwd
 
 COPY --chown=1000 maven/emodb-web-* /app/emodb-web.jar

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,10 @@ Also, to speed things up, you can try skipping tests. I usually do ` -DskipTests
 
 It's based on the official image, but in order to supply our own `cassandra.yml` configuration, we have to "inherit" the official build. Again, running from `$GITROOT`:
 
-    docker build $GITROOT -f ./docker/cassandra-Dockerfile -t bazaarvoice/cassandra:2.2.19
+```bash
+  cd docker/
+  docker build . -f ./cassandra-Dockerfile -t bazaarvoice/cassandra:2.2.19
+```
 
 Note that `docker-compose up` will build this for you if you skip this step and  the image hasn't been built before. If you make changes and want to rebuild, you can also skip this step and just include  the `--build` argument to `docker-compose up`, which will force rebuilding the Cassandra image.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 
 services:
   zookeeper:
-    image: 'zookeeper:3.4.14'
+    image: 'zookeeper:3.5.9'
     networks:
       - emodb
     ports:


### PR DESCRIPTION
## Github Issue #

-

## What Are We Doing Here?

as alpine corretto image doesn't support ARM architecture it was decided to use coretto image, based on `scratch`.
also java runtime has been upgraded from 8 to 11

## How to Test and Verify

1. Check out this PR
2. Follow instructions mentioned in https://github.com/bazaarvoice/emodb/blob/master/docker/README.md
3. Profit

## Risk

### Level 

`Low`

### Required Testing

`Smoke`, `Regression`, or `Manual`.

### Risk Summary

-

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
