### PR TITLE
postman tests for add role endpoint

### DIFF
--- a/quality/postman/emodb_tests_uac_role.postman_collection.json
+++ b/quality/postman/emodb_tests_uac_role.postman_collection.json
@@ -1,0 +1,6281 @@
+{
+	"info": {
+		"_postman_id": "12e9cd09-b7a9-4c4a-8e46-8e8749f96a56",
+		"name": "EmoDB_Tests_uac_role",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "role",
+			"item": [
+				{
+					"name": "{group}",
+					"item": [
+						{
+							"name": "{id}",
+							"item": [
+								{
+									"name": "Create role",
+									"item": [
+										{
+											"name": "TC: Create role with json media type without permission",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"reason\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.reason).to.eql(\"not authorized\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}",
+																	"disabled": true
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "get Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 404\", function () {",
+																	"    pm.response.to.have.status(404);",
+																	"});",
+																	"",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+																	"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+																	"    pm.expect(jsonData.message).to.eql(\"Role not found\");",
+																	"    pm.expect(jsonData.suppressed).to.eql([]); ",
+																	"});",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with x.json-create-role media type without permission",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"reason\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.reason).to.eql(\"not authorized\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}",
+																	"disabled": true
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "get Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 404\", function () {",
+																	"    pm.response.to.have.status(404);",
+																	"});",
+																	"",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+																	"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+																	"    pm.expect(jsonData.message).to.eql(\"Role not found\");",
+																	"    pm.expect(jsonData.suppressed).to.eql([]); ",
+																	"});",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with json media type",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "get Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"var expectedPermissions = [",
+																	"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+																	"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+																	"    ]",
+																	"",
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+																	"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+																	"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+																	"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+																	"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+																	"});",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with x.json-create-role media type",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "get Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"var expectedPermissions = [",
+																	"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+																	"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+																	"    ]",
+																	"",
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+																	"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+																	"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+																	"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+																	"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+																	"});",
+																	"",
+																	""
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "GET",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "GET",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with json media type and conflicting request id",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Assert response\", function () {",
+																	"    pm.expect(pm.response.text()).to.include(\"Body contains conflicting role identifier\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}-conflicting\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with json media type and conflicting request group",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Assert response\", function () {",
+																	"    pm.expect(pm.response.text()).to.include(\"Body contains conflicting role identifier\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}-conflicting\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with json media type and empty body",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 422\", function () {",
+																	"    pm.response.to.have.status(422);",
+																	"});",
+																	"",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"errors\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.errors).to.eql([]);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with x.json-create-role media type and empty body",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"",
+																	"pm.test(\"Assert response\", function () {",
+																	"    pm.expect(pm.response.text()).to.eql(\"com.fasterxml.jackson.databind.JsonMappingException: No content to map due to end-of-input\\n at [Source: ; line: 1, column: 1]\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create duplicate role with json media type",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "create Duplicate Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 409\", function () {",
+																	"    pm.response.to.have.status(409);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+																	"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+																	"    pm.expect(jsonData.message).to.eql(\"Role exists\");",
+																	"    pm.expect(jsonData.suppressed).to.eql([]);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create duplicate role with x.json-create-role media type",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "create Duplicate Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 409\", function () {",
+																	"    pm.response.to.have.status(409);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+																	"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+																	"    pm.expect(jsonData.message).to.eql(\"Role exists\");",
+																	"    pm.expect(jsonData.suppressed).to.eql([]);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with special characters in group",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4()+\"_!@#$%^\");",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 405\", function () {",
+																	"    pm.response.to.have.status(405);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    pm.expect(pm.response.text()).to.eql(\"\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4()+\"_!@#$%^\");",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 405\", function () {",
+																	"    pm.response.to.have.status(405);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    pm.expect(pm.response.text()).to.eql(\"\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with special characters in id",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4())+\"_!@#$%^\";"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4()+\"_!@#$%^\");"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 403\", function () {",
+																	"    pm.response.to.have.status(403);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"reason\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.reason).to.eql(\"not authorized\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with numbers in group",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4()+\"_12345\");",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4()+\"_12345\");",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with numbers in id",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4()+\"_12345\");"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4()+\"_12345\");"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with json media type without id",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"message\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.message).to.eql(\"Instantiation of [simple type, class com.bazaarvoice.emodb.uac.api.EmoRole] value failed: id\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"group\": \"{{group}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with json media type without group",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 400\", function () {",
+																	"    pm.response.to.have.status(400);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    pm.expect(pm.response.text()).to.eql(\"Body contains conflicting role identifier\");",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\":\"{{id}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with json media type without permissions",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"group\": \"{{group}}\",\n    \"id\":\"{{id}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"disabled": true
+															},
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role without Description",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n\n    \"name\": \"postman test group\",\n    \"group\": \"{{group}}\",\n    \"id\":\"{{id}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \"name\": \"postman test group\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role without Name",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \"description\": \"test with postman\",\n    \"group\": \"{{group}}\",\n    \"id\":\"{{id}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \"description\": \"test with postman\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"authenticationId\": \"\",\n    \"id\": \"\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with not existing permissions",
+											"item": [
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read1|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll1|if(like(\\\"postman*\\\"))\"\n    ],\n    \"description\": \"test with postman\",\n    \"group\": \"{{group}}\",\n    \"id\":\"{{id}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"authenticationId\": \"\",\n    \"id\": \"\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read2|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll2|if(like(\\\"postman*\\\"))\"\n    ],\n    \"description\": \"test with postman\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"authenticationId\": \"\",\n    \"id\": \"\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										},
+										{
+											"name": "TC: Create role with new permissions",
+											"item": [
+												{
+													"name": "create Role From Update Request without permissions",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"description\": \"test with postman\",\n    \"group\": \"{{group}}\",\n    \"id\":\"{{id}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request with permissions",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 409\", function () {",
+																	"    pm.response.to.have.status(409);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+																	"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+																	"    pm.expect(jsonData.message).to.eql(\"Role exists\");",
+																	"    pm.expect(jsonData.suppressed).to.eql([]);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \"description\": \"test with postman\",\n    \"group\": \"{{group}}\",\n    \"id\":\"{{id}}\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request without permissions",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	"const uuid = require('uuid');",
+																	"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+																	"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 201\", function () {",
+																	"    pm.response.to.have.status(201);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"description\": \"test with postman\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "create Role From Update Request with permissions",
+													"event": [
+														{
+															"listen": "prerequest",
+															"script": {
+																"exec": [
+																	""
+																],
+																"type": "text/javascript"
+															}
+														},
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 409\", function () {",
+																	"    pm.response.to.have.status(409);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+																	"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+																	"    pm.expect(jsonData.message).to.eql(\"Role exists\");",
+																	"    pm.expect(jsonData.suppressed).to.eql([]);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "POST",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/x.json-create-role",
+																"type": "text"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \"description\": \"test with postman\"\n}"
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "POST",
+																"header": [],
+																"body": {
+																	"mode": "raw",
+																	"raw": "{\n    \"permissions\": [\n        \"et eu amet eiusmod\",\n        \"velit an\"\n    ],\n    \"description\": \"ex ut cupidatat quis\",\n    \"name\": \"quis elit amet\"\n}"
+																},
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "Internal Server Error",
+															"code": 500,
+															"_postman_previewlanguage": "text",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "text/plain"
+																}
+															],
+															"cookie": [],
+															"body": ""
+														}
+													]
+												},
+												{
+													"name": "delete Role",
+													"event": [
+														{
+															"listen": "test",
+															"script": {
+																"exec": [
+																	"pm.test(\"Status code is 200\", function () {",
+																	"    pm.response.to.have.status(200);",
+																	"});",
+																	"pm.test(\"Assert response\", function () {",
+																	"    var jsonData = pm.response.json();",
+																	"    var expectedResponseProperties = [\"success\"];",
+																	"    ",
+																	"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+																	"    pm.expect(jsonData.success).to.eql(true);",
+																	"});"
+																],
+																"type": "text/javascript"
+															}
+														}
+													],
+													"request": {
+														"method": "DELETE",
+														"header": [
+															{
+																"key": "Content-Type",
+																"value": "application/json"
+															}
+														],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"query": [
+																{
+																	"key": "APIKey",
+																	"value": "{{api_key}}"
+																}
+															]
+														}
+													},
+													"response": [
+														{
+															"name": "successful operation",
+															"originalRequest": {
+																"method": "DELETE",
+																"header": [],
+																"url": {
+																	"raw": "{{baseurl_dc1}/uac/1/role/{{group}}/{{id}}",
+																	"host": [
+																		"{{baseurl_dc1}"
+																	],
+																	"path": [
+																		"uac",
+																		"1",
+																		"role",
+																		"{{group}}",
+																		"{{id}}"
+																	],
+																	"variable": [
+																		{
+																			"key": "group"
+																		},
+																		{
+																			"key": "id"
+																		}
+																	]
+																}
+															},
+															"status": "OK",
+															"code": 200,
+															"_postman_previewlanguage": "json",
+															"header": [
+																{
+																	"key": "Content-Type",
+																	"value": "application/json"
+																}
+															],
+															"cookie": [],
+															"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"pm.environment.set(\"description\", \"test with postman\");",
+							"pm.environment.set(\"name\", \"postman test group\");"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## What Are We Doing Here?

New Postman tests have been added for uac/1/role/{group}/{id} emodb endpoint
## How to Test and Verify

1. Run this PR on postman Jenkins Pipeline 
2. Verify that all tests are passed and that tests are run for uac/1/role/{group}/{id} endpoint

## Risk
no changes to existing code. new unstable tests can be added to test suite run
### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

No risks are expected for existing functionality, however new unstable tests can be introduced to our test suite

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
