### PR TITLE
new postman tests for GET uac/1/role get all roles endpoint

### DIFF
--- a/quality/postman/emodb_tests_uac_role_get_all_roles.postman_collection.json
+++ b/quality/postman/emodb_tests_uac_role_get_all_roles.postman_collection.json
@@ -1,0 +1,215 @@
+{
+	"info": {
+		"_postman_id": "12e9cd09-b7a9-4c4a-8e46-8e8749f96a56",
+		"name": "EmoDB_Tests_uac_role_get_all_roles",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "role",
+			"item": [
+				{
+					"name": "{group}",
+					"item": [
+						{
+							"name": "{id}",
+							"item": []
+						}
+					]
+				},
+				{
+					"name": "Get all roles",
+					"item": [
+						{
+							"name": "TC: Request without access to resource",
+							"item": [
+								{
+									"name": "get All Roles",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 403\", function () {",
+													"    pm.response.to.have.status(403);",
+													"});",
+													"",
+													"pm.test(\"Assert response\", function () {",
+													"    pm.expect(pm.response.json()).to.eql({\"reason\":\"not authorized\"});",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseurl_dc1}}/uac/1/role",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"uac",
+												"1",
+												"role"
+											],
+											"query": [
+												{
+													"key": "APIKey",
+													"value": "{{api_key_no_rights}}",
+													"disabled": true
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"name": "successful operation",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{}"
+										}
+									]
+								}
+							]
+						},
+						{
+							"name": "TC: Request with access to resource",
+							"item": [
+								{
+									"name": "get All Roles",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Status code is 200\", function () {",
+													"    pm.response.to.have.status(200);",
+													"});",
+													"",
+													"pm.test(\"Assert response\", function () {",
+													"    pm.expect(pm.response.json().length).to.be.above(1);",
+													"    pm.expect(pm.response.json()[0]).to.have.keys(\"group\",\"id\",\"permissions\",\"description\",\"name\");",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "GET",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"url": {
+											"raw": "{{baseurl_dc1}}/uac/1/role?APIKey={{api_key}}",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"uac",
+												"1",
+												"role"
+											],
+											"query": [
+												{
+													"key": "APIKey",
+													"value": "{{api_key}}"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"name": "successful operation",
+											"originalRequest": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role"
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{}"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"pm.environment.set(\"description\", \"test with postman\");",
+							"pm.environment.set(\"name\", \"postman test group\");"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## What Are We Doing Here?

New postman tests have been added for uac/1/role endpoint which is returning all roles

## How to Test and Verify

1. Run this branch on CI with jenkins file running this collection
2. Verify that all tests are passed and that tests are run for GET /uac/1/role endpoint
3. Profit

## Risk
There is tiny potential  impact which is also not expected

### Level 

`Low`

### Required Testing

`Manual`

### Risk Summary

New unstable or failing tests have been added to repo

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
