### PR TITLE
postman tests for delete role emodb endpoint

### DIFF
--- a/quality/postman/emodb_tests_uac_role_delete_role.postman_collection.json
+++ b/quality/postman/emodb_tests_uac_role_delete_role.postman_collection.json
@@ -1,0 +1,3916 @@
+{
+	"info": {
+		"_postman_id": "263ef2f0-347c-4c7e-880c-2efe214f0981",
+		"name": "EmoDB_Tests_uac_role_delete_role",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "role",
+			"item": [
+				{
+					"name": "{group}",
+					"item": [
+						{
+							"name": "{id}",
+							"item": [
+								{
+									"name": "TC: Delete role with both media type without permissions",
+									"item": [
+										{
+											"name": "create Role From Update Request with json media type",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/json",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role - no access",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 403\", function () {",
+															"    pm.response.to.have.status(403);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    pm.expect(pm.response.json().reason).to.eql(\"not authorized\");",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key_no_rights}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key_no_rights}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										},
+										{
+											"name": "create Role From Update Request with x.json-create-role media type",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"postman_\"+ uuid.v4());",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role - no access",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 403\", function () {",
+															"    pm.response.to.have.status(403);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    pm.expect(pm.response.json().reason).to.eql(\"not authorized\");",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key_no_rights}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key_no_rights}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "TC: Delete role with json media type and _ group",
+									"item": [
+										{
+											"name": "create Role From Update Request",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"_\");",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/json",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"_\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "TC: Delete role with x.json-create-role media type and _ group",
+									"item": [
+										{
+											"name": "create Role From Update Request",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"_\");",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "TC: Delete role with json media type",
+									"item": [
+										{
+											"name": "create Role From Update Request",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"postman_\"+uuid.v4());",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/json",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "TC: Delete role with x.json-create-role media type and _ group",
+									"item": [
+										{
+											"name": "create Role From Update Request",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"postman_\"+uuid.v4());",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "TC: Delete role with json media type and incorrect id",
+									"item": [
+										{
+											"name": "create Role From Update Request",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"postman_\"+uuid.v4());",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/json",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role - incorrect id",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 404\", function () {",
+															"    pm.response.to.have.status(404);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\")+\"_incorrect\");",
+															"    pm.expect(jsonData.message).to.eql(\"Role not found\");",
+															"    pm.expect(jsonData.suppressed).to.eql([]);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}_incorrect?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}_incorrect"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "TC: Delete role with x.json-create-role media type and incorrect id",
+									"item": [
+										{
+											"name": "create Role From Update Request",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"postman_\"+uuid.v4());",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role - incorrect id",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 404\", function () {",
+															"    pm.response.to.have.status(404);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\")+\"_incorrect\");",
+															"    pm.expect(jsonData.message).to.eql(\"Role not found\");",
+															"    pm.expect(jsonData.suppressed).to.eql([]);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}_incorrect?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}_incorrect"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "TC: Delete role with json media type and incorrect group",
+									"item": [
+										{
+											"name": "create Role From Update Request",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"postman_\"+uuid.v4());",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/json",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\",\n    \"id\": \"{{id}}\",\n    \"group\": \"{{group}}\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role - incorrect group",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 404\", function () {",
+															"    pm.response.to.have.status(404);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\")+\"_incorrect\");",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.message).to.eql(\"Role not found\");",
+															"    pm.expect(jsonData.suppressed).to.eql([]);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}_incorrect/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}_incorrect",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "TC: Delete role with x.json-create-role media type and incorrect group",
+									"item": [
+										{
+											"name": "create Role From Update Request",
+											"event": [
+												{
+													"listen": "prerequest",
+													"script": {
+														"exec": [
+															"const uuid = require('uuid');",
+															"pm.environment.set(\"group\", \"postman_\"+uuid.v4());",
+															"pm.environment.set(\"id\", \"postman_\"+uuid.v4());"
+														],
+														"type": "text/javascript"
+													}
+												},
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 201\", function () {",
+															"    pm.response.to.have.status(201);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"disabled": true
+													},
+													{
+														"key": "Content-Type",
+														"value": "application/x.json-create-role",
+														"type": "text"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"permissions\": [\n        \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",\n        \"databus|poll|if(like(\\\"postman*\\\"))\"\n    ],\n    \n    \"description\": \"test with postman\",\n    \"name\": \"postman test group\"\n}"
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "POST",
+														"header": [],
+														"body": {
+															"mode": "raw",
+															"raw": ""
+														},
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "Internal Server Error",
+													"code": 500,
+													"_postman_previewlanguage": "text",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "text/plain"
+														}
+													],
+													"cookie": [],
+													"body": ""
+												}
+											]
+										},
+										{
+											"name": "get Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"var expectedPermissions = [",
+															"    \"sor|read|intrinsic(\\\"~table\\\":like(\\\"postman*\\\"))\",",
+															"    \"databus|poll|if(like(\\\"postman*\\\"))\"",
+															"    ]",
+															"",
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"description\",\"permissions\",\"name\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\"));",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.description).to.eql(pm.environment.get(\"description\"));",
+															"    pm.expect(jsonData.permissions.sortBy).to.deep.equal(expectedPermissions.sortBy);",
+															"    pm.expect(jsonData.name).to.eql(pm.environment.get(\"name\")); ",
+															"});",
+															"",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "GET",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"group\": \"laboris laborum sunt cillum\",\n \"id\": \"tempor aliqua anim\",\n \"permissions\": [\n  \"sint commodo\",\n  \"culpa exercitation\"\n ],\n \"description\": \"ex sint sunt qui\",\n \"name\": \"occaecat consequat Excepteur dolor\"\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role - incorrect group",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 404\", function () {",
+															"    pm.response.to.have.status(404);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"group\",\"id\",\"message\",\"suppressed\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.group).to.eql(pm.environment.get(\"group\")+\"_incorrect\");",
+															"    pm.expect(jsonData.id).to.eql(pm.environment.get(\"id\"));",
+															"    pm.expect(jsonData.message).to.eql(\"Role not found\");",
+															"    pm.expect(jsonData.suppressed).to.eql([]);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}_incorrect/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}_incorrect",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										},
+										{
+											"name": "delete Role",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"pm.test(\"Status code is 200\", function () {",
+															"    pm.response.to.have.status(200);",
+															"});",
+															"pm.test(\"Assert response\", function () {",
+															"    var jsonData = pm.response.json();",
+															"    var expectedResponseProperties = [\"success\"];",
+															"    ",
+															"    pm.expect(jsonData).to.have.keys(expectedResponseProperties);",
+															"    pm.expect(jsonData.success).to.eql(true);",
+															"});"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": ""
+												},
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"query": [
+														{
+															"key": "APIKey",
+															"value": "{{api_key}}"
+														}
+													]
+												}
+											},
+											"response": [
+												{
+													"name": "successful operation",
+													"originalRequest": {
+														"method": "DELETE",
+														"header": [],
+														"url": {
+															"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+															"host": [
+																"{{baseurl_dc1}}"
+															],
+															"path": [
+																"uac",
+																"1",
+																"role",
+																"{{group}}",
+																"{{id}}"
+															],
+															"variable": [
+																{
+																	"key": "group"
+																},
+																{
+																	"key": "id"
+																}
+															]
+														}
+													},
+													"status": "OK",
+													"code": 200,
+													"_postman_previewlanguage": "json",
+													"header": [
+														{
+															"key": "Content-Type",
+															"value": "application/json"
+														}
+													],
+													"cookie": [],
+													"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+												}
+											]
+										}
+									]
+								},
+								{
+									"name": "delete Role",
+									"request": {
+										"method": "DELETE",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": ""
+										},
+										"url": {
+											"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}?APIKey={{api_key}}",
+											"host": [
+												"{{baseurl_dc1}}"
+											],
+											"path": [
+												"uac",
+												"1",
+												"role",
+												"{{group}}",
+												"{{id}}"
+											],
+											"query": [
+												{
+													"key": "APIKey",
+													"value": "{{api_key}}"
+												}
+											]
+										}
+									},
+									"response": [
+										{
+											"name": "successful operation",
+											"originalRequest": {
+												"method": "DELETE",
+												"header": [],
+												"url": {
+													"raw": "{{baseurl_dc1}}/uac/1/role/{{group}}/{{id}}",
+													"host": [
+														"{{baseurl_dc1}}"
+													],
+													"path": [
+														"uac",
+														"1",
+														"role",
+														"{{group}}",
+														"{{id}}"
+													],
+													"variable": [
+														{
+															"key": "group"
+														},
+														{
+															"key": "id"
+														}
+													]
+												}
+											},
+											"status": "OK",
+											"code": 200,
+											"_postman_previewlanguage": "json",
+											"header": [
+												{
+													"key": "Content-Type",
+													"value": "application/json"
+												}
+											],
+											"cookie": [],
+											"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"pm.environment.set(\"description\", \"test with postman\");",
+							"pm.environment.set(\"name\", \"postman test group\");"
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## What Are We Doing Here?

Postman tests have been created for DELETE /uac/1/role/{group}/{id} endpoint
## How to Test and Verify

1. Run this branch on Jenkins 
2. Verify that tests for DELETE /uac/1/role/{group}/{id} endpoint have been executed and past

## Risk
broken or unstable tests have been added to test suite

### Level 
`Low`

### Required Testing

`Smoke`
### Risk Summary
Existing functionality has not been affected, but new unstable tests could be introduced to test scope.

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
