### PR TITLE
PD-179663 support C* 3.11.x

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -24,10 +24,10 @@
     </scm>
 
     <properties>
-        <astyanax.version>3.8.0-bv12</astyanax.version>
+        <astyanax.version>3.8.0-bv13</astyanax.version>
         <dropwizard-metrics-datadog.version>1.1.13</dropwizard-metrics-datadog.version>
-        <cassandra.version>3.0.25</cassandra.version>
-        <cassandra-maven-plugin.version>${cassandra.version}.1</cassandra-maven-plugin.version>
+        <cassandra.version>3.11.12</cassandra.version>
+        <cassandra-maven-plugin.version>3.0.25.1</cassandra-maven-plugin.version>
         <curator.version>2.4.2</curator.version>
         <curator-extensions.version>1.4.2</curator-extensions.version>
         <dropwizard.version>0.7.1</dropwizard.version>
@@ -75,7 +75,7 @@
         <mockito.version>3.7.0</mockito.version>
         <testng.version>7.3.0</testng.version>
         <junit.version>4.13.1</junit.version>
-        <logback.version>1.1.3</logback.version>
+        <logback.version>1.2.9</logback.version>
     </properties>
 
     <dependencyManagement>
@@ -514,6 +514,10 @@
                     </exclusion>
                     <exclusion>
                         <groupId>io.dropwizard.metrics</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>


### PR DESCRIPTION
## Github Issue #

-

## What Are We Doing Here?

update C* related maven dependency to be consistent with the new version of C* (3.11.12)

## How to Test and Verify

1. Check out this PR
2. Run `mvn clean verify  -Ddependency-check.skip=true`
3. Profit

## Risk

### Level 

`Low`

### Required Testing

`Smoke`

### Risk Summary

No issues are expected, code should be compatible with both 3.0.x and 3.11.x versions of C*

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
