### PR TITLE
PD-176738 use C* 3.11.x for local env

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,13 +22,13 @@ Docker is now included with mvn and docker image will be built if we select prof
 
 Also, to speed things up, you can try skipping tests. I usually do ` -DskipTests -DskipITs` and then watch in awe as Maven proceeds to run all of the tests anyway.
 
-### build Cassandra 3.0.25
+### build Cassandra
 
 It's based on the official image, but in order to supply our own `cassandra.yml` configuration, we have to "inherit" the official build. Again, running from `$GITROOT`:
 
 ```bash
   cd docker/
-  docker build . -f ./cassandra-Dockerfile -t bazaarvoice/cassandra:3.0.25
+  docker build . -f ./cassandra-Dockerfile -t bazaarvoice/cassandra:3.11.12
 ```
 
 Note that `docker-compose up` will build this for you if you skip this step and  the image hasn't been built before. If you make changes and want to rebuild, you can also skip this step and just include  the `--build` argument to `docker-compose up`, which will force rebuilding the Cassandra image.

--- a/docker/cassandra-Dockerfile
+++ b/docker/cassandra-Dockerfile
@@ -1,3 +1,3 @@
-FROM cassandra:3.0.25
+FROM cassandra:3.11.12
 COPY ./cassandra.yaml /etc/cassandra/
 CMD ["cassandra", "-f"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       interval: 10s
 
   cassandra-dc1:
-    image: 'bazaarvoice/cassandra:3.0.25'
+    image: 'bazaarvoice/cassandra:3.11.12'
     build:
       context: .
       dockerfile: cassandra-Dockerfile
@@ -41,7 +41,7 @@ services:
       test: ["CMD-SHELL", "nodetool status | grep UN || exit 1"]
 
   kafka:
-    image: 'confluentinc/cp-kafka:5.3.1'
+    image: 'confluentinc/cp-kafka:6.2.0'
     networks:
       - emodb
     ports:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -27,7 +27,7 @@
         <astyanax.version>3.8.0-bv13</astyanax.version>
         <dropwizard-metrics-datadog.version>1.1.13</dropwizard-metrics-datadog.version>
         <cassandra.version>3.11.12</cassandra.version>
-        <cassandra-maven-plugin.version>3.0.25.1</cassandra-maven-plugin.version>
+        <cassandra-maven-plugin.version>${cassandra.version}.1</cassandra-maven-plugin.version>
         <curator.version>2.4.2</curator.version>
         <curator-extensions.version>1.4.2</curator-extensions.version>
         <dropwizard.version>0.7.1</dropwizard.version>


### PR DESCRIPTION
## Github Issue #

-

## What Are We Doing Here?

use C* 3.11.x for local environment

## How to Test and Verify

1. Check out this PR
2. Run `mvn clean verify  -Ddependency-check.skip=true`
3. Profit

## Risk

### Level 

`Low`

### Required Testing

`Smoke`

### Risk Summary

No issues are expected, code should be compatible with both 3.0.x and 3.11.x versions of C*

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
