### PR TITLE
adding postman tests for get api-key endpoint

### DIFF
--- a/quality/postman/emodb_tests_uac_get_api-key.postman_collection.json
+++ b/quality/postman/emodb_tests_uac_get_api-key.postman_collection.json
@@ -1,0 +1,735 @@
+{
+	"info": {
+		"_postman_id": "8fda45f3-0ac2-48e1-9af9-ea0f6258fa8e",
+		"name": "EmoDB_Tests_uac_get_api-key",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "TC: Get api-key without permissions",
+			"item": [
+				{
+					"name": "create Api Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.environment.set('id', pm.response.json().id);",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Assert response body\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.keys([\"key\",\"id\"]);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x.json-create-api-key"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"owner\": \"postman\"\n}"
+						},
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key?APIKey={{api_key}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key"
+							],
+							"query": [
+								{
+									"key": "APIKey",
+									"value": "{{api_key}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"description\": \"postman\",\n    \"owner\": \"postman\"\n}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/uac/1/api-key?key={{api-key}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"uac",
+										"1",
+										"api-key"
+									],
+									"query": [
+										{
+											"key": "key",
+											"value": "{{api-key}}"
+										}
+									]
+								}
+							},
+							"status": "Internal Server Error",
+							"code": 500,
+							"_postman_previewlanguage": "text",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "text/plain"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "get Api Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 403\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.test(\"Assert response\", function () {",
+									"    pm.expect(jsonData).to.have.keys(\"reason\");",
+									"    pm.expect(jsonData.reason).to.eql(\"not authorized\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}?APIKey={{api_key_no_rights}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key",
+								"{{id}}"
+							],
+							"query": [
+								{
+									"key": "APIKey",
+									"value": "{{api_key_no_rights}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"uac",
+										"1",
+										"api-key",
+										"{{id}}"
+									],
+									"variable": [
+										{
+											"key": "id"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "delete Api Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Assert response body\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.success).to.eql(true);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"authenticationId\": \"pariatur\",\n    \"id\": \"elit nostrud\"\n}"
+						},
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}?APIKey={{api_key}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key",
+								"{{id}}"
+							],
+							"query": [
+								{
+									"key": "APIKey",
+									"value": "{{api_key}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"uac",
+										"1",
+										"api-key",
+										"{{id}}"
+									],
+									"variable": [
+										{
+											"key": "id"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "TC: Get api-key",
+			"item": [
+				{
+					"name": "create Api Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.environment.set('id', pm.response.json().id);",
+									"",
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Assert response body\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData).to.have.keys([\"key\",\"id\"]);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x.json-create-api-key"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"owner\": \"postman\"\n}"
+						},
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key?APIKey={{api_key}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key"
+							],
+							"query": [
+								{
+									"key": "APIKey",
+									"value": "{{api_key}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"description\": \"postman\",\n    \"owner\": \"postman\"\n}"
+								},
+								"url": {
+									"raw": "{{baseurl_dc1}}/uac/1/api-key?key={{api-key}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"uac",
+										"1",
+										"api-key"
+									],
+									"query": [
+										{
+											"key": "key",
+											"value": "{{api-key}}"
+										}
+									]
+								}
+							},
+							"status": "Internal Server Error",
+							"code": 500,
+							"_postman_previewlanguage": "text",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "text/plain"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "get Api Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.test(\"Assert response\", function () {",
+									"    pm.expect(jsonData).to.have.keys([\"id\",\"maskedKey\",\"issued\",\"owner\"]);",
+									"    pm.expect(jsonData.owner).to.eql(\"postman\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}?APIKey={{api_key}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key",
+								"{{id}}"
+							],
+							"query": [
+								{
+									"key": "APIKey",
+									"value": "{{api_key}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"uac",
+										"1",
+										"api-key",
+										"{{id}}"
+									],
+									"variable": [
+										{
+											"key": "id"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "delete Api Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Assert response body\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.success).to.eql(true);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"authenticationId\": \"pariatur\",\n    \"id\": \"elit nostrud\"\n}"
+						},
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}?APIKey={{api_key}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key",
+								"{{id}}"
+							],
+							"query": [
+								{
+									"key": "APIKey",
+									"value": "{{api_key}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"uac",
+										"1",
+										"api-key",
+										"{{id}}"
+									],
+									"variable": [
+										{
+											"key": "id"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n \"success\": false,\n \"debug\": {}\n}"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "TC: Get api-key, request with wrong id",
+			"item": [
+				{
+					"name": "get Api Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {",
+									"    pm.response.to.have.status(404);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.test(\"Assert response\", function () {",
+									"    pm.expect(jsonData).to.have.keys([\"message\",\"suppressed\"]);",
+									"    pm.expect(jsonData.message).to.eql(\"API Key not found\");",
+									"    pm.expect(jsonData.suppressed).to.eql([]);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}_wrong?APIKey={{api_key}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key",
+								"{{id}}_wrong"
+							],
+							"query": [
+								{
+									"key": "APIKey",
+									"value": "{{api_key}}"
+								}
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"uac",
+										"1",
+										"api-key",
+										"{{id}}"
+									],
+									"variable": [
+										{
+											"key": "id"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "TC: Get api-key, request with special charecters in id",
+			"item": [
+				{
+					"name": "get Api Key",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 403\", function () {",
+									"    pm.response.to.have.status(403);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.test(\"Assert response\", function () {",
+									"    pm.expect(jsonData).to.have.keys(\"reason\");",
+									"    pm.expect(jsonData.reason).to.eql(\"not authorized\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{baseurl_dc1}}/uac/1/api-key/@#$%^_\"{{id}}?APIKey={{api_key}}",
+							"host": [
+								"{{baseurl_dc1}}"
+							],
+							"path": [
+								"uac",
+								"1",
+								"api-key",
+								"@"
+							],
+							"hash": "$%^_\"{{id}}?APIKey={{api_key}}"
+						}
+					},
+					"response": [
+						{
+							"name": "successful operation",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{baseurl_dc1}}/uac/1/api-key/{{id}}",
+									"host": [
+										"{{baseurl_dc1}}"
+									],
+									"path": [
+										"uac",
+										"1",
+										"api-key",
+										"{{id}}"
+									],
+									"variable": [
+										{
+											"key": "id"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
## What Are We Doing Here?

New postman tests have been created for get api-key uac endpoint 

## How to Test and Verify

1. Run corresponding branch from EMODB with this branch on CI 
2. Verify that get uac api-key endpoint tests are executed and passed
3. Profit

## Risk

### Level 

`Medium`
### Required Testing

`Manual`

### Risk Summary

new unstable postman tests can be introduced to test suite of the application

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
