### PR TITLE
argument for jacoco has been updated according to plugin update

### DIFF
--- a/common/stash/pom.xml
+++ b/common/stash/pom.xml
@@ -79,7 +79,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- Need to add system property to force default character encoding to be US-ASCII -->
-                    <argLine>${jacoco.agent.argLine} -Dfile.encoding=US-ASCII</argLine> <!-- activate the JaCoCo javaagent -->
+                    <argLine>@{argLine} -Dfile.encoding=US-ASCII</argLine> <!-- activate the JaCoCo javaagent -->
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## What Are We Doing Here?

We update argument for Jacobo plugin activation according to plugin update

## How to Test and Verify

1. Run mvn clean package
2. Verify that tests for emodb-common-stash have been executed
3. Profit

## Risk

### Level 

`Low`

### Required Testing

`Regression`
### Risk Summary

Build can be broken or Jacobo will stop supplying code coverage analysis  

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
