### PR TITLE
fix s3 client

### DIFF
--- a/sor/src/main/java/com/bazaarvoice/emodb/sor/audit/s3/AthenaAuditWriter.java
+++ b/sor/src/main/java/com/bazaarvoice/emodb/sor/audit/s3/AthenaAuditWriter.java
@@ -206,11 +206,16 @@ public class AthenaAuditWriter implements AuditStore {
             credentialsProvider = new DefaultAWSCredentialsProviderChain();
         }
 
-        return AmazonS3ClientBuilder.standard()
-                .withCredentials(credentialsProvider)
-                .withRegion(Regions.fromName(configuration.getLogBucketRegion()))
-                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(configuration.getS3Endpoint(), Regions.getCurrentRegion().getName()))
-                .build();
+        AmazonS3ClientBuilder amazonS3ClientBuilder = AmazonS3ClientBuilder.standard()
+                .withCredentials(credentialsProvider);
+
+        if (configuration.getS3Endpoint() != null) {
+            amazonS3ClientBuilder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(configuration.getS3Endpoint(), Regions.getCurrentRegion().getName()));
+        } else {
+            amazonS3ClientBuilder.withRegion(Regions.fromName(configuration.getLogBucketRegion()));
+
+        }
+        return amazonS3ClientBuilder.build();
     }
 
     @Override


### PR DESCRIPTION
## Github Issue #

-

## What Are We Doing Here?

fix following trace:
```
rror in custom provider, java.lang.IllegalStateException: Only one of Region or EndpointConfiguration may be set.
  at com.bazaarvoice.emodb.sor.DataStoreModule.provideAuditStore(DataStoreModule.java:303) (via modules: com.bazaarvoice.emodb.web.EmoModule -> com.bazaarvoice.emodb.web.EmoModule$DataStoreSetup -> com.bazaarvoice.emodb.sor.DataStoreModule)
  at com.bazaarvoice.emodb.sor.DataStoreModule.provideAuditStore(DataStoreModule.java:303) (via modules: com.bazaarvoice.emodb.web.EmoModule -> com.bazaarvoice.emodb.web.EmoModule$DataStoreSetup -> com.bazaarvoice.emodb.sor.DataStoreModule)
  while locating com.bazaarvoice.emodb.sor.audit.AuditStore
  while locating com.bazaarvoice.emodb.sor.audit.AuditWriter
    for parameter 11 at com.bazaarvoice.emodb.sor.core.DefaultDataStore.<init>(DefaultDataStore.java:138)
  at com.bazaarvoice.emodb.sor.DataStoreModule.configure(DataStoreModule.java:260) (via modules: com.bazaarvoice.emodb.web.EmoModule -> com.bazaarvoice.emodb.web.EmoModule$DataStoreSetup -> com.bazaarvoice.emodb.sor.DataStoreModule)
  while locating com.bazaarvoice.emodb.sor.core.DefaultDataStore
  while locating com.bazaarvoice.emodb.sor.core.DataProvider
    for parameter 2 at com.bazaarvoice.emodb.databus.core.DefaultDatabus.<init>(DefaultDatabus.java:168)
  while locating com.bazaarvoice.emodb.databus.core.DefaultDatabus
  at com.bazaarvoice.emodb.databus.DatabusModule.configure(DatabusModule.java:169) (via modules: com.bazaarvoice.emodb.web.EmoModule -> com.bazaarvoice.emodb.web.EmoModule$DatabusSetup -> com.bazaarvoice.emodb.databus.DatabusModule)
  while locating com.bazaarvoice.emodb.databus.core.OwnerAwareDatabus
    for parameter 0 at com.bazaarvoice.emodb.databus.core.DatabusFactory.<init>(DatabusFactory.java:35)
  at com.bazaarvoice.emodb.databus.DatabusModule.configure(DatabusModule.java:170) (via modules: com.bazaarvoice.emodb.web.EmoModule -> com.bazaarvoice.emodb.web.EmoModule$DatabusSetup -> com.bazaarvoice.emodb.databus.DatabusModule)
  while locating com.bazaarvoice.emodb.databus.core.DatabusFactory
Caused by: java.lang.IllegalStateException: Only one of Region or EndpointConfiguration may be set.
        at com.amazonaws.client.builder.AwsClientBuilder.setRegion(AwsClientBuilder.java:450)
        at com.amazonaws.client.builder.AwsClientBuilder.configureMutableProperties(AwsClientBuilder.java:424)
        at com.amazonaws.client.builder.AwsSyncClientBuilder.build(AwsSyncClientBuilder.java:46)
        at com.bazaarvoice.emodb.sor.audit.s3.AthenaAuditWriter.getAmazonS3Client(AthenaAuditWriter.java:213)
        at com.bazaarvoice.emodb.sor.audit.s3.AthenaAuditWriter.<init>(AthenaAuditWriter.java:114)
        at com.bazaarvoice.emodb.sor.DataStoreModule.provideAuditStore(DataStoreModule.java:304)
        at com.bazaarvoice.emodb.sor.DataStoreModule$$FastClassByGuice$$4c6246a2.invoke(<generated>)
```