### PR TITLE
Emodb Jdk8 Modifier Update

### DIFF
--- a/auth/auth-client/pom.xml
+++ b/auth/auth-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/auth/auth-core/pom.xml
+++ b/auth/auth-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/auth/auth-store/pom.xml
+++ b/auth/auth-store/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/auth/auth-util/pom.xml
+++ b/auth/auth-util/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>emodb</artifactId>
         <groupId>com.bazaarvoice.emodb</groupId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/blob-api/pom.xml
+++ b/blob-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/blob-clients/blob-client-common/pom.xml
+++ b/blob-clients/blob-client-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/blob-clients/blob-client-jersey2/pom.xml
+++ b/blob-clients/blob-client-jersey2/pom.xml
@@ -16,7 +16,8 @@
     <name>EmoDB Blob HTTP Jersey 2 Client</name>
 
     <properties>
-        <jackson.version>${jackson-jersey2.version}</jackson.version>
+        <jackson.version>${com.fasterxml.jackson.version}</jackson.version>
+        <jackson.jersey2.version>${jackson-jersey2.version}</jackson.jersey2.version>
         <guava.version>${guava-jersey2.version}</guava.version>
         <rison.version>${rison-jersey2.version}</rison.version>
     </properties>

--- a/blob-clients/blob-client-jersey2/pom.xml
+++ b/blob-clients/blob-client-jersey2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/blob-clients/blob-client/pom.xml
+++ b/blob-clients/blob-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/blob/pom.xml
+++ b/blob/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/cachemgr/pom.xml
+++ b/cachemgr/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/api/pom.xml
+++ b/common/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/astyanax/pom.xml
+++ b/common/astyanax/pom.xml
@@ -26,6 +26,12 @@
             <groupId>com.bazaarvoice.emodb</groupId>
             <artifactId>emodb-common-json</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.bazaarvoice.ostrich</groupId>

--- a/common/astyanax/pom.xml
+++ b/common/astyanax/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/client-jax-rs-2/pom.xml
+++ b/common/client-jax-rs-2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/client-jax-rs-2/pom.xml
+++ b/common/client-jax-rs-2/pom.xml
@@ -27,6 +27,20 @@
             <groupId>com.bazaarvoice.emodb</groupId>
             <artifactId>emodb-common-json</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Third party dependencies -->

--- a/common/client-jersey2/pom.xml
+++ b/common/client-jersey2/pom.xml
@@ -40,6 +40,20 @@
             <groupId>com.bazaarvoice.emodb</groupId>
             <artifactId>emodb-common-json</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jsr310</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/common/client-jersey2/pom.xml
+++ b/common/client-jersey2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/client/pom.xml
+++ b/common/client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/dropwizard/pom.xml
+++ b/common/dropwizard/pom.xml
@@ -21,6 +21,12 @@
             <groupId>com.bazaarvoice.emodb</groupId>
             <artifactId>emodb-common-json</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.bazaarvoice.emodb</groupId>

--- a/common/dropwizard/pom.xml
+++ b/common/dropwizard/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/jersey-client/pom.xml
+++ b/common/jersey-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/json/pom.xml
+++ b/common/json/pom.xml
@@ -61,6 +61,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.10.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.datatype</groupId>
+                    <artifactId>jackson-datatype-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/common/json/pom.xml
+++ b/common/json/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/stash/pom.xml
+++ b/common/stash/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/uuid/pom.xml
+++ b/common/uuid/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/common/zookeeper/pom.xml
+++ b/common/zookeeper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/databus-api/pom.xml
+++ b/databus-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/databus-client-common/pom.xml
+++ b/databus-client-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/databus-client-jersey2/pom.xml
+++ b/databus-client-jersey2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/databus-client/pom.xml
+++ b/databus-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/databus/pom.xml
+++ b/databus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/datacenter/pom.xml
+++ b/datacenter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/job-api/pom.xml
+++ b/job-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/job/pom.xml
+++ b/job/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/megabus/pom.xml
+++ b/megabus/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -35,13 +35,13 @@
         <guava.version>20.0</guava.version>
         <guava-jersey2.version>27.0.1-jre</guava-jersey2.version>
         <guice.version>4.0</guice.version>
-        <jackson.version>2.10.2</jackson.version>
+        <jackson.version>2.10.5</jackson.version>
         <jackson.databind.version>2.10.5.1</jackson.databind.version>
         <jackson-jersey2.version>2.10.2</jackson-jersey2.version>
         <jetty.version>9.0.7.v20131107</jetty.version>
         <jetty-jersey2.version>9.4.17.v20190418</jetty-jersey2.version>
         <jna.version>5.3.1</jna.version>
-        <com.fasterxml.jackson.version>2.10.2</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.10.5</com.fasterxml.jackson.version>
         <metrics.version>3.0.2</metrics.version>
         <ostrich.version>1.9.3</ostrich.version>
         <rison.version>2.9.10.2</rison.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>com.bazaarvoice.emodb</groupId>
     <artifactId>emodb-parent</artifactId>
-    <version>6.5.31</version>
+    <version>6.5.32-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>EmoDB Parent</name>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
 

--- a/quality/integration/pom.xml
+++ b/quality/integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/quality/pom.xml
+++ b/quality/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/queue-api/pom.xml
+++ b/queue-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/queue-client-common/pom.xml
+++ b/queue-client-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/queue-client-jersey2/pom.xml
+++ b/queue-client-jersey2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/queue-client/pom.xml
+++ b/queue-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/queue/pom.xml
+++ b/queue/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sor-api/pom.xml
+++ b/sor-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sor-client-common/pom.xml
+++ b/sor-client-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sor-client-jersey2/pom.xml
+++ b/sor-client-jersey2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sor-client-jersey2/pom.xml
+++ b/sor-client-jersey2/pom.xml
@@ -16,7 +16,8 @@
     <name>EmoDB System of Record HTTP Client Jersey2.x</name>
 
     <properties>
-        <jackson.version>${jackson-jersey2.version}</jackson.version>
+        <jackson.version>${com.fasterxml.jackson.version}</jackson.version>
+        <jackson.jersey2.version>${jackson-jersey2.version}</jackson.jersey2.version>
         <guava.version>${guava-jersey2.version}</guava.version>
         <rison.version>${rison-jersey2.version}</rison.version>
     </properties>
@@ -69,6 +70,13 @@
             <artifactId>emodb-common-stash</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson</groupId>
+            <artifactId>jackson-bom</artifactId>
+            <version>${jackson.version}</version>
+            <scope>import</scope>
+            <type>pom</type>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -96,6 +104,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
+            <version>${com.fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/sor-client/pom.xml
+++ b/sor-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/sor/pom.xml
+++ b/sor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/table/pom.xml
+++ b/table/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/uac-api/pom.xml
+++ b/uac-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/uac-client-jersey2/pom.xml
+++ b/uac-client-jersey2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/uac-client-jersey2/pom.xml
+++ b/uac-client-jersey2/pom.xml
@@ -16,7 +16,8 @@
     <name>EmoDB User Access Control Jersey2 Client</name>
 
     <properties>
-        <jackson.version>${jackson-jersey2.version}</jackson.version>
+        <jackson.version>${com.fasterxml.jackson.version}</jackson.version>
+        <jackson.jersey2.version>${jackson-jersey2.version}</jackson.jersey2.version>
         <guava.version>${guava-jersey2.version}</guava.version>
         <rison.version>${rison-jersey2.version}</rison.version>
     </properties>

--- a/uac-client/pom.xml
+++ b/uac-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/web-local/pom.xml
+++ b/web-local/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/yum/pom.xml
+++ b/yum/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.bazaarvoice.emodb</groupId>
         <artifactId>emodb-parent</artifactId>
-        <version>6.5.31</version>
+        <version>6.5.32-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
**Jira Issue**
https://bazaarvoice.atlassian.net/browse/PD-211835

**What Are We Doing Here?**
Emodb is one of the 4 repositories where the critical vulnerabilities needs to be remediated in synk. Jackson-datatype-jdk8 modifier has been updated to 2.10.5.

**DOD:**
All the remediation code should be tested, reviewed and merge to mainline.
Push to QA environment and validate.

**Acceptance Criteria:**
All the Improper Input Validation Vulnerabilities should be remediated in Synk(11 in number).

**How to Test and Verify**

Check out local build :
Unit testing : mvn clean install
![image](https://github.com/bazaarvoice/emodb/assets/134580247/124a4ebe-4e2e-4459-b85e-d22d7fdd0d68)


**Risk**
Level : Low

**Required Testing**
Manual.

**Risk Summary**
Since risk level will be low,we will be monitoring for vulnerability issues of jackson library in snyk dashboard.
