### PR TITLE
PD-220325-Add-logs-for-the-megabus-for-debugging-purpose

### DIFF
--- a/megabus/src/main/java/com/bazaarvoice/megabus/refproducer/MegabusRefProducer.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/refproducer/MegabusRefProducer.java
@@ -59,6 +59,8 @@ public class MegabusRefProducer extends AbstractScheduledService {
     private final Meter _eventMeter;
     private final Meter _errorMeter;
 
+    private static final Logger logger = LoggerFactory.getLogger(MegabusRefProducer.class);
+
     public MegabusRefProducer(MegabusRefProducerConfiguration config, DatabusEventStore eventStore,
                               RateLimitedLogFactory logFactory, MetricRegistry metricRegistry,
                               Producer<String, JsonNode> producer, ObjectMapper objectMapper, Topic topic,
@@ -147,6 +149,9 @@ public class MegabusRefProducer extends AbstractScheduledService {
                 .map(ref -> new MegabusRef(ref.getTable(), ref.getKey(), ref.getChangeId(), _clock.instant(), MegabusRef.RefType.NORMAL))
                 .collect(Collectors.groupingBy(ref -> {
                     String key = Coordinate.of(ref.getTable(), ref.getKey()).toString();
+                    if(ref.getTable().contains("apikey")){
+                        logger.info("debugging mega-bus delay while provisioning apikey 2: = {}",key);
+                    }
                     return Utils.toPositive(Utils.murmur2(key.getBytes())) % _topic.getPartitions();
                 }, Collectors.toList()))
                 .entrySet()

--- a/megabus/src/main/java/com/bazaarvoice/megabus/tableevents/TableEventProcessor.java
+++ b/megabus/src/main/java/com/bazaarvoice/megabus/tableevents/TableEventProcessor.java
@@ -37,7 +37,7 @@ public class TableEventProcessor extends AbstractScheduledService {
 
     private static final int FUTURE_BATCH_SIZE = 10000;
 
-    private static final Logger _log = LoggerFactory.getLogger(TableEventProcessor.class);
+    private static final Logger logger = LoggerFactory.getLogger(TableEventProcessor.class);
 
     private final TableEventRegistry _tableEventRegistry;
     private final MetricRegistry _metricRegistry;
@@ -80,11 +80,13 @@ public class TableEventProcessor extends AbstractScheduledService {
     }
 
     private void processTableEvent(String table, String uuid, MegabusRef.RefType refType) {
-
         Iterator<Future<RecordMetadata>> futures =  _tableEventTools.getIdsForStorage(table, uuid)
                 .map(key -> new MegabusRef(table, key, TimeUUIDs.minimumUuid(), null, refType))
                 .map(ref -> {
                     String key = Coordinate.of(ref.getTable(), ref.getKey()).toString();
+                    if(table.contains("apikey")){
+                        logger.info("debugging mega-bus delay while provisioning apikey 1: = {}",key);
+                    }
                     return new ProducerRecord<String, JsonNode>(_topic.getName(),
                             Utils.toPositive(Utils.murmur2(key.getBytes())) % _topic.getPartitions(),
                             TimeUUIDs.newUUID().toString(),_objectMapper.valueToTree(Collections.singletonList(ref)));


### PR DESCRIPTION
## Github Issue #

[](https://bazaarvoice.atlassian.net/browse/PD-220325)

## What Are We Doing Here?

Added few logs in megabus which will helps us to debug the provisioning issue where keys are not reflecting.
These are very specific to the api keys table.

## How to Test and Verify

1. Check out this PR
2.Build the local, pls refer screenshot below.
![image](https://github.com/bazaarvoice/emodb/assets/120096920/64fa3d5b-88d2-4763-9fec-a5e69dda2ae2)

3. Profit

## Risk
If added will be useful in debugging.

### Level 
Low

### Required Testing

No testing required as for this, already run the local build.
![image](https://github.com/bazaarvoice/emodb/assets/120096920/99f27a5b-5e59-45aa-9862-a16b2f1d29f7)


### Risk Summary

None

## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
