### PR TITLE
Pd 218696 emo db data bus dropwizard upgrade

### DIFF
--- a/databus-client-common/pom.xml
+++ b/databus-client-common/pom.xml
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
+            <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/databus-client/pom.xml
+++ b/databus-client/pom.xml
@@ -39,24 +39,57 @@
         <dependency>
             <groupId>com.bazaarvoice.ostrich</groupId>
             <artifactId>ostrich-dropwizard</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.dropwizard</groupId>
+                    <artifactId>dropwizard-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- 3rd-party dependencies -->
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>com.sun.jersey.contribs</groupId>
-            <artifactId>jersey-apache-client4</artifactId>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-client</artifactId>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -88,7 +121,39 @@
                     <groupId>ch.qos.logback:logback-core</groupId>
                     <artifactId>logback-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.hk2.external</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-server</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/databus-client/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusClientFactory.java
+++ b/databus-client/src/main/java/com/bazaarvoice/emodb/databus/client/DatabusClientFactory.java
@@ -5,62 +5,37 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientHandlerException;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.client.apache4.ApacheHttpClient4;
-import com.sun.jersey.client.apache4.ApacheHttpClient4Handler;
-import com.sun.jersey.client.apache4.config.ApacheHttpClient4Config;
-import com.sun.jersey.client.apache4.config.DefaultApacheHttpClient4Config;
-import io.dropwizard.client.HttpClientBuilder;
-import io.dropwizard.client.HttpClientConfiguration;
-import io.dropwizard.jackson.Jackson;
-import io.dropwizard.jersey.jackson.JacksonMessageBodyProvider;
-import io.dropwizard.util.Duration;
-import org.apache.http.client.HttpClient;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import org.glassfish.jersey.client.ClientProperties;
 
-import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
 
 public class DatabusClientFactory extends AbstractDatabusClientFactory {
 
-    private static ValidatorFactory _validatorFactory = Validation.buildDefaultValidatorFactory();
 
-    public static DatabusClientFactory forCluster(String clusterName, MetricRegistry metricRegistry) {
-        HttpClientConfiguration httpClientConfiguration = new HttpClientConfiguration();
-        httpClientConfiguration.setKeepAlive(Duration.seconds(1));
-        return new DatabusClientFactory(clusterName, createDefaultJerseyClient(httpClientConfiguration, metricRegistry, getServiceName(clusterName)));
-    }
 
     /**
      * Connects to the Databus using the specified Jersey client.  If you're using Dropwizard, use this
      * factory method and pass the Dropwizard-constructed Jersey client.
      */
     public static DatabusClientFactory forClusterAndHttpClient(String clusterName, Client client) {
+        client.property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true);
         return new DatabusClientFactory(clusterName, client);
     }
 
-    public static DatabusClientFactory forClusterAndHttpConfiguration(String clusterName, HttpClientConfiguration configuration, MetricRegistry metricRegistry) {
-        return new DatabusClientFactory(clusterName, createDefaultJerseyClient(configuration, metricRegistry, getServiceName(clusterName)));
-    }
+
 
     protected DatabusClientFactory(String clusterName, Client jerseyClient) {
         super(clusterName, new JerseyEmoClient(jerseyClient));
     }
 
-    private static ApacheHttpClient4 createDefaultJerseyClient(HttpClientConfiguration configuration, MetricRegistry metricRegistry, String serviceName) {
-        HttpClient httpClient = new HttpClientBuilder(metricRegistry).using(configuration).build(serviceName);
-        ApacheHttpClient4Handler handler = new ApacheHttpClient4Handler(httpClient, null, true);
-        ApacheHttpClient4Config config = new DefaultApacheHttpClient4Config();
-        config.getSingletons().add(new JacksonMessageBodyProvider(Jackson.newObjectMapper(), _validatorFactory.getValidator()));
-        return new ApacheHttpClient4(handler, config);
-    }
 
     @Override
     public boolean isRetriableException(Exception e) {
         return super.isRetriableException(e) ||
-                (e instanceof UniformInterfaceException &&
-                ((UniformInterfaceException) e).getResponse().getStatus() >= 500) ||
-                Iterables.any(Throwables.getCausalChain(e), Predicates.instanceOf(ClientHandlerException.class));
+                (e instanceof WebApplicationException &&
+                ((WebApplicationException) e).getResponse().getStatus() >= 500) ||
+                Iterables.any(Throwables.getCausalChain(e), Predicates.instanceOf(ProcessingException.class));
     }
 }

--- a/databus/pom.xml
+++ b/databus/pom.xml
@@ -145,11 +145,11 @@
 
         <!-- 3rd-party dependencies -->
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-annotation</artifactId>
         </dependency>
         <dependency>
@@ -173,12 +173,22 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
+            <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-lifecycle</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-server</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -201,10 +211,6 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.cassandra</groupId>

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/DatabusModule.java
@@ -69,7 +69,7 @@ import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.util.Duration;
 import org.apache.curator.framework.CuratorFramework;

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/DefaultReplicationManager.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/DefaultReplicationManager.java
@@ -26,7 +26,7 @@ import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 import io.dropwizard.lifecycle.ExecutorServiceManager;
 import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.util.Duration;

--- a/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/ReplicationClient.java
+++ b/databus/src/main/java/com/bazaarvoice/emodb/databus/repl/ReplicationClient.java
@@ -3,10 +3,10 @@ package com.bazaarvoice.emodb.databus.repl;
 import com.bazaarvoice.emodb.auth.apikey.ApiKeyRequest;
 import com.google.common.base.Charsets;
 import com.google.common.io.BaseEncoding;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.GenericType;
-import com.sun.jersey.api.client.UniformInterfaceException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.WebApplicationException;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -43,11 +43,11 @@ public class ReplicationClient implements ReplicationSource {
                     .segment(channel)
                     .queryParam("limit", limit)
                     .build();
-            return _client.resource(uri)
-                    .accept(MediaType.APPLICATION_JSON_TYPE)
+            return _client.target(uri)
+            .request(MediaType.APPLICATION_JSON_TYPE)
                     .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
                     .get(new GenericType<List<ReplicationEvent>>() {});
-        } catch (UniformInterfaceException e) {
+        } catch (WebApplicationException e) {
             throw convertException(e);
         }
     }
@@ -60,22 +60,21 @@ public class ReplicationClient implements ReplicationSource {
             URI uri = _replicationSource.clone()
                     .segment(channel, "ack")
                     .build();
-            _client.resource(uri)
-                    .type(MediaType.APPLICATION_JSON_TYPE)
+            _client.target(uri).request(MediaType.APPLICATION_JSON_TYPE)
                     .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
-                    .post(eventIds);
-        } catch (UniformInterfaceException e) {
+                    .post(Entity.entity(eventIds, "application/x.json-condition"));
+        } catch (WebApplicationException e) {
             throw convertException(e);
         }
     }
 
-    private RuntimeException convertException(UniformInterfaceException e) {
-        ClientResponse response = e.getResponse();
-        String exceptionType = response.getHeaders().getFirst("X-BV-Exception");
+    private RuntimeException convertException(WebApplicationException e) {
+        Response response = e.getResponse();
+        String exceptionType = (String) response.getHeaders().getFirst("X-BV-Exception");
 
         if (response.getStatus() == Response.Status.BAD_REQUEST.getStatusCode() &&
                 IllegalArgumentException.class.getName().equals(exceptionType)) {
-            return new IllegalArgumentException(response.getEntity(String.class), e);
+            return new IllegalArgumentException(response.readEntity(String.class), e);
         }
         return e;
     }

--- a/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
+++ b/databus/src/test/java/com/bazaarvoice/emodb/databus/DatabusModuleTest.java
@@ -34,7 +34,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.TypeLiteral;
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
 import org.apache.curator.utils.EnsurePath;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -358,7 +358,7 @@
             <dependency>
                 <groupId>net.sourceforge.argparse4j</groupId>
                 <artifactId>argparse4j</artifactId>
-                <version>0.4.3</version>
+                <version>0.4.4</version>
             </dependency>
             <dependency>
                 <groupId>org.coursera</groupId>
@@ -952,6 +952,8 @@
                                 <unusedDeclaredDependency>org.apache.httpcomponents:httpclient</unusedDeclaredDependency>
                                 <unusedDeclaredDependency>io.dropwizard:dropwizard-client</unusedDeclaredDependency>
                                 <unusedDeclaredDependency>io.dropwizard:dropwizard-jackson</unusedDeclaredDependency>
+                                <unusedDeclaredDependency>io.dropwizard.metrics:metrics-core</unusedDeclaredDependency>
+                                <unusedDeclaredDependency>io.dropwizard:dropwizard-core</unusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                             <ignoredDependencies>
                                 <!-- TODO migrate to jakarta.xml.bind -->


### PR DESCRIPTION
## Github Issue #

[1234](https://github.com/bazaarvoice/emodb/issues/11)

## What Are We Doing Here?

Currently many of EmoDB services rely on Dropwizard 0.7 version that was released in the middle of 2014. At the same time other dependencies also rely on the same version. It was decided to upgrade iteratively.
Upgrade path would be 0.7.1 -> 0.8.5 -> 1.3.20 -> 2.x
Emodb-Databus is one of the module where drop-wizard version will be upgraded with its corresponding jersey specific functionalities.
EMODB-DataBus from 0.7.1. --> 0.8.5
## How to Test and Verify

1. Check out this PR
2. Run mvn clean install on submodule
3. check dependency tree of these submodule


## Code Review Checklist

- [ ] Tests are included. If not, make sure you leave us a line or two for the reason.

- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
