### PR TITLE
PD-218698 web module part 1 changes

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -512,6 +512,11 @@
                 <version>${jersey2.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-server</artifactId>
+                <version>${jersey2.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>
                 <version>${jersey.version}</version>

--- a/quality/integration/pom.xml
+++ b/quality/integration/pom.xml
@@ -261,12 +261,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
             <scope>test</scope>
         </dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -302,19 +302,19 @@
             <artifactId>aws-java-sdk-sts</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-annotation</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-healthchecks</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.codahale.metrics</groupId>
+            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-servlets</artifactId>
         </dependency>
         <dependency>
@@ -361,19 +361,11 @@
             <artifactId>guice-assistedinject</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey.contribs</groupId>
-            <artifactId>jersey-apache-client4</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
+            <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
+            <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
         </dependency>
         <dependency>

--- a/web/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyAuthenticationTokenGenerator.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/auth/apikey/ApiKeyAuthenticationTokenGenerator.java
@@ -2,7 +2,7 @@ package com.bazaarvoice.emodb.auth.apikey;
 
 import com.bazaarvoice.emodb.auth.jersey.AuthenticationTokenGenerator;
 import com.google.common.base.Strings;
-import com.sun.jersey.api.core.HttpRequestContext;
+import javax.ws.rs.container.ContainerRequestContext;
 
 /**
  * {@link AuthenticationTokenGenerator} implementation for ApiKeys.  Key can arrive as either a header or query param.
@@ -12,10 +12,10 @@ import com.sun.jersey.api.core.HttpRequestContext;
 public class ApiKeyAuthenticationTokenGenerator implements AuthenticationTokenGenerator<ApiKey> {
 
     @Override
-    public ApiKeyAuthenticationToken createToken(HttpRequestContext context) {
-        String apiKey = context.getHeaderValue(ApiKeyRequest.AUTHENTICATION_HEADER);
+    public ApiKeyAuthenticationToken createToken(ContainerRequestContext context) {
+        String apiKey = context.getHeaders().getFirst(ApiKeyRequest.AUTHENTICATION_HEADER);
         if (Strings.isNullOrEmpty(apiKey)) {
-            apiKey = context.getQueryParameters().getFirst(ApiKeyRequest.AUTHENTICATION_PARAM);
+            apiKey = (String) context.getProperty(ApiKeyRequest.AUTHENTICATION_PARAM);
             if (Strings.isNullOrEmpty(apiKey)) {
                 return null;
             }

--- a/web/src/main/java/com/bazaarvoice/emodb/auth/jersey/AuthenticationTokenGenerator.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/auth/jersey/AuthenticationTokenGenerator.java
@@ -1,7 +1,7 @@
 package com.bazaarvoice.emodb.auth.jersey;
 
 import com.bazaarvoice.emodb.auth.identity.AuthIdentity;
-import com.sun.jersey.api.core.HttpRequestContext;
+import javax.ws.rs.container.ContainerRequestContext;
 import org.apache.shiro.authc.AuthenticationToken;
 
 /**
@@ -16,5 +16,5 @@ public interface AuthenticationTokenGenerator<T extends AuthIdentity> {
      * @param context The request context
      * @return The authentication token, or null if one could not be generated
      */
-    AuthenticationToken createToken(HttpRequestContext context);
+    AuthenticationToken createToken(ContainerRequestContext context);
 }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/EmoModule.java
@@ -152,7 +152,7 @@ import com.google.inject.ProvisionException;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.server.ServerFactory;

--- a/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/auth/SecurityModule.java
@@ -66,7 +66,7 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.permission.PermissionResolver;

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/CompactionControlModule.java
@@ -34,7 +34,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.utils.ZKPaths;
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/client/CompactionControlClient.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/client/CompactionControlClient.java
@@ -5,8 +5,9 @@ import com.bazaarvoice.emodb.client.EmoClient;
 import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.api.StashRunTimeInfo;
 import com.bazaarvoice.emodb.sor.api.StashTimeKey;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
+import org.glassfish.jersey.client.ClientResponse;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.WebApplicationException;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -49,7 +50,7 @@ public class CompactionControlClient implements CompactionControlSource {
                     .type(MediaType.APPLICATION_JSON_TYPE)
                     .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
                     .post();
-        } catch (UniformInterfaceException e) {
+        } catch (WebApplicationException e) {
             throw convertException(e);
         }
     }
@@ -68,7 +69,7 @@ public class CompactionControlClient implements CompactionControlSource {
                     .type(MediaType.APPLICATION_JSON_TYPE)
                     .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
                     .delete();
-        } catch (UniformInterfaceException e) {
+        } catch (WebApplicationException e) {
             throw convertException(e);
         }
     }
@@ -87,7 +88,7 @@ public class CompactionControlClient implements CompactionControlSource {
                     .accept(MediaType.APPLICATION_JSON_TYPE)
                     .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
                     .get(StashRunTimeInfo.class);
-        } catch (UniformInterfaceException e) {
+        } catch (WebApplicationException e) {
             throw convertException(e);
         }
     }
@@ -102,7 +103,7 @@ public class CompactionControlClient implements CompactionControlSource {
                     .type(MediaType.APPLICATION_JSON_TYPE)
                     .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
                     .get(Map.class);
-        } catch (UniformInterfaceException e) {
+        } catch (WebApplicationException e) {
             throw convertException(e);
         }
     }
@@ -120,18 +121,18 @@ public class CompactionControlClient implements CompactionControlSource {
                     .type(MediaType.APPLICATION_JSON_TYPE)
                     .header(ApiKeyRequest.AUTHENTICATION_HEADER, _apiKey)
                     .get(Map.class);
-        } catch (UniformInterfaceException e) {
+        } catch (WebApplicationException e) {
             throw convertException(e);
         }
     }
 
-    private RuntimeException convertException(UniformInterfaceException e) {
-        ClientResponse response = e.getResponse();
-        String exceptionType = response.getHeaders().getFirst("X-BV-Exception");
+    private RuntimeException convertException(WebApplicationException e) {
+        Response response = e.getResponse();
+        String exceptionType = (String) response.getHeaders().getFirst("X-BV-Exception");
 
         if (response.getStatus() == Response.Status.BAD_REQUEST.getStatusCode() &&
                 IllegalArgumentException.class.getName().equals(exceptionType)) {
-            return new IllegalArgumentException(response.getEntity(String.class), e);
+            return new IllegalArgumentException(response.readEntity(String.class), e);
         }
         return e;
     }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/client/CompactionControlClientFactory.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/compactioncontrol/client/CompactionControlClientFactory.java
@@ -6,7 +6,7 @@ import com.bazaarvoice.emodb.common.jersey.dropwizard.JerseyEmoClient;
 import com.bazaarvoice.emodb.sor.api.CompactionControlSource;
 import com.bazaarvoice.emodb.sor.client.AbstractDataStoreClientFactoryBase;
 import com.bazaarvoice.ostrich.ServiceEndPoint;
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 
 /**
  * SOA factory for Jersey clients to use Compaction control resources.

--- a/web/src/main/java/com/bazaarvoice/emodb/web/partition/PartitionAwareServiceFactory.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/partition/PartitionAwareServiceFactory.java
@@ -15,7 +15,7 @@ import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
 import com.google.common.reflect.AbstractInvocationHandler;
 import com.google.common.reflect.Reflection;
-import com.sun.jersey.api.client.ClientHandlerException;
+import javax.ws.rs.ProcessingException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -114,7 +114,7 @@ public class PartitionAwareServiceFactory<S> implements MultiThreadedServiceFact
                     // If the exception was due to connection issues and not necessarily the target let the caller know.
                     // It's possible the connection timed out due to a problem on the target, but from our perspective
                     // there's no definitive way of knowing.
-                    if (targetException instanceof ClientHandlerException) {
+                    if (targetException instanceof ProcessingException) {
                         _errorMeter.mark();
                         throw new PartitionForwardingException("Failed to handle request at endpoint", targetException.getCause());
                     }

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/FaviconResource.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/FaviconResource.java
@@ -3,7 +3,7 @@ package com.bazaarvoice.emodb.web.resources;
 import com.google.common.base.Splitter;
 import com.google.common.hash.Hashing;
 import com.google.common.net.HttpHeaders;
-import com.sun.jersey.spi.resource.Singleton;
+import javax.inject.Singleton;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/blob/BlobStoreResource1.java
@@ -29,7 +29,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Maps;
 import com.google.common.collect.PeekingIterator;
-import com.sun.jersey.api.client.ClientResponse;
+import javax.ws.rs.core.Response;
 import io.dropwizard.jersey.params.AbstractParam;
 import io.dropwizard.jersey.params.LongParam;
 import io.swagger.annotations.Api;
@@ -396,7 +396,7 @@ public class BlobStoreResource1 {
         if (range == null) {
             response.header(HttpHeaders.CONTENT_LENGTH, metadata.getLength());
         } else {
-            response.status(ClientResponse.Status.PARTIAL_CONTENT);
+            response.status(Response.Status.PARTIAL_CONTENT);
             response.header(HttpHeaders.CONTENT_LENGTH, range.getLength());
             response.header("Content-Range", "bytes " + range.getOffset() + "-" +
                     (range.getOffset() + range.getLength() - 1) + "/" + metadata.getLength());

--- a/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusRelayClientFactory.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/resources/databus/DatabusRelayClientFactory.java
@@ -3,7 +3,7 @@ package com.bazaarvoice.emodb.web.resources.databus;
 import com.bazaarvoice.emodb.client.EmoClient;
 import com.bazaarvoice.emodb.databus.api.AuthDatabus;
 import com.bazaarvoice.emodb.databus.client.DatabusClientFactory;
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 
 import java.net.URI;
 

--- a/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
+++ b/web/src/main/java/com/bazaarvoice/emodb/web/scanner/ScanUploadModule.java
@@ -88,7 +88,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
-import com.sun.jersey.api.client.Client;
+import javax.ws.rs.client.Client;
 import io.dropwizard.setup.Environment;
 import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.LoggerFactory;

--- a/web/src/test/java/com/bazaarvoice/emodb/web/partition/PartitionAwareServiceFactoryTest.java
+++ b/web/src/test/java/com/bazaarvoice/emodb/web/partition/PartitionAwareServiceFactoryTest.java
@@ -7,7 +7,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.google.common.net.HostAndPort;
-import com.sun.jersey.api.client.ClientHandlerException;
+import javax.ws.rs.ProcessingException;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -125,7 +125,7 @@ public class PartitionAwareServiceFactoryTest {
 
     @Test
     public void testDelegateConnectionTimeoutException() throws Exception {
-        doThrow(new ClientHandlerException(new ConnectTimeoutException())).when(_delegate).doIt();
+        doThrow(new ProcessingException(new ConnectTimeoutException())).when(_delegate).doIt();
         TestInterface service = _serviceFactory.create(_remoteEndPoint);
 
         try {


### PR DESCRIPTION
## Github Issue #

## What Are We Doing Here?
Currently many of EmoDB services rely on Dropwizard 0.7 version that was released in the middle of 2014. At the same time other dependencies also rely on the same version. It was decided to upgrade iteratively.
Upgrade path would be 0.7.1 -> 0.8.5 -> 1.3.20 -> 2.x
Emodb-web is one of the module where drop-wizard version will be upgraded with its corresponding jersey specific functionalities.
EMODB-web from 0.7.1. --> 0.8.5
Part 1 will covering the following package using com.sun.jersey

com.bazaarvoice.emodb.web.resources.databus;

com.bazaarvoice.emodb.web.scanner;

com.bazaarvoice.emodb.web.resources.blob;

com.bazaarvoice.emodb.web.resources.blob

com.bazaarvoice.emodb.auth.dropwizard;

Sub Folder inside web mobule covered 

**web - >**
> auth [Half]
> compaction Control
> client 
> partition
> resources
> blob
> databus
> scanner

**auth ->**
> apikey
> jersey [Half]

Separate files which are at root level -
> EmoModule.java