### PR TITLE
PD-233234: Kodak_Jersey_upgrade_Exceptions

### DIFF
--- a/blob-clients/blob-client-jersey2/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreClient.java
+++ b/blob-clients/blob-client-jersey2/src/main/java/com/bazaarvoice/emodb/blob/client/BlobStoreClient.java
@@ -93,7 +93,7 @@ public class BlobStoreClient implements AuthBlobStore {
      * Delay after which streaming connections are automatically closed if the caller doesn't begin reading the stream.
      * The caller can still read the contents after this time elapses but will incur a new round-trip request/response.
      */
-    private static final Duration BLOB_CONNECTION_CLOSED_TIMEOUT = Duration.ofSeconds(2);
+    private static final Duration BLOB_CONNECTION_CLOSED_TIMEOUT = Duration.ofSeconds(6);
 
     private final EmoClient _client;
     private final UriBuilder _blobStore;


### PR DESCRIPTION
## Github Issue #

https://bazaarvoice.atlassian.net/browse/PD-233234

## What Are We Doing Here?

Increasing the timeout of the blob client for jersey2
## How to Test and Verify

1. Check out this PR
2. Run Command X, Click Button Y
3. Profit

## Risk

### Level 

medium

### Required Testing

None 

### Risk Summary

This changes needed as part of kodak request where they are reporting about timeout exception.

## Code Review Checklist



- [ ] Pulled down the PR and performed verification of at least being able to
build and run.

- [ ] Well documented, including updates to any necessary markdown files. When
we inevitably come back to this code it will only take hours to figure out, not
days.

- [ ] Consistent/Clear/Thoughtful? We are better with this code. We also aren't
a victim of rampaging consistency, and should be using this course of action. 
We don't have coding standards out yet for this project, so please make sure to address any feedback regarding STYLE so the codebase remains consistent.

- [ ] PR has a valid summary, and a good description.
