### PR TITLE
Reverting - REDS : Changes with  CL_ONE with respect to read consistency 

### DIFF
--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -340,19 +340,13 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
      */
     private Iterator<Column<ByteBuffer>> readManifestForChannel(final String channel, final boolean weak) {
         final ByteBuffer oldestSlab = weak ? _oldestSlab.getIfPresent(channel) : null;
-        ConsistencyLevel consistency = ConsistencyLevel.CL_LOCAL_ONE ;//CL_LOCAL_QUORUM;;
-
+        final ConsistencyLevel consistency;
         RangeBuilder range = new RangeBuilder().setLimit(50);
         if (oldestSlab != null) {
             range.setStart(oldestSlab);
+            consistency = ConsistencyLevel.CL_LOCAL_ONE;
         } else {
-
-            try{
-                String _sysConsistency = System.getProperty("read-consistency");
-                consistency = ConsistencyLevel.valueOf(_sysConsistency);
-            } catch(Exception e){
-                _log.debug("encountered exception while parsing ", e);
-            }
+            consistency = ConsistencyLevel.CL_LOCAL_QUORUM;
         }
 
         final Iterator<Column<ByteBuffer>> manifestColumns = executePaginated(
@@ -405,7 +399,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
         // Using a lower consistency level could result in (a) duplicate events because we miss deletes and (b)
         // incorrectly closing or deleting slabs when slabs look empty if we miss adds.
         ColumnList<Integer> eventColumns = execute(
-                _keyspace.prepareQuery(ColumnFamilies.SLAB, ConsistencyLevel.CL_LOCAL_ONE)
+                _keyspace.prepareQuery(ColumnFamilies.SLAB, ConsistencyLevel.CL_LOCAL_QUORUM)
                         .getKey(slabId)
                         .withColumnRange(start, Constants.OPEN_SLAB_MARKER, false, Integer.MAX_VALUE));
 


### PR DESCRIPTION
Github Issue
https://bazaarvoice.atlassian.net/browse/PD-234305

What Are We Doing Here?
Changed event store manifest reads to use CL_ONE with respect to read consistency.

How to test:
mvn clean install

![image](https://github.com/bazaarvoice/emodb/assets/134580247/262d0ef9-5e80-4c25-af83-6d5d30211772)


Risk
Level
Medium

Required Testing
Unit Testing , Integration testing.