### PR TITLE
5xx Exceptions: Updating CL_LOCAL_QUORUM to CL_TWO

### DIFF
--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -341,6 +341,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
     private Iterator<Column<ByteBuffer>> readManifestForChannel(final String channel, final boolean weak) {
         final ByteBuffer oldestSlab = weak ? _oldestSlab.getIfPresent(channel) : null;
         final ConsistencyLevel consistency;
+        
         RangeBuilder range = new RangeBuilder().setLimit(50);
         if (oldestSlab != null) {
             range.setStart(oldestSlab);
@@ -398,6 +399,7 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
         // Event add and delete write with local quorum, so read with local quorum to get a consistent view of things.
         // Using a lower consistency level could result in (a) duplicate events because we miss deletes and (b)
         // incorrectly closing or deleting slabs when slabs look empty if we miss adds.
+
         ColumnList<Integer> eventColumns = execute(
                 _keyspace.prepareQuery(ColumnFamilies.SLAB, ConsistencyLevel.CL_TWO)
                         .getKey(slabId)

--- a/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
+++ b/event/src/main/java/com/bazaarvoice/emodb/event/db/astyanax/AstyanaxEventReaderDAO.java
@@ -341,13 +341,14 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
     private Iterator<Column<ByteBuffer>> readManifestForChannel(final String channel, final boolean weak) {
         final ByteBuffer oldestSlab = weak ? _oldestSlab.getIfPresent(channel) : null;
         final ConsistencyLevel consistency;
-        
+
         RangeBuilder range = new RangeBuilder().setLimit(50);
+
         if (oldestSlab != null) {
             range.setStart(oldestSlab);
-            consistency = ConsistencyLevel.CL_LOCAL_ONE;
+              consistency = ConsistencyLevel.CL_LOCAL_ONE;
         } else {
-            consistency = ConsistencyLevel.CL_TWO;
+              consistency = ConsistencyLevel.CL_TWO;
         }
 
         final Iterator<Column<ByteBuffer>> manifestColumns = executePaginated(
@@ -400,8 +401,10 @@ public class AstyanaxEventReaderDAO implements EventReaderDAO {
         // Using a lower consistency level could result in (a) duplicate events because we miss deletes and (b)
         // incorrectly closing or deleting slabs when slabs look empty if we miss adds.
 
+
         ColumnList<Integer> eventColumns = execute(
-                _keyspace.prepareQuery(ColumnFamilies.SLAB, ConsistencyLevel.CL_TWO)
+
+                  _keyspace.prepareQuery(ColumnFamilies.SLAB, ConsistencyLevel.CL_TWO)
                         .getKey(slabId)
                         .withColumnRange(start, Constants.OPEN_SLAB_MARKER, false, Integer.MAX_VALUE));
 


### PR DESCRIPTION
Github Issue
https://bazaarvoice.atlassian.net/browse/PD-234305

What Are We Doing Here?
Changed event store manifest reads to use CL_ONE with respect to read consistency.

How to test:
mvn clean install

![image](https://github.com/bazaarvoice/emodb/assets/134580247/07dc502c-32df-4a90-95db-ca49220c8f91)


Risk
Level
Medium

Required Testing
Unit Testing , Integration testing.